### PR TITLE
Eliminate more virtuoso dependencies

### DIFF
--- a/assembl/lib/sqla.py
+++ b/assembl/lib/sqla.py
@@ -32,7 +32,7 @@ from sqlalchemy.orm.util import has_identity
 from sqlalchemy.util import classproperty
 from sqlalchemy.orm.session import object_session, Session
 from sqlalchemy.engine import strategies
-from virtuoso.vmapping import PatternIriClass
+from sqla_rdfbridge.mapping import PatternIriClass
 from zope.sqlalchemy import ZopeTransactionExtension
 from zope.sqlalchemy.datamanager import mark_changed as z_mark_changed
 from zope.component import getGlobalSiteManager

--- a/assembl/models/action.py
+++ b/assembl/models/action.py
@@ -19,7 +19,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.inspection import inspect
 from sqlalchemy.orm import relationship, backref, column_property
-from virtuoso.vmapping import IriClass
+from sqla_rdfbridge.mapping import IriClass
 from abc import abstractproperty
 
 from . import DiscussionBoundBase, DiscussionBoundTombstone, TombstonableMixin, Post

--- a/assembl/models/auth.py
+++ b/assembl/models/auth.py
@@ -35,7 +35,7 @@ from sqlalchemy.orm.attributes import NO_VALUE
 from sqlalchemy.sql.functions import count
 from pyramid.security import Everyone, Authenticated
 from rdflib import URIRef
-from virtuoso.vmapping import PatternIriClass
+from sqla_rdfbridge.mapping import PatternIriClass
 import transaction
 
 from ..lib import config

