### PR TITLE
Add piwik tracking to new frontend

### DIFF
--- a/assembl/static/js/app/internal_modules/analytics/abstract.js
+++ b/assembl/static/js/app/internal_modules/analytics/abstract.js
@@ -29,8 +29,8 @@ var moduleName = 'Analytics_Abstract',
   
   /*
    *
-   * In order to understand the event structure, please refer to docs/events.md for a broad explanation. 
-   * If any changes in architecture are made to the this file, please update docs/events.md, as appropriate.
+   * In order to understand the event structure, please refer to `doc/analytics/events.rst` for a broad explanation. 
+   * If any changes in architecture are made to the this file, please update `doc/analytics/events.rst`, as appropriate.
    * However, event definitions and summary should be done right here, in this file.
    * 
    */
@@ -70,8 +70,8 @@ var moduleName = 'Analytics_Abstract',
   };
 
   /** 
-   * _CATEGORY_DEFINITIONS: Normally accessed as dispatcher.actions.CONSTANT
-   * Defines which UI element a custom event originate from?
+   * _ACTION_DEFINITIONS: Normally accessed as dispatcher.actions.CONSTANT
+   * Defines which high-level user process did the event originate from?
    * 
    */
   var _ACTION_DEFINITIONS = {
@@ -99,7 +99,11 @@ var moduleName = 'Analytics_Abstract',
       PRODUCING: 'PRODUCING'
   };
 
-
+  /** 
+   * _EVENT_DEFINITIONS: Normally accessed as dispatcher.events.CONSTANT
+   * Defines each precise event object, which has `action`, `category`, and `eventName` fields.
+   * 
+   */
   var _EVENT_DEFINITIONS = {
       /**
        * Event fired when clicked on 'About' section of navigation carrousal on left  

--- a/assembl/static2/js/app/index.jsx
+++ b/assembl/static2/js/app/index.jsx
@@ -26,8 +26,8 @@ let customBrowserHistory;
 const isPiwikEnabled = get(window, ['globalAnalytics', 'piwik', 'isActive'], false);
 if (isPiwikEnabled) {
   const piwik = PiwikReactRouter({
-    url: 'your-piwik-installation.com',
-    siteId: 1
+    alreadyInitialized: true,
+    enableLinkTracking: false // this option has already been activated in the piwik tracking script present in the DOM
   });
   customBrowserHistory = piwik.connectToHistory(history);
 } else {

--- a/assembl/static2/js/app/index.jsx
+++ b/assembl/static2/js/app/index.jsx
@@ -2,18 +2,42 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { AppContainer } from 'react-hot-loader';
 import { Router, browserHistory } from 'react-router';
+import PiwikReactRouter from 'piwik-react-router';
 import { ApolloProvider } from 'react-apollo';
+import get from 'lodash/get';
 import 'bootstrap/dist/css/bootstrap.css';
 import createAppStore from './store';
 import client from './client';
 import Routes from './routes';
 
+
+/*
+`piwik-react-router` expects that we provide it with a browser history.
+We provide it with `react-router`'s `browserHistory`.
+This is not the official way of doing it.
+The official way is using the `history` library, called with `import history from './utils/history';`.
+For details, see https://github.com/ReactTraining/react-router/blob/master/FAQ.md#how-do-i-access-the-history-object-outside-of-components
+*/
+const history = browserHistory;
+
 const store = createAppStore(client);
+
+let customBrowserHistory;
+const isPiwikEnabled = get(window, ['globalAnalytics', 'piwik', 'isActive'], false);
+if (isPiwikEnabled) {
+  const piwik = PiwikReactRouter({
+    url: 'your-piwik-installation.com',
+    siteId: 1
+  });
+  customBrowserHistory = piwik.connectToHistory(history);
+} else {
+  customBrowserHistory = history;
+}
 
 ReactDOM.render(
   <AppContainer>
     <ApolloProvider store={store} client={client}>
-      <Router history={browserHistory} routes={Routes} />
+      <Router history={customBrowserHistory} routes={Routes} />
     </ApolloProvider>
   </AppContainer>,
   document.getElementById('root')
@@ -26,7 +50,7 @@ if (module.hot) {
     ReactDOM.render(
       <AppContainer>
         <ApolloProvider store={store} client={client}>
-          <Router history={browserHistory} routes={NewRoutes} />
+          <Router history={customBrowserHistory} routes={NewRoutes} />
         </ApolloProvider>
       </AppContainer>,
       document.getElementById('root')

--- a/assembl/static2/package.json
+++ b/assembl/static2/package.json
@@ -66,7 +66,7 @@
     "json-loader": "^0.5.4",
     "lodash": "^4.17.4",
     "moment": "^2.18.1",
-    "piwik-react-router": "^0.9.0",
+    "piwik-react-router": "assembl/piwik-react-router#skip_piwik_initialization",
     "prop-types": "^15.5.8",
     "react": "^15.4.1",
     "react-apollo": "^1.2.0",

--- a/assembl/static2/package.json
+++ b/assembl/static2/package.json
@@ -66,6 +66,7 @@
     "json-loader": "^0.5.4",
     "lodash": "^4.17.4",
     "moment": "^2.18.1",
+    "piwik-react-router": "^0.9.0",
     "prop-types": "^15.5.8",
     "react": "^15.4.1",
     "react-apollo": "^1.2.0",

--- a/assembl/static2/yarn.lock
+++ b/assembl/static2/yarn.lock
@@ -3939,6 +3939,13 @@ pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
 
+piwik-react-router@assembl/piwik-react-router#skip_piwik_initialization:
+  version "0.9.0"
+  resolved "https://codeload.github.com/assembl/piwik-react-router/tar.gz/55a93a216a23fd3058bef33b47f989f1059196a8"
+  dependencies:
+    url-join "^1.1.0"
+    warning "^3.0.0"
+
 pkg-dir@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-1.0.0.tgz#7a4b508a8d5bb2d629d447056ff4e9c9314cf3d4"
@@ -5434,6 +5441,10 @@ uniqs@^2.0.0:
 unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
+
+url-join@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/url-join/-/url-join-1.1.0.tgz#741c6c2f4596c4830d6718460920d0c92202dc78"
 
 url-join@^2.0.0:
   version "2.0.2"

--- a/assembl/templates/index_react.jinja2
+++ b/assembl/templates/index_react.jinja2
@@ -37,6 +37,7 @@
         {% endif %}
         <div id='root'></div>
         {% block main_js %}
+            {% include 'analytics_common.jinja2' %}
             <script src='{{REACT_URL}}/build/bundle.js'></script>
             {% if NODE_ENV == 'development' %}
                 <script src="{{REACT_URL}}/build/theme_{{theme_name}}_web.js"></script>

--- a/assembl/views/discussion/views.py
+++ b/assembl/views/discussion/views.py
@@ -296,7 +296,7 @@ def react_view(request, required_permission=P_READ):
         get_route=get_route,
         **common_context
     )
-    context.update(context_update)
+    context.update(common_context)
     return context
 
 

--- a/assembl/views/discussion/views.py
+++ b/assembl/views/discussion/views.py
@@ -296,7 +296,6 @@ def react_view(request, required_permission=P_READ):
         get_route=get_route,
         **common_context
     )
-    context.update(common_context)
     return context
 
 

--- a/assembl/views/discussion/views.py
+++ b/assembl/views/discussion/views.py
@@ -218,6 +218,7 @@ def react_view(request, required_permission=P_READ):
         "REACT_URL": old_context['REACT_URL'],
         "NODE_ENV": node_env,
         "assembl_version": pkg_resources.get_distribution("assembl").version,
+        "web_analytics": old_context['web_analytics'],
     }
 
     if discussion:
@@ -295,6 +296,7 @@ def react_view(request, required_permission=P_READ):
         get_route=get_route,
         **common_context
     )
