### PR TITLE
Push the logic to ensure linked list integrity upon delete/reorder to backend

### DIFF
--- a/assembl/alembic/versions/4253aa01a525_idea_message_column_previous_column_id_.py
+++ b/assembl/alembic/versions/4253aa01a525_idea_message_column_previous_column_id_.py
@@ -1,0 +1,37 @@
+"""idea_message_column.previous_column_id.ondelete
+
+Revision ID: 4253aa01a525
+Revises: 2f0a72a2f3ec
+Create Date: 2016-12-07 06:25:24.625025
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '4253aa01a525'
+down_revision = '2f0a72a2f3ec'
+
+from alembic import context, op
+import sqlalchemy as sa
+import transaction
+
+
+from assembl.lib import config
+
+
+def upgrade(pyramid_env):
+    with context.begin_transaction():
+        op.drop_constraint(
+            "idea_message_column_previous_column_id_fkey", "idea_message_column")
+        op.create_foreign_key(
+            "idea_message_column_previous_column_id_fkey", "idea_message_column",
+            "idea_message_column", ["previous_column_id"], ["id"],
+            ondelete="SET NULL")
+
+
+def downgrade(pyramid_env):
+    with context.begin_transaction():
+        op.drop_constraint(
+            "idea_message_column_previous_column_id_fkey", "idea_message_column")
+        op.create_foreign_key(
+            "idea_message_column_previous_column_id_fkey", "idea_message_column",
+            "idea_message_column", ["previous_column_id"], ["id"])

--- a/assembl/models/idea_msg_columns.py
+++ b/assembl/models/idea_msg_columns.py
@@ -41,8 +41,10 @@ class IdeaMessageColumn(DiscussionBoundBase):
              ":py:attr:`assembl.models.generic.Content.message_classifier`"))
     header = Column(UnicodeText,
         doc="Text which will be shown above the column")
-    previous_column_id = Column(Integer, ForeignKey(id), nullable=True,
-        unique=True, doc="Allows ordering columns as a linked list")
+    previous_column_id = Column(
+        Integer, ForeignKey(id, ondelete='SET NULL'),
+        nullable=True, unique=True,
+        doc="Allows ordering columns as a linked list")
     name_id = Column(Integer, ForeignKey(LangString.id), nullable=False,
         doc="The name of the column as a langstr")
     color = Column(String(20),

--- a/assembl/static/js/app/views/admin/adminMessageColumns.js
+++ b/assembl/static/js/app/views/admin/adminMessageColumns.js
@@ -207,26 +207,29 @@ var MessageColumnView = Marionette.LayoutView.extend({
         model: this.model.get('name'),
       }));
   },
-  reorderColumnUp: function(ev) {
-    var index = this.getIndex(),
-        previousModel = this.model.collection.at(index-1);
-    this.model.set('previous_column', previousModel.get('previous_column'));
-    previousModel.set('previous_column', this.model.id);
-    this.model.collection.sort();
-    this.model.save(null, {success: function() {
-      previousModel.save();
-    }});
-
-    ev.preventDefault();
-  },
   reorderColumnDown: function(ev) {
     var index = this.getIndex(),
-        nextModel = this.model.collection.at(index+1);
-    nextModel.set('previous_column', this.model.get('previous_column'));
-    this.model.set('previous_column', nextModel.id);
-    this.model.collection.sort();
-    this.model.save();
-    nextModel.save();
+        nextModel = this.model.collection.at(index + 1);
+    Promise.resolve($.ajax(nextModel.url() + "/reorder_up", {
+        method: "POST"})).then(function(data) {
+        nextModel.collection.fetch({
+          success: function() {
+            nextModel.collection.sort();
+          }
+        });
+    });
+    ev.preventDefault();
+  },
+  reorderColumnUp: function(ev) {
+    var model = this.model;
+    Promise.resolve($.ajax(model.url() + "/reorder_up", {
+        method: "POST"})).then(function(data) {
+        model.collection.fetch({
+          success: function() {
+            model.collection.sort();
+          }
+        });
+    });
     ev.preventDefault();
   },
   deleteColumn: function(ev) {
@@ -239,9 +242,8 @@ var MessageColumnView = Marionette.LayoutView.extend({
     this.model.destroy({
       success: function() {
         if (nextModel !== null) {
-          // do this after delete, or uniqueness of previous_column will prevent change.
-          nextModel.set('previous_column', prevColumn);
-          nextModel.save();
+          // update the previous_column value
+          nextModel.fetch();
         }
       },
     });

--- a/assembl/views/api2/idea_msg_columns.py
+++ b/assembl/views/api2/idea_msg_columns.py
@@ -1,0 +1,52 @@
+from pyramid.view import view_config
+from pyramid.httpexceptions import HTTPOk
+
+from assembl.models import IdeaMessageColumn
+from ..traversal import InstanceContext, CollectionContext
+from . import (
+    FORM_HEADER, JSON_HEADER, instance_put_json, instance_put_form,
+    collection_add_json, collection_add_with_params, instance_del)
+
+
+@view_config(
+    context=InstanceContext, request_method='DELETE', renderer='json',
+    ctx_instance_class=IdeaMessageColumn)
+def column_del(request):
+    """Delete a column and adjust the next column's previous_column_id"""
+    ctx = request.context
+    instance = ctx._instance
+    db = instance.db
+    next_column = db.query(IdeaMessageColumn).filter_by(
+        previous_column_id=instance.id).first()
+    previous_id = instance.previous_column_id
+    response = instance_del(request)
+    if next_column and previous_id:
+        db.flush()
+        next_column.previous_column_id = previous_id
+    return response
+
+
+@view_config(
+    context=InstanceContext, request_method='POST', renderer='json',
+    ctx_instance_class=IdeaMessageColumn, name="reorder_up")
+def column_reorder_up(request):
+    """Switch this column with the previous column
+    and adjust the next column's previous_column_id"""
+    ctx = request.context
+    instance = ctx._instance
+    db = instance.db
+    next_column = db.query(IdeaMessageColumn).filter_by(
+        previous_column_id=instance.id).first()
+    previous_column = instance.previous_column
+    pre_previous_id = previous_column.previous_column_id
+    # clear first to avoid index uniqueness checks
+    previous_column.previous_column_id = None
+    instance.previous_column_id = None
+    if next_column:
+        next_column.previous_column_id = None
+    db.flush()
+    instance.previous_column_id = pre_previous_id
+    previous_column.previous_column_id = instance.id
+    if next_column:
+        next_column.previous_column_id = previous_column.id
+    return HTTPOk()


### PR DESCRIPTION
...and database
Made reordering into a RPC ajax call. Not RESTish, but this guarantees integrity.
