### PR TITLE
Add analytics to sentiments on message.

### DIFF
--- a/assembl/static/js/app/internal_modules/analytics/abstract.js
+++ b/assembl/static/js/app/internal_modules/analytics/abstract.js
@@ -412,7 +412,37 @@ var moduleName = 'Analytics_Abstract',
        * Event fired when the user has successfully left the group (ie removed the userRole.PARTICIPANT from his/her list of roles)
        * assembl/static/js/app/models/roles.js
        */
-      LEAVE_DISCUSSION: {action: 'ONBOARDING', category: 'NOTIFICATION', eventName: 'LEAVE_DISCUSSION'}
+      LEAVE_DISCUSSION: {action: 'ONBOARDING', category: 'NOTIFICATION', eventName: 'LEAVE_DISCUSSION'},
+
+      /**
+       * Event fired when a user clicks on the 'Agree' or "Like" sentiment on a message.
+       * All sentiment events are found in assembl/static/js/app/views/message.js
+       */
+      SELECT_SENTIMENT_LIKE: {action: 'INTERACTING', category: 'MESSAGE', eventName: 'SELECT_SENTIMENT_LIKE'},
+
+      /**
+       * Event fired when a user clicks on the 'Disagree' sentiment on a message.
+       * All sentiment events are found in assembl/static/js/app/views/message.js
+       */
+      SELECT_SENTIMENT_DISAGREE: {action: 'INTERACTING', category: 'MESSAGE', eventName: 'SELECT_SENTIMENT_DISAGREE'},
+
+      /**
+       * Event fired when a user clicks on the 'Don't Understand sentiment on a message.
+       * All sentiment events are found in assembl/static/js/app/views/message.js
+       */
+      SELECT_SENTIMENT_DU: {action: 'INTERACTING', category: 'MESSAGE', eventName: 'SELECT_SENTIMENT_DONT_UNDERSTAND'},
+
+      /**
+       * Event fired when a user clicks on the 'More Info' sentiment on a message.
+       * All sentiment events are found in assembl/static/js/app/views/message.js
+       */
+      SELECT_SENTIMENT_MORE: {action: 'INTERACTING', category: 'MESSAGE', eventName: 'SELECT_SENTIMENT_MORE_INFO'},
+
+      /**
+       * Event fired when a user clicks on the 'More Info' sentiment on a message.
+       * All sentiment events are found in assembl/static/js/app/views/message.js
+       */
+      DESELECT_SENTIMENT: {action: 'INTERACTING', category: 'MESSAGE', eventName: 'DESELECT_SENTIMENT'},
   };
 
   /**

--- a/assembl/static/js/app/models/sentimentStats.js
+++ b/assembl/static/js/app/models/sentimentStats.js
@@ -1,0 +1,49 @@
+'use strict'
+
+var Analytics = require('../internal_modules/analytics/dispatcher.js');
+
+// Enum of conversion between sentiment to statistics
+var SENTIMENT_TO_STASTICS = {
+  LikeSentimentOfPost: 'like',
+  DisagreeSentimentOfPost: 'disagree',
+  DontUnderstandSentimentOfPost: 'idu',
+  MoreInfoSentimentOfPost: 'more',
+  DESELECT: 'deselect'
+};
+
+
+/**
+ * Method that converts the backend-based name of the sentiment
+ * to an event name prepared for statistics
+ *
+ * Note: Pass 'DESELECT' in order to track sentiment deselection
+ */
+function fireSentimentAnalyticsEvent(sentiment){
+  if (!(SENTIMENT_TO_STASTICS[sentiment])){
+    // console.log("sentiment " + sentiment + " is not a valid sentiment. Will not process analytics");
+    return;
+  }
+
+  var analytics = Analytics.getInstance();
+  switch (SENTIMENT_TO_STASTICS[sentiment]){
+    case 'like':
+      analytics.trackEvent(analytics.events.SELECT_SENTIMENT_LIKE);
+      break;
+    case 'disagree':
+      analytics.trackEvent(analytics.events.SELECT_SENTIMENT_DISAGREE);
+      break;
+    case 'idu':
+      analytics.trackEvent(analytics.events.SELECT_SENTIMENT_DU);
+      break;
+    case 'more':
+      analytics.trackEvent(analytics.events.SELECT_SENTIMENT_MORE);
+      break;
+    case 'deselect':
+      analytics.trackEvent(analytics.events.DESELECT_SENTIMENT);
+      break;
+    default:
+      throw Exception("Sentiment " + sentiment + " is not a valid sentiment to track!");
+  }
+};
+
+module.exports = fireSentimentAnalyticsEvent;

