### PR TITLE
Conditional home

### DIFF
--- a/assembl/models/preferences.py
+++ b/assembl/models/preferences.py
@@ -348,6 +348,15 @@ class Preferences(MutableMapping, Base, NamedClassMixin):
             "default": [strip_country(x) for x in config.get_config().get(
                 'available_languages', 'fr en').split()]
         },
+        # Whether the discussion uses the new React landing page
+        {
+            "id": "landing_page",
+            "value_type": "bool",
+            "name": _("Use landing page"),
+            "description": _("Are users directed to the landing page and phases at login, or diretly to the debate"),
+            "allow_user_override": None,
+            "default": False,
+        },
         # full class name of translation service to use, if any
         # e.g. assembl.nlp.translate.GoogleTranslationService
         {

--- a/assembl/templates/discussion_list.jinja2
+++ b/assembl/templates/discussion_list.jinja2
@@ -24,7 +24,7 @@
 
   {% if not user %}
     <div class="gu gu1of5 bx bx-default">
-      <h4 class="h4"><a href="{{get_route('new_login')}}">{{ gettext("Sign in") }}</a></h4>
+      <h4 class="h4"><a href="{{get_route('react_login')}}">{{ gettext("Sign in") }}</a></h4>
       {% trans %} to see all available discussions.{% endtrans %}
     </div>
   {% endif %}

--- a/assembl/templates/discussion_list.jinja2
+++ b/assembl/templates/discussion_list.jinja2
@@ -24,7 +24,7 @@
 
   {% if not user %}
     <div class="gu gu1of5 bx bx-default">
-      <h4 class="h4"><a href="{{get_route('login')}}">{{ gettext("Sign in") }}</a></h4>
+      <h4 class="h4"><a href="{{get_route('new_login')}}">{{ gettext("Sign in") }}</a></h4>
       {% trans %} to see all available discussions.{% endtrans %}
     </div>
   {% endif %}

--- a/assembl/templates/login.jinja2
+++ b/assembl/templates/login.jinja2
@@ -39,7 +39,7 @@
               {% for provider in providers %}
                 <form id="{{provider.name}}" class="mts js_login_{{provider.type}}" method="get" action="{{provider.login}}">
                   {% if discussion %}
-                    <input type="hidden" name="next" value="{{ get_route('new_home')}}" />
+                    <input type="hidden" name="next" value="{{ get_route('bare_slug')}}" />
                   {% endif %}
 
                   {% for k, v in provider.extra.items() %}

--- a/assembl/templates/profile.jinja2
+++ b/assembl/templates/profile.jinja2
@@ -207,7 +207,7 @@
               {% for provider in providers %}
                 <form id="{{provider.name}}" class="mts js_login_{{provider.type}}" method="get" action="{{provider.add_account}}">
                   {% if discussion %}
-                    <input type="hidden" name="next" value="{{ get_route('new_home')}}" />
+                    <input type="hidden" name="next" value="{{ get_route('bare_slug')}}" />
                   {% endif %}
 
                   {% for k, v in provider.extra.items() %}

--- a/assembl/templates/views/navBarLeft.tmpl
+++ b/assembl/templates/views/navBarLeft.tmpl
@@ -1,6 +1,6 @@
 <ul class="man pan">
     <li class="sub logo-container fl">
-        <a href="{{ get_route('new_home') }}" class="{% if discussion.logo %}assembl-custom-logo{% else %}assembl-logo{% endif %}" class="sign-in">{% if discussion.logo %}<img src="{{ discussion.logo }}" />{% endif %}</a>
+        <a href="{{ get_route('bare_slug') }}" class="{% if discussion.logo %}assembl-custom-logo{% else %}assembl-logo{% endif %}" class="sign-in">{% if discussion.logo %}<img src="{{ discussion.logo }}" />{% endif %}</a>
     </li>
     <li class="sub fl">
         <div id="onlinedot" class="onlinedot fl socketIndicator">

--- a/assembl/templates/views/navBarRight.tmpl
+++ b/assembl/templates/views/navBarRight.tmpl
@@ -17,7 +17,7 @@
     {% else %}
     {% if request.current_route_path().split('/')[-1] not in ('login', 'register')  %}
     <li class="sub fl mrs">
-        <a href="{{ get_route('react_login')}}?next={{ get_route('bare_slug')}}" class="btn btn-primary btn-sm joinDiscussion js_needJoinDiscussion" >{{ gettext('Join this discussion') }}</a>
+        <a href="{{ get_route('react_login')}}?next={{ get_route('home')}}" class="btn btn-primary btn-sm joinDiscussion js_needJoinDiscussion" >{{ gettext('Join this discussion') }}</a>
     </li>
     {% endif %}
     {% endif %}
@@ -57,7 +57,7 @@
         </div>
         {% else %}
           {% if request.current_route_path().split('/')[-1] not in ('login', 'register')  %}
-            <a href="{{ get_route('react_login')}}?next={{ get_route('bare_slug')}}" class="btn btn-default btn-sm sign-in-link">{{ gettext('Sign in') }}</a>
+            <a href="{{ get_route('react_login')}}?next={{ get_route('home')}}" class="btn btn-default btn-sm sign-in-link">{{ gettext('Sign in') }}</a>
           {% endif %}
         {% endif %}
     </li>

--- a/assembl/templates/views/navBarRight.tmpl
+++ b/assembl/templates/views/navBarRight.tmpl
@@ -17,7 +17,7 @@
     {% else %}
     {% if request.current_route_path().split('/')[-1] not in ('login', 'register')  %}
     <li class="sub fl mrs">
-        <a href="{{ get_route('react_login')}}?next={{ get_route('new_home')}}" class="btn btn-primary btn-sm joinDiscussion js_needJoinDiscussion" >{{ gettext('Join this discussion') }}</a>
+        <a href="{{ get_route('react_login')}}?next={{ get_route('bare_slug')}}" class="btn btn-primary btn-sm joinDiscussion js_needJoinDiscussion" >{{ gettext('Join this discussion') }}</a>
     </li>
     {% endif %}
     {% endif %}
@@ -57,7 +57,7 @@
         </div>
         {% else %}
           {% if request.current_route_path().split('/')[-1] not in ('login', 'register')  %}
-            <a href="{{ get_route('react_login')}}?next={{ get_route('new_home')}}" class="btn btn-default btn-sm sign-in-link">{{ gettext('Sign in') }}</a>
+            <a href="{{ get_route('react_login')}}?next={{ get_route('bare_slug')}}" class="btn btn-default btn-sm sign-in-link">{{ gettext('Sign in') }}</a>
           {% endif %}
         {% endif %}
     </li>

--- a/assembl/views/__init__.py
+++ b/assembl/views/__init__.py
@@ -156,6 +156,8 @@ def get_provider_data(get_route, providers=None):
 def create_get_route(request, discussion=None):
     if discussion:
         def get_route(name, **kwargs):
+            if name == "bare_slug":
+                name = "new_home" if discussion.preferences['landing_page'] else "home"
             try:
                 return request.route_path('contextual_' + name,
                                           discussion_slug=discussion.slug,
@@ -490,9 +492,6 @@ def redirector(request):
     return HTTPMovedPermanently(request.route_url(
         'home', discussion_slug=request.matchdict.get('discussion_slug')))
 
-
-def is_using_new_frontend():
-    return config.get('new_frontend', False)
 
 def includeme(config):
     """ Initialize views and renderers at app start-up time. """

--- a/assembl/views/auth/views.py
+++ b/assembl/views/auth/views.py
@@ -639,11 +639,19 @@ def user_confirm_email(request):
     if account and account.verified and logged_in:
         # no need to revalidate, just send to discussion.
         # Question: maybe_auto_subscribe? Doubt it.
+        if inferred_discussion:
+            if inferred_discussion.preferences['landing_page']:
+                route = 'new_home'
+            else:
+                route = 'home'
+        else:
+            route = 'discussion_list'
+        error = localizer.translate(
+            _("Email <%s> already confirmed")) % (account.email,)
+        request.session.flash(error)
         return HTTPFound(location=request.route_url(
-            'new_home' if inferred_discussion else 'discussion_list',
-            discussion_slug=inferred_discussion.slug,
-            _query=dict(message=localizer.translate(
-                _("Email <%s> already confirmed")) % (account.email,))))
+            route,
+            discussion_slug=inferred_discussion.slug if inferred_discussion else None))
 
     if validity != Validity.VALID or old_token:
         # V-, B-: Invalid or obsolete token

