### PR TITLE
fix SourceReader import was blocked when MailingList encountered empty HTML document

### DIFF
--- a/assembl/models/mail.py
+++ b/assembl/models/mail.py
@@ -288,8 +288,8 @@ class AbstractMailbox(PostSource):
         doc = None
         try:
             doc = html.fromstring(message_body)
-        except: # We can get "ParserError: Document is empty", which has to be caught, otherwise it blocks the SourceReader
-            return message_body
+        except etree.ParserError: # If the parsed HTML document is empty, we get a "ParserError: Document is empty" exception. So the stripped message we return is an empty string (if we keep the exception it blocks the SourceReader)
+            return ""
 
         #Strip GMail quotes
         matches = doc.find_class('gmail_quote')

--- a/assembl/models/mail.py
+++ b/assembl/models/mail.py
@@ -284,7 +284,13 @@ class AbstractMailbox(PostSource):
 
         debug = True;
         from lxml import html, etree
-        doc = html.fromstring(message_body)
+
+        doc = None
+        try:
+            doc = html.fromstring(message_body)
+        except: # We can get "ParserError: Document is empty", which has to be caught, otherwise it blocks the SourceReader
+            return message_body
+
         #Strip GMail quotes
         matches = doc.find_class('gmail_quote')
         if len(matches) > 0:


### PR DESCRIPTION
fix SourceReader import was blocked when MailingList encountered empty HTML document

(I was trying to import emails from a mailing list into a discussion, using the mailing list feature)