--- a/assembl/static/js/app/views/message.js
+++ b/assembl/static/js/app/views/message.js
@@ -32,21 +32,13 @@ var Marionette = require('../shims/marionette.js'),
     IdeaContentLink = require('../models/ideaContentLink.js'),
     ConfirmModal = require('./confirmModal.js'),
     Growl = require('../utils/growl.js'),
-    MessageModel = require('../models/message.js');
+    MessageModel = require('../models/message.js'),
+    SentimentStastics = require('../models/sentimentStats.js');
 
 var MIN_TEXT_TO_TOOLTIP = 5,
     TOOLTIP_TEXT_LENGTH = 10,
     IDEA_CLASSIFICATION_LENGTH = 3;
 
-
-// Enum of conversion between sentiment to statistics
-var SENTIMENT_TO_STASTICS = {
-  LikeSentimentOfPost: 'like',
-  DisagreeSentimentOfPost: 'disagree',
-  DontUnderstandSentimentOfPost: 'idu',
-  MoreInfoSentimentOfPost: 'more',
-  DESELECT: 'deselect'
-};
 
 /**
  * @class app.views.message.IdeaClassificationNameListView
@@ -1151,37 +1143,10 @@ var MessageView = Marionette.LayoutView.extend({
   },
 
   /**
-   * Method that converts the backend-based name of the sentiment
-   * to an event name prepared for statistics
-   *
-   * Note: Pass 'DESELECT' in order to track sentiment deselection
+   * Method that sends the analytics event according to the specificiation
    */
   fireSentimentAnalyticsEvent: function(sentiment){
-    if (!(SENTIMENT_TO_STASTICS[sentiment])){
-      console.log("sentiment " + sentiment + " is not a valid sentiment. Will not process analytics");
-      return;
-    }
-
-    var analytics = Analytics.getInstance();
-    switch (SENTIMENT_TO_STASTICS[sentiment]){
-      case 'like':
-        analytics.trackEvent(analytics.events.SELECT_SENTIMENT_LIKE);
-        break;
-      case 'disagree':
-        analytics.trackEvent(analytics.events.SELECT_SENTIMENT_DISAGREE);
-        break;
-      case 'idu':
-        analytics.trackEvent(analytics.events.SELECT_SENTIMENT_DU);
-        break;
-      case 'more':
-        analytics.trackEvent(analytics.events.SELECT_SENTIMENT_MORE);
-        break;
-      case 'deselect':
-        analytics.trackEvent(analytics.events.DESELECT_SENTIMENT);
-        break;
-      default:
-        console.warn("Improper sentiment was passed for analytics");
-    }
+    SentimentStastics(sentiment);
   },
 
   onClickShare: function(e) {

--- a/assembl/static/js/app/views/message.js
+++ b/assembl/static/js/app/views/message.js
@@ -1060,7 +1060,6 @@ var MessageView = Marionette.LayoutView.extend({
   },
 
   onClickEmoticon: function(event){
-    console.log("Message Model:", this.model);
     var isUserConnected = Ctx.isUserConnected();
     var that = this;
     if(isUserConnected){


### PR DESCRIPTION
Please review the method in which events were added to the analytics client, and when they are called.

Also consider this question: Should analytics event be thrown at same time as sentiment ajax call to backend? Or should ajax call successfully complete, and then analytics event be thrown? Discuss.