### PR TITLE
specified display of survey's questions for small retina screens

### DIFF
--- a/assembl/static2/css/views/debate.scss
+++ b/assembl/static2/css/views/debate.scss
@@ -397,7 +397,10 @@
   }
 }
 
-@media screen and (max-width: 767px) {
+@media screen and
+(max-width: 767px),
+(-webkit-min-device-pixel-ratio: 2),
+(min-resolution: 192dpi) {
   .video-section {
     .video-title-section {
       margin: $margin-section-xs 0 0;


### PR DESCRIPTION
following the rejection by Fred (the send button was still hidden on the Yoga because it has a retina-like screen)