--- a/assembl/views/discussion/views.py
+++ b/assembl/views/discussion/views.py
@@ -218,15 +218,14 @@ def react_view(request):
             if login_url:
                 pass
             elif next_view:
-                # TODO: What if !canUseReact here?
-                login_url = request.route_url("general_react_page",
+                # Assuming that the next_view already knows about canUseReact.
+                # If not, will be re-routed
+                login_url = request.route_url("contextual_react_login",
                                               discussion_slug=discussion.slug,
-                                              extra_path='/login',
                                               _query={"next": next_view})
             else:
                 login_url = request.route_url(
-                    'contextual_react_login', discussion_slug=discussion.slug,
-                    extra_path='/login')
+                    'contextual_react_login', discussion_slug=discussion.slug)
             return HTTPTemporaryRedirect(login_url)
         elif not canRead:
             # User is logged-in but doesn't have access to the discussion

--- a/assembl/views/discussion/views.py
+++ b/assembl/views/discussion/views.py
@@ -326,14 +326,12 @@ def includeme(config):
     config.add_route('bare_slug', '/{discussion_slug}')
     config.add_route('auto_bare_slug', '/{discussion_slug}/')
     config.add_route('general_react_page', '/{discussion_slug}/*extra_path')
-    config.add_route('new_login', '/login')
 
     react_routes = [
                         "new_home",
                         "bare_slug",
                         "new_styleguide",
-                        "general_react_page",
-                        "new_login"
+                        "general_react_page"
                     ]
 
     register_react_views(config, react_routes)

