### PR TITLE
use transform-react-inline-elements babel plugin for faster stateless…

### DIFF
--- a/assembl/static2/package.json
+++ b/assembl/static2/package.json
@@ -29,6 +29,7 @@
     "babel-loader": "^7.1.2",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
+    "babel-plugin-transform-react-inline-elements": "^6.22.0",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.6.0",
     "babel-preset-react": "^6.16.0",

--- a/assembl/static2/webpack.config.js
+++ b/assembl/static2/webpack.config.js
@@ -59,7 +59,9 @@ module.exports = {
                 // we need plugins and presets here for that.
                 // A dependency is transpiled only if it's in the include below.
                 plugins: [
-                  'transform-object-rest-spread', 'transform-class-properties',
+                  'transform-object-rest-spread',
+                  'transform-class-properties',
+                  'transform-react-inline-elements',
                   ['transform-runtime', { helpers: true, polyfill: false }]
                 ],
                 presets: [["env", { "modules": false, "targets": { "ie": 11 },

--- a/assembl/static2/yarn.lock
+++ b/assembl/static2/yarn.lock
@@ -841,6 +841,12 @@ babel-plugin-transform-react-display-name@^6.23.0:
   dependencies:
     babel-runtime "^6.22.0"
 
+babel-plugin-transform-react-inline-elements@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-inline-elements/-/babel-plugin-transform-react-inline-elements-6.22.0.tgz#6687211a32b49a52f22c573a2b5504a25ef17c53"
+  dependencies:
+    babel-runtime "^6.22.0"
+
 babel-plugin-transform-react-jsx-self@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz#df6d80a9da2612a121e6ddd7558bcbecf06e636e"


### PR DESCRIPTION
… react components

see https://www.bram.us/2017/05/08/45-faster-react-stateless-functional-components/
Probably not a 45% improvement tho