### PR TITLE
Precreate notification subscriptions on discussion creation.

### DIFF
--- a/assembl/auth/util.py
+++ b/assembl/auth/util.py
@@ -363,8 +363,8 @@ def maybe_auto_subscribe(user, discussion):
     # really auto-subscribe user
     user.subscribe(discussion)
     discussion.db.flush()
-    # apply new notifications
-    user.get_notification_subscriptions(discussion.id)
+    # apply new notifications (on the same thread)
+    user.get_notification_subscriptions(discussion.id, on_thread=False)
     return True
 
 

--- a/assembl/tests/fixtures/discussion.py
+++ b/assembl/tests/fixtures/discussion.py
@@ -27,30 +27,15 @@ def discussion(request, test_session, default_preferences):
         preferences = discussion.preferences
         discussion.preferences = None
         discussion.preferences_id = None
+        for ut in discussion.user_templates:
+            for ns in ut.notification_subscriptions:
+                ns.delete()
+            ut.delete()
         test_session.delete(preferences)
         test_session.delete(discussion)
         test_session.flush()
     request.addfinalizer(fin)
     return d
-
-
-@pytest.fixture(scope="function")
-def discussion_synth_notification(request, test_session, discussion):
-    """Notification Subscription on Synthesis fixture"""
-    from assembl.models import (
-        NotificationSubscriptionFollowSyntheses, NotificationCreationOrigin)
-    u = discussion.user_templates[0]
-    sns = NotificationSubscriptionFollowSyntheses(
-        user=u, discussion=discussion,
-        creation_origin=NotificationCreationOrigin.USER_REQUESTED)
-    test_session.expire(u, ['notification_subscriptions'])
-
-    def fin():
-        print "finalizer discussion_synth_notification"
-        test_session.delete(sns)
-        test_session.flush()
-    request.addfinalizer(fin)
-    return sns
 
 
 @pytest.fixture(scope="function")
@@ -70,6 +55,10 @@ def discussion2(request, test_session):
         test_session.delete(d.table_of_contents)
         test_session.delete(d.root_idea)
         test_session.delete(d.next_synthesis)
+        for ut in d.user_templates:
+            for ns in ut.notification_subscriptions:
+                ns.delete()
+            ut.delete()
         preferences = d.preferences
         d.preferences = None
         test_session.delete(preferences)

--- a/assembl/tests/views_tests/test_api.py
+++ b/assembl/tests/views_tests/test_api.py
@@ -197,7 +197,6 @@ def disabledtest_next_synthesis_idea_management(
 
 
 def test_api_register(discussion, test_app_no_perm,
-                      discussion_synth_notification,
                       test_webrequest):
     from assembl.models import AbstractAgentAccount
     test_app_no_perm.app.registry.\
@@ -262,8 +261,7 @@ def test_api_register(discussion, test_app_no_perm,
 
 @pytest.mark.xfail
 def test_csv_subscribe(discussion, test_app_no_perm,
-                       test_app, discussion_synth_notification,
-                       test_webrequest):
+                       test_app, test_webrequest):
     from assembl.models import User, AbstractAgentAccount
     test_app_no_perm.app.registry.\
         settings['assembl.validate_registration_emails'] = 'true'

--- a/assembl/tests/views_tests/test_view_notification.py
+++ b/assembl/tests/views_tests/test_view_notification.py
@@ -27,8 +27,8 @@ def test_default_notifications(test_app, test_session, discussion, participant1_
     # Template created
     assert len(discussion.user_templates) == 1
     template = discussion.user_templates[0]
-    # Template has no subscriptions to start with
-    assert not len(template.notification_subscriptions)
+    # Template has base subscriptions to start with
+    assert len(template.notification_subscriptions) == 3
     # Get the user's notifications. Should not be empty.
     response = test_app.get(
         '/data/Discussion/%d/all_users/%d/notification_subscriptions' % (
@@ -96,8 +96,8 @@ def test_user_unsubscribed_stable(test_app, discussion, admin_user, participant1
     # Template created
     assert len(discussion.user_templates) == 1
     template = discussion.user_templates[0]
-    # Template has no subscriptions to start with
-    assert not len(template.notification_subscriptions)
+    # Template has base subscriptions to start with
+    assert len(template.notification_subscriptions) == 3
     # Get the user's notifications. Should not be empty.
     response = test_app.get(
         '/data/Discussion/%d/all_users/%d/notification_subscriptions' % (
@@ -158,8 +158,8 @@ def test_user_subscribed_stable(test_app, discussion, admin_user, participant1_u
    # Template created
     assert len(discussion.user_templates) == 1
     template = discussion.user_templates[0]
-    # Template has no subscriptions to start with
-    assert not len(template.notification_subscriptions)
+    # Template has base subscriptions to start with
+    assert len(template.notification_subscriptions) == 3
     # Get the user's notifications. Should not be empty.
     response = test_app.get(
         '/data/Discussion/%d/all_users/%d/notification_subscriptions' % (


### PR DESCRIPTION
Distinguish cases where NS are created through API calls on an existing user (which may be concurrent)
from NS creation on auto-subscribe, which MUST NOT be on a thread.
Ref: http://sentry.carrefour.bluenove.com/sentry/carrefour/issues/74/