--- a/assembl/views/discussion/views.py
+++ b/assembl/views/discussion/views.py
@@ -238,9 +238,10 @@ def react_view(request):
             return Response(body, 401)
         if not canUseReact:
             # Discussion not set up for landing page
-            extra_path = request.path[1:].split("/")  # exclude preceding slash
-            if len(extra_path) > 1:
-                extra_path = "/" + "/".join(extra_path[1:])
+            extra_path = request.path.split("/")  # There is a preceding slash
+            if len(extra_path) > 2:
+                # Carry over all paths after the slug
+                extra_path = "/" + "/".join(extra_path[2:])
             else:
                 extra_path = None
             query = request.query_string or None

--- a/assembl/views/discussion/views.py
+++ b/assembl/views/discussion/views.py
@@ -326,12 +326,14 @@ def includeme(config):
     config.add_route('bare_slug', '/{discussion_slug}')
     config.add_route('auto_bare_slug', '/{discussion_slug}/')
     config.add_route('general_react_page', '/{discussion_slug}/*extra_path')
+    config.add_route('new_login', '/login')
 
     react_routes = [
                         "new_home",
                         "bare_slug",
                         "new_styleguide",
-                        "general_react_page"
+                        "general_react_page",
+                        "new_login"
                     ]
 
     register_react_views(config, react_routes)

--- a/assembl/views/discussion/views.py
+++ b/assembl/views/discussion/views.py
@@ -238,15 +238,16 @@ def react_view(request):
             return Response(body, 401)
         if not canUseReact:
             # Discussion not set up for landing page
-            extra_path = request.path.split("/")
-            if len(extra_path) > 2:
-                extra_path = "/" + "/".join(extra_path[2:])
+            extra_path = request.path[1:].split("/")  # exclude preceding slash
+            if len(extra_path) > 1:
+                extra_path = "/" + "/".join(extra_path[1:])
             else:
                 extra_path = None
+            query = request.query_string or None
             url = request.route_url('home',
                                     discussion_slug=discussion.slug,
                                     extra_path=extra_path,
-                                    _query=request.query_string)
+                                    _query=query)
             return HTTPTemporaryRedirect(url)
     else:
         return get_login_context(request)

--- a/development.ini
+++ b/development.ini
@@ -331,8 +331,6 @@ activate_tour = true
 # minified_js = debug builds with map, which is much slower.
 minified_js = false
 
-#Switch that will enable using version 1 vs version 2 of Assembl's front-end
-new_frontend = false
 use_webpack_server = false
 # UNIQUE_PER_SERVER
 webpack_port=8080

--- a/production.ini
+++ b/production.ini
@@ -320,8 +320,6 @@ activate_tour = false
 # minified_js = debug builds with map, which is much slower.
 minified_js = false
 
-#Switch that will enable using version 1 vs version 2 of Assembl's front-end
-new_frontend = false
 use_webpack_server = false
 
 # Default subscriptions


### PR DESCRIPTION
rename new_home_bare->bare_slug. React views redirect to debate/slug according to a new landing_page preference. get_route also translates bare_slug routes to either home or new_home appropriately. Many get_route(new_home) now use bare_route. Some attendant cleanup.