### PR TITLE
Attachment image prev styling

### DIFF
--- a/assembl/static2/css/components/richTextEditor.scss
+++ b/assembl/static2/css/components/richTextEditor.scss
@@ -46,6 +46,22 @@
   position: relative;
 
   .insertion-box {
+
+    min-height: 200px;
+    position: absolute;
+    left: 50%;
+    transform: translate(-50%);
+    bottom: 0;
+    width: 80%;
+    z-index: 1040;
+    border: 1px solid rgba(0, 0, 0, 0.2);
+    border-radius: 5px;
+    box-shadow: 1px 1px 1px 0px #656565;
+
+    .with-image-preview {
+      min-height: 350px;
+    }
+
     .assembl-icon-cancel {
       float: right;
       cursor: pointer;
@@ -55,28 +71,51 @@
       label {
         position: absolute;
         left: 50%;
-        top: 14%;
+        top: 11%;
         transform: translate(-50%);
         font-size: $font-size-sm;
+      }
+    }
+
+    .with-preview {
+      min-height: 320px;
+
+      .btn-default {
+        top: 21%;
+      }
+
+      .preview img {
+        top: 35%;
+        max-height: 42%;
+      }
+
+      .button-submit {
+        top: 87%;
       }
     }
 
     .btn-default {
       position: absolute;
       left: 50%;
-      top: 35%;
+      top: 27%;
       transform: translate(-50%);
     }
 
     .button-submit {
       position: absolute;
       left: 50%;
-      top: 70%;
-      transform: translate(-50%);
+      top: 80%;
+      transform: translate(-50%, -50%);
     }
 
+
     .preview img {
-      width: 50%;
+      max-width: 60%;
+      max-height: 35%;
+      position: absolute;
+      top: 40%;
+      left: 50%;
+      transform: translate(-50%);
     }
 
     .preview-title {
@@ -88,17 +127,6 @@
       transform: translate(-50%);
       font-size: $font-size-xxs;
     }
-
-    min-height: 250px;
-    position: absolute;
-    left: 50%;
-    transform: translate(-50%);
-    bottom: 0;
-    width: 80%;
-    z-index: 1040;
-    border: 1px solid rgba(0, 0, 0, 0.2);
-    border-radius: 5px;
-    box-shadow: 1px 1px 1px 0px #656565;
   }
 
   .editor-header {

--- a/assembl/static2/js/app/components/common/attachFileForm.jsx
+++ b/assembl/static2/js/app/components/common/attachFileForm.jsx
@@ -36,12 +36,18 @@ class AttachFileForm extends React.Component<*, AttachFileFormProps, AttachFileF
   };
 
   render() {
+    let isImage;
+    const file = this.state.file;
+    if (file !== null) {
+      isImage = file.type.includes('image');
+    }
+
     return (
-      <div className="attach-file">
+      <div className={isImage ? 'attach-file with-preview' : 'attach-file'}>
         <label htmlFor="attachment">
           <Translate value="common.attachFileForm.label" />
         </label>
-        <FileUploader handleChange={this.handleFileChange} fileOrUrl={this.state.file} withPreview={false} />
+        <FileUploader handleChange={this.handleFileChange} fileOrUrl={this.state.file} isImage={isImage} withPreview />
         <Button className="button-submit button-dark btn btn-default" onClick={this.handleSubmit}>
           <Translate value="common.attachFileForm.submit" />
         </Button>

--- a/assembl/static2/js/app/components/common/fileUploader.jsx
+++ b/assembl/static2/js/app/components/common/fileUploader.jsx
@@ -67,7 +67,7 @@ class FileUploader extends React.Component {
   render() {
     const fileSrc = this.state.fileSrc;
     const fileIsImage = this.props.isImage;
-    const urlIsImage = fileSrc && fileSrc.includes('png' || 'jpeg' || 'jpg' || 'gif');
+    const urlIsImage = fileSrc && fileSrc.endsWith('png' || 'jpeg' || 'jpg' || 'gif');
     const isImage = fileIsImage || urlIsImage;
     return (
       <div>

--- a/assembl/static2/js/app/components/common/fileUploader.jsx
+++ b/assembl/static2/js/app/components/common/fileUploader.jsx
@@ -68,23 +68,24 @@ class FileUploader extends React.Component {
     const fileSrc = this.state.fileSrc;
     const fileIsImage = this.props.isImage;
     const urlIsImage = fileSrc && fileSrc.includes('png' || 'jpeg' || 'jpg' || 'gif');
+    const isImage = fileIsImage || urlIsImage;
     return (
       <div>
         <Button onClick={this.handleUploadButtonClick}>
           <Translate value="common.uploadButton" />
         </Button>
-        {this.props.withPreview
-          ? <div className={this.state.fileSrc ? 'preview' : 'hidden'}>
+        {this.props.withPreview && isImage
+          ? <div className={fileSrc ? 'preview' : 'hidden'}>
             <img
               src={fileSrc}
               ref={(p) => {
                 this.preview = p;
               }}
-              alt={fileIsImage || urlIsImage ? 'preview' : ''}
+              alt="preview"
             />
           </div>
           : null}
-        {!fileIsImage &&
+        {!isImage &&
           <div className="preview-title">
             {this.state.fileName}
           </div>}

--- a/assembl/static2/js/app/components/common/fileUploader.jsx
+++ b/assembl/static2/js/app/components/common/fileUploader.jsx
@@ -10,8 +10,9 @@ class FileUploader extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      filename: '',
-      fileSrc: undefined
+      fileName: '',
+      fileSrc: undefined,
+      fileType: ''
     };
     this.handleChangePreview = this.handleChangePreview.bind(this);
     this.handleUploadButtonClick = this.handleUploadButtonClick.bind(this);
@@ -35,7 +36,7 @@ class FileUploader extends React.Component {
   handleChangePreview() {
     const file = this.fileInput.files[0];
     this.setState({
-      filename: file.name || ''
+      fileName: file.name || ''
     });
     this.props.handleChange(file);
   }
@@ -50,7 +51,7 @@ class FileUploader extends React.Component {
         'load',
         () => {
           this.setState({
-            filename: file.name || '',
+            fileName: file.name || '',
             fileSrc: reader.result
           });
         },
@@ -65,6 +66,9 @@ class FileUploader extends React.Component {
   }
 
   render() {
+    const fileSrc = this.state.fileSrc;
+    const fileIsImage = this.props.isImage;
+    const urlIsImage = fileSrc && fileSrc.includes('png' || 'jpeg' || 'jpg' || 'gif');
     return (
       <div>
         <Button onClick={this.handleUploadButtonClick}>
@@ -73,17 +77,18 @@ class FileUploader extends React.Component {
         {this.props.withPreview
           ? <div className={this.state.fileSrc ? 'preview' : 'hidden'}>
             <img
-              src={this.state.fileSrc}
+              src={fileSrc}
               ref={(p) => {
                 this.preview = p;
               }}
-              alt="preview"
+              alt={fileIsImage || urlIsImage ? 'preview' : ''}
             />
           </div>
           : null}
-        <div className="preview-title">
-          {this.state.filename}
-        </div>
+        {!fileIsImage &&
+          <div className="preview-title">
+            {this.state.fileName}
+          </div>}
         <input
           type="file"
           onChange={this.handleChangePreview}

--- a/assembl/static2/js/app/components/common/fileUploader.jsx
+++ b/assembl/static2/js/app/components/common/fileUploader.jsx
@@ -11,8 +11,7 @@ class FileUploader extends React.Component {
     super(props);
     this.state = {
       fileName: '',
-      fileSrc: undefined,
-      fileType: ''
+      fileSrc: undefined
     };
     this.handleChangePreview = this.handleChangePreview.bind(this);
     this.handleUploadButtonClick = this.handleUploadButtonClick.bind(this);

--- a/assembl/static2/tests/unit/components/common/__snapshots__/fileUploader.spec.jsx.snap
+++ b/assembl/static2/tests/unit/components/common/__snapshots__/fileUploader.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`FileUploader component should render an image uploader 1`] = `
+exports[`FileUploader component should render a file uploader for an image file 1`] = `
 <div>
   <button
     className="btn btn-default"
@@ -23,6 +23,29 @@ exports[`FileUploader component should render an image uploader 1`] = `
       src="http://www.example.com/foobar.png"
     />
   </div>
+  <input
+    className="hidden"
+    onChange={[Function]}
+    type="file"
+  />
+</div>
+`;
+
+exports[`FileUploader component should render a file uploader with the filename if the file is not an image 1`] = `
+<div>
+  <button
+    className="btn btn-default"
+    disabled={false}
+    onClick={[Function]}
+    type="button"
+  >
+    <span
+      className={undefined}
+      style={undefined}
+    >
+      Upload Button
+    </span>
+  </button>
   <div
     className="preview-title"
   >
@@ -36,7 +59,7 @@ exports[`FileUploader component should render an image uploader 1`] = `
 </div>
 `;
 
-exports[`FileUploader component should render an image uploader without preview 1`] = `
+exports[`FileUploader component should render a file uploader without preview 1`] = `
 <div>
   <button
     className="btn btn-default"

--- a/assembl/static2/tests/unit/components/common/fileUploader.spec.jsx
+++ b/assembl/static2/tests/unit/components/common/fileUploader.spec.jsx
@@ -4,7 +4,7 @@ import renderer from 'react-test-renderer';
 import FileUploader from '../../../../js/app/components/common/fileUploader';
 
 describe('FileUploader component', () => {
-  it('should render an image uploader', () => {
+  it('should render a file uploader for an image file', () => {
     const handleChangeSpy = jest.fn(() => {});
     const component = renderer.create(
       <FileUploader fileOrUrl="http://www.example.com/foobar.png" handleChange={handleChangeSpy} />
@@ -13,10 +13,19 @@ describe('FileUploader component', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it('should render an image uploader without preview', () => {
+  it('should render a file uploader without preview', () => {
     const handleChangeSpy = jest.fn(() => {});
     const file = new File([''], 'foobar.png');
     const component = renderer.create(<FileUploader fileOrUrl={file} handleChange={handleChangeSpy} withPreview={false} />);
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should render a file uploader with the filename if the file is not an image', () => {
+    // FIXME: due to the async nature of FileReader, it is very difficult to really render the filename in the snapshot
+    const handleChangeSpy = jest.fn(() => {});
+    const file = new File([''], 'foobar.pdf');
+    const component = renderer.create(<FileUploader fileOrUrl={file} handleChange={handleChangeSpy} />);
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });


### PR DESCRIPTION
The modal is now adapting to properly display an image preview in case the uploaded file is an image. If it's any other format of file it will just display the file name and keep its original size.