--- a/assembl/models/generic.py
+++ b/assembl/models/generic.py
@@ -22,7 +22,7 @@ from sqlalchemy import (
 from sqlalchemy.orm import relationship, backref, aliased
 from sqlalchemy.sql.functions import count
 from ..lib.sqla_types import CoerceUnicode
-from virtuoso.vmapping import PatternIriClass
+from sqla_rdfbridge.mapping import PatternIriClass
 # from virtuoso.textindex import TextIndex, TableWithTextIndex
 from bs4 import BeautifulSoup
 

--- a/assembl/models/idea.py
+++ b/assembl/models/idea.py
@@ -31,7 +31,7 @@ from sqlalchemy import (
     func,
 )
 from sqlalchemy.ext.associationproxy import association_proxy
-from virtuoso.vmapping import IriClass, PatternIriClass
+from sqla_rdfbridge.mapping import IriClass, PatternIriClass
 
 from ..lib.utils import get_global_base_url
 from ..nlp.wordcounter import WordCounter

--- a/assembl/models/idea_content_link.py
+++ b/assembl/models/idea_content_link.py
@@ -16,7 +16,7 @@ from sqlalchemy import (
     event,
 )
 from rdflib import URIRef
-from virtuoso.vmapping import PatternIriClass
+from sqla_rdfbridge.mapping import PatternIriClass
 
 from . import DiscussionBoundBase
 from ..semantic.virtuoso_mapping import QuadMapPatternS

--- a/assembl/semantic/namespaces.py
+++ b/assembl/semantic/namespaces.py
@@ -3,7 +3,6 @@ from rdflib import Graph as _Graph
 from rdflib.namespace import (
     Namespace, NamespaceManager as _NamespaceManager,
     RDF, RDFS, OWL, XSD, DC, DCTERMS, FOAF, SKOS)  # VOID
-from virtuoso.vmapping import VirtRDF
 
 SIOC = Namespace('http://rdfs.org/sioc/ns#')
 OA = Namespace('http://www.openannotation.org/ns/')
@@ -20,6 +19,7 @@ QUADNAMES = Namespace('http://purl.org/assembl/quadnames/')
 # COHERE = Namespace('http://cohere.open.ac.uk/ontology/cohere.owl#')
 # DUL = Namespace('http://www.loa-cnr.it/ontologies/DUL.owl#')
 # AIF = Namespace('http://www.arg.dundee.ac.uk/aif#')
+VirtRDF = Namespace('http://www.openlinksw.com/schemas/virtrdf#')
 
 namespace_manager = _NamespaceManager(_Graph())
 _name, _var = None, None

--- a/assembl/tests/model_tests/test_langstring.py
+++ b/assembl/tests/model_tests/test_langstring.py
@@ -179,7 +179,7 @@ def test_user_language_preference_en_to_fr_explicit_and_fr_explicit(
     Add {fr: Explicit} to User Language Preference
     Expect: IntegrityError
     """
-    from pyodbc import IntegrityError
+    from sqlalchemy.exc import IntegrityError
     from assembl.models.auth import (
         LanguagePreferenceOrder,
         UserLanguagePreference

--- a/fabfile.py
+++ b/fabfile.py
@@ -906,11 +906,6 @@ def install_builddeps():
         # glibtoolize, bison, flex, gperf are on osx by default.
         # brew does not know aclocal, autoheader...
         # They exist on macports, but do we want to install that?
-        if not exists('/usr/local/lib/libiodbc.2.dylib'):
-            run('brew install libiodbc')
-            # may require a sudo
-            if not run('brew link libiodbc', quiet=True):
-                sudo('brew link libiodbc')
         if not exists('/usr/local/bin/gfortran'):
             run('brew install gcc isl')
     else:
@@ -918,9 +913,6 @@ def install_builddeps():
         sudo('apt-get install -y automake bison flex gperf gawk')
         sudo('apt-get install -y graphviz pkg-config gfortran')
         sudo('apt-get install -y phantomjs', warn_only=True)
-
-        # will hopefully die soon
-        sudo('apt-get install -y unixodbc-dev')
     execute(update_python_package_builddeps)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -146,6 +146,7 @@ sphinxcontrib-zopeext==0.2.1
 Sphinx==1.4.4
 splinter==0.7.3
 SQLAlchemy==1.0.13
+-e git+https://github.com/conversence/sqlalchemy-rdfbridge.git#egg=sqlalchemy-rdfbridge
 sqlalchemy-schemadisplay==1.3
 sqlparse==0.1.19
 -e git+https://github.com/assembl/sqltap.git@assembl#egg=sqltap
@@ -157,7 +158,6 @@ Unidecode==0.4.19
 uritemplate==0.6
 uwsgitop==0.9
 venusian==1.0
--e git+https://github.com/maparent/sqlalchemy-rdfbridge.git#egg=sqlalchemy-rdfbridge
 psycopg2==2.6.1
 waitress==0.9.0
 WebOb==1.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -97,7 +97,6 @@ pyIsEmail==v1.3.1
 dnspython==1.14.0   # must come after pyisemail?
 PyJWT==1.4.0
 pylibmc==1.5.1
--e git+https://github.com/maparent/pyodbc.git@v3-virtuoso#egg=pyodbc
 pyOpenSSL==16.0.0
 pyparsing==2.1.5
 pyramid-autodoc==1.0.0
@@ -158,7 +157,7 @@ Unidecode==0.4.19
 uritemplate==0.6
 uwsgitop==0.9
 venusian==1.0
--e git+https://github.com/maparent/virtuoso-python#egg=virtuoso
+-e git+https://github.com/maparent/sqlalchemy-rdfbridge.git#egg=sqlalchemy-rdfbridge
 psycopg2==2.6.1
 waitress==0.9.0
 WebOb==1.6.1


### PR DESCRIPTION
I've been asked to make some improvements to my virtuoso-python handler, and it's a bit messy. So as to avoid interference with Assembl as I make those changes, I have extracted some key classes used by Assembl in a separate module that does not require pyodbc. It is now possible for Assembl to use that separate module, avoid use of pyodbc altogether, and I can make those modifications without breaking Assembl.
If you have no objections, I'd like to merge this soonish so I can merge the the handler work.

It would be possible to be even more radical, and remove all QuadMapPatterns, but that would require a prior buy-in, to be discussed.