+    context.update(context_update)
     return context
 
 

--- a/doc/analytics/events.rst
+++ b/doc/analytics/events.rst
@@ -5,19 +5,19 @@ All custom events that will currently be fired by assembl are defined
 in: ``../../assembl/static/js/app/internal\_modules/analytics/abstract.js``
 
 Events in Piwik (and other Analytics software) are on a multi-axis
-spectrum. These axis are:
+spectrum. These axes are:
 
 Category, Action, and Event Name
 
-Often times, these axii are orthogonal to each other. As a result,
+Often times, these axes are orthogonal to each other. As a result,
 events can be defined in multi-dimensional space. Do not let this
 concept bog you down, however. It simply means that analytic events
 simply have some luggage with them. That luggage is the contexts in which
 the event was fired. Within Piwik, each axis can be viewed in
-relation to 1 of the other axii. Assembl has decided that these axis
+relation to 1 of the other axes. Assembl has decided that these axes
 should convey a meaningful structure. This means that the context of an
 event should have value to the analytst who reads reports generated upon
-events being fired. Assembl tries to simply this by defining the axis as
+events being fired. Assembl tries to simplify this by defining the axes as
 follows:
 
 -  Category: Which physical UI element did the event originate from?  Typically


### PR DESCRIPTION
This corresponds to story DEVAS-655.
This triggers piwik tracking everytime the React application changes the browser URL.
Adding custom piwik actions types on specific user behavior will be for a next time.