### PR TITLE
Message source manual start forces restart

### DIFF
--- a/assembl/models/generic.py
+++ b/assembl/models/generic.py
@@ -149,6 +149,11 @@ class ContentSource(DiscussionBoundBase):
     # Cannot be readable to all, because subclasses contain passwords
     crud_permissions = CrudPermissions(P_ADMIN_DISC, P_ADMIN_DISC)
 
+    def reset_errors(self):
+        self.connection_error = None
+        self.error_description = None
+        self.error_backoff_until = None
+
 
 class PostSource(ContentSource):
     """

--- a/assembl/static/js/app/views/admin/generalSource.js
+++ b/assembl/static/js/app/views/admin/generalSource.js
@@ -110,8 +110,8 @@ var ReadSource = Marionette.ItemView.extend({
         url,
         {
           method: "POST",
-          contentType: "application/json",
-          data: payload
+          contentType: "application/json; charset=UTF-8",
+          data: JSON.stringify(payload)
         }
       ).then(function() {
         Growl.showBottomGrowl(Growl.GrowlReason.SUCCESS, i18n.gettext('Import has begun!'))

--- a/assembl/static/js/app/views/admin/generalSource.js
+++ b/assembl/static/js/app/views/admin/generalSource.js
@@ -8,6 +8,7 @@ var Marionette = require('../../shims/marionette.js'),
     i18n = require('../../utils/i18n.js'),
     Types = require('../../utils/types.js'),
     Ctx = require('../../common/context.js'),
+    Permissions = require('../../utils/permissions.js'),
     Growl = require('../../utils/growl.js'),
     Source = require('../../models/sources.js'),
     CollectionManager = require('../../common/collectionManager.js'),
@@ -99,13 +100,22 @@ var ReadSource = Marionette.ItemView.extend({
     },
 
     manualStart: function(evt){
-        var url = this.model.url() + "/fetch_posts";
-        $.ajax(url, {
+      var url = this.model.url() + "/fetch_posts";
+      var user = Ctx.getCurrentUser();
+      var payload = {};
+      if (user.can(Permissions.ADMIN_DISCUSSION)){
+        payload.force_restart = true;
+      }
+      $.ajax(
+        url,
+        {
           method: "POST",
           contentType: "application/json",
-          data: {}}).then(function() {
-            Growl.showBottomGrowl(Growl.GrowlReason.SUCCESS, i18n.gettext('Import has begun!'))
-          });
+          data: payload
+        }
+      ).then(function() {
+        Growl.showBottomGrowl(Growl.GrowlReason.SUCCESS, i18n.gettext('Import has begun!'))
+      });
     },
 
     serializeData: function() {

--- a/assembl/tasks/source_reader.py
+++ b/assembl/tasks/source_reader.py
@@ -529,8 +529,9 @@ class SourceDispatcher(ConsumerMixin):
             source = ContentSource.get(source_id)
             if not source:
                 return False
-            if (source.connection_error == ReaderStatus.IRRECOVERABLE_ERROR
-                    and not force_restart):
+            if force_restart:
+                source.reset_errors()
+            if source.connection_error == ReaderStatus.IRRECOVERABLE_ERROR:
                 return False
             reader = source.make_reader()
             self.readers[source_id] = reader

--- a/assembl/views/api2/content_source.py
+++ b/assembl/views/api2/content_source.py
@@ -60,6 +60,7 @@ def fetch_posts(request):
             raise HTTPUnauthorized("Only discussion administrator\
                                    can "+'and'.join(requested))
 
+    # TODO: This block of code could be moved downstream. But we could not find a better place yet. See https://github.com/assembl/assembl/pull/51#discussion_r87990963
     if force_restart:
         csource.reset_errors()
 

--- a/assembl/views/api2/content_source.py
+++ b/assembl/views/api2/content_source.py
@@ -23,16 +23,15 @@ def fetch_posts(request):
     ctx = request.context
     csource = ctx._instance
 
-    def request_parameter(key, default_value=None):
-        # when client POSTs data as JSON, in Pyramid data does not arrive in request.POST but in request.json_body
-        return request.json_body.get(key, default_value)
+    # when client POSTs data as JSON, in Pyramid data does not arrive in request.POST but in request.json_body
+    json = request.json_body
 
-    force_restart = request_parameter('force_restart', False)
-    reimport = request_parameter('reimport', False)
-    reprocess = request_parameter('reprocess', False)
-    upper_bound = request_parameter('upper_limit', None)
-    lower_bound = request_parameter('lower_limit', None)
-    
+    force_restart = json.get('force_restart', False)
+    reimport = json.get('reimport', False)
+    reprocess = json.get('reprocess', False)
+    upper_bound = json.get('upper_limit', None)
+    lower_bound = json.get('lower_limit', None)
+
     try:
         if upper_bound:
             _ = parse(upper_bound)


### PR DESCRIPTION
In the "Discussion parameters" page, "Server settings" section, the "manual start" link on a source was not starting a fetch if the source was in at least one of the error states. Now the fetch is really forced.
