### PR TITLE
rearranged positioning in the post editor

### DIFF
--- a/assembl/static2/css/common.scss
+++ b/assembl/static2/css/common.scss
@@ -71,7 +71,6 @@ input.placeholder, textarea.placeholder {
 .color {
   color: $first-color;
 }
-
 .color2 {
   color: $second-color;
 }
@@ -233,9 +232,14 @@ input.placeholder, textarea.placeholder {
 
 .form-label {
     color: $grey3;
-    font-family: $font-family6;
-    font-size: $font-size-s;
-    padding: 0 0 5px 3px;
+    font-family: $font-family;
+    font-size: $font-size-xs;
+    padding: 0 0 3px 22px;
+}
+
+.form-label-body {
+  position: absolute;
+  top: 131px
 }
 
 @media screen and (min-width: 992px) {

--- a/assembl/static2/css/components/buttons.scss
+++ b/assembl/static2/css/components/buttons.scss
@@ -44,7 +44,7 @@
 
 .button-submit {
   @extend .button-generic;
-  padding: 10px 50px;
+  padding: 11px 24px;
 
   &:active {
     box-shadow: none;
@@ -58,7 +58,7 @@
 
 .button-cancel {
   @extend .button-generic;
-  padding: 10px 50px;
+  padding: 11px 24px;
 }
 
 .button-light {
@@ -90,6 +90,3 @@
     outline: none;
   }
 }
-
-
-

--- a/assembl/static2/css/components/overflowMenu.scss
+++ b/assembl/static2/css/components/overflowMenu.scss
@@ -8,6 +8,7 @@
 
     &:hover {
       color: $first-color;
+      cursor: pointer;
     }
 
     &:last-child {

--- a/assembl/static2/css/components/richTextEditor.scss
+++ b/assembl/static2/css/components/richTextEditor.scss
@@ -26,6 +26,14 @@
   }
 }
 
+.sm-title {
+  font-size: $font-size-sm;
+}
+
+.margin-left-9 {
+  margin-left: 9px;
+}
+
 .top-post-form {
   .editor-toolbar {
     margin-bottom: 5px;
@@ -34,6 +42,7 @@
 
 .rich-text-editor {
   font-family: $font-family;
+  margin-top: 16px;
 
   .insertion-box {
     .assembl-icon-cancel {
@@ -54,6 +63,8 @@
   }
 
   .editor-toolbar {
+    display: flex;
+    justify-content: flex-end;
     .btn-group {
       margin-right: 5px;
 

--- a/assembl/static2/js/app/components/debate/thread/editPostForm.jsx
+++ b/assembl/static2/js/app/components/debate/thread/editPostForm.jsx
@@ -131,8 +131,8 @@ class EditPostForm extends React.PureComponent<void, EditPostFormProps, EditPost
     return (
       <Row>
         <Col xs={12} md={12}>
-          <div className="color">
-            <span className="assembl-icon-back-arrow" />&nbsp;<Translate value="debate.edit.title" />
+          <div className="color margin-left-9">
+            <span className="assembl-icon-edit" />&nbsp;<Translate value="debate.edit.title" className="sm-title" />
           </div>
         </Col>
         <Col xs={12} md={12}>
@@ -152,7 +152,7 @@ class EditPostForm extends React.PureComponent<void, EditPostFormProps, EditPost
                 maxLength={TEXT_INPUT_MAX_LENGTH}
               />}
             <FormGroup>
-              <div className="form-label">
+              <div className="form-label form-label-body">
                 <Translate value="debate.edit.body" />
               </div>
               <RichTextEditor


### PR DESCRIPTION
the span's positionning in absolute above the richtexteditor is temporary, a cleaner solution is desirable
