### PR TITLE
add disallow_robots option in docker.rc

### DIFF
--- a/configs/docker.rc
+++ b/configs/docker.rc
@@ -77,3 +77,5 @@ docker_secure_rproxy = true
 # Will we use the certbot on this docker instance?
 docker_certbot =
 
+# Should we return a restrictive robots.txt?
+disallow_robots =

--- a/docker/nginx_default.jinja2
+++ b/docker/nginx_default.jinja2
@@ -15,6 +15,12 @@ server {
   # This is the server name, if you're running multiple servers
   server_name {{public_hostname_}};
 
+  {% if disallow_robots %}
+      location /robots.txt {
+          return 200 "User-agent: *\nDisallow: /";
+      }
+  {% endif %}
+
   location /.well-known {
       #This is for domain verification
       alias /var/www/html/.well-known;


### PR DESCRIPTION
One of Freds request for the preprod server is that it should not be referenced

So I just need to add `disallow_robots = true` in my_docker.rc