### PR TITLE
Fix misaligned carets (with flex) (DEVAS-611)

### DIFF
--- a/assembl/static2/css/components/avatar.scss
+++ b/assembl/static2/css/components/avatar.scss
@@ -21,10 +21,6 @@
     font-size: $font-size-xs;
     margin: 3px 0;
   }
-
-  .caret {
-    padding-bottom: 5px;
-  }
 }
 
 @media screen and (max-width: 767px) {

--- a/assembl/static2/css/components/dropdown.scss
+++ b/assembl/static2/css/components/dropdown.scss
@@ -8,6 +8,7 @@
   vertical-align: text-bottom;
 
   .dropdown-toggle {
+    height: 20px;
     color: $first-color;
     font-size: $font-size-xs;
 
@@ -38,6 +39,12 @@
     .caret {
       color: $first-color;
     }
+  }
+
+  .dropdown > a {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
   }
 }
 

--- a/assembl/static2/css/components/navbar.scss
+++ b/assembl/static2/css/components/navbar.scss
@@ -67,7 +67,12 @@
   }
 
   .navbar-language {
-    margin: 2px 0 0 5px;
+    margin: 1px 0 0 5px;
+
+    .caret {
+        position: relative;
+        left: 0.3em;
+    }
   }
 }
 


### PR DESCRIPTION
Should work on all browsers except IE<=9
Tested on firefox, safari and chrome on osx