### PR TITLE
Change img in IdeaInterface

### DIFF
--- a/assembl/graphql/schema.py
+++ b/assembl/graphql/schema.py
@@ -580,20 +580,15 @@ class IdeaInterface(graphene.Interface):
     num_posts = graphene.Int()
     num_contributors = graphene.Int()
     num_children = graphene.Int(identifier=graphene.String())
-    img_url = graphene.String()
-    img_mimetype = graphene.String()
+    img = graphene.Field(Document)
     order = graphene.Float()
 
     def resolve_num_posts(self, args, context, info):
         return self.num_posts
 
-    def resolve_img_url(self, args, context, info):
+    def resolve_img(self, args, context, info):
         if self.attachments:
-            return self.attachments[0].external_url
-
-    def resolve_img_mimetype(self, args, context, info):
-        if self.attachments:
-            return self.attachments[0].document.mime_type
+            return self.attachments[0].document
 
     def resolve_order(self, args, context, info):
         return self.get_order_from_first_parent()

--- a/assembl/static2/js/app/components/administration/saveButton.jsx
+++ b/assembl/static2/js/app/components/administration/saveButton.jsx
@@ -34,9 +34,9 @@ const createVariablesForMutation = (thematic) => {
   return {
     identifier: 'survey',
     titleEntries: thematic.titleEntries,
-    // If imgUrl is an object, it means it's a File.
+    // If thematic.img.externalUrl is an object, it means it's a File.
     // We need to send image: null if we didn't change the image.
-    image: typeof thematic.imgUrl === 'object' ? thematic.imgUrl : null,
+    image: typeof thematic.img.externalUrl === 'object' ? thematic.img.externalUrl : null,
     // if video is null, pass {} to remove all video fields on server side
     video: thematic.video === null ? {} : convertVideoDescriptionsToHTML(thematic.video),
     questions: thematic.questions

--- a/assembl/static2/js/app/components/administration/survey/themeForm.jsx
+++ b/assembl/static2/js/app/components/administration/survey/themeForm.jsx
@@ -9,7 +9,7 @@ import FileUploader from '../../common/fileUploader';
 import { deleteThematicTooltip } from '../../common/tooltips';
 
 export const DumbThemeCreationForm = ({
-  imgMimetype,
+  imgMimeType,
   imgUrl,
   index,
   markAsToDelete,
@@ -41,7 +41,7 @@ export const DumbThemeCreationForm = ({
       </div>
       <FormControlWithLabel label={ph} onChange={handleTitleChange} required type="text" value={title} />
       <FormGroup>
-        <FileUploader fileOrUrl={imgUrl} handleChange={handleImageChange} mimeType={imgMimetype} />
+        <FileUploader fileOrUrl={imgUrl} handleChange={handleImageChange} mimeType={imgMimeType} />
       </FormGroup>
       <div className="pointer right">
         <OverlayTrigger placement="top" overlay={deleteThematicTooltip}>
@@ -65,8 +65,8 @@ const mapStateToProps = ({ admin: { thematicsById } }, { id, selectedLocale }) =
     return entry.get('localeCode') === selectedLocale;
   });
   return {
-    imgMimetype: thematic.get('imgMimetype', ''),
-    imgUrl: thematic.get('imgUrl', ''),
+    imgMimeType: thematic.getIn(['img', 'mimeType']),
+    imgUrl: thematic.getIn(['img', 'externalUrl']),
     title: titleEntry ? titleEntry.get('value', '') : '',
     toDelete: thematic.get('toDelete', false)
   };

--- a/assembl/static2/js/app/components/common/withLoadingIndicator.jsx
+++ b/assembl/static2/js/app/components/common/withLoadingIndicator.jsx
@@ -8,7 +8,7 @@ import Loader from './loader';
 const withLoadingIndicator = (loaderProps = {}) => {
   return (WrappedComponent) => {
     return (props) => {
-      if (props.data.loading) {
+      if (props.loading || (props.data && props.data.loading)) {
         return <Loader {...loaderProps} />;
       }
       return <WrappedComponent {...props} />;

--- a/assembl/static2/js/app/components/debate/common/ideasLevel.jsx
+++ b/assembl/static2/js/app/components/debate/common/ideasLevel.jsx
@@ -268,7 +268,7 @@ class IdeasLevel extends React.Component {
                   style={nbLevel > 1 ? { width: ideaPreviewWidth } : {}}
                 >
                   <IdeaPreview
-                    imgUrl={idea.imgUrl}
+                    imgUrl={idea.img ? idea.img.externalUrl : ''}
                     numPosts={idea.numPosts}
                     numContributors={idea.numContributors}
                     numChildren={idea.numChildren}

--- a/assembl/static2/js/app/components/debate/common/themes.jsx
+++ b/assembl/static2/js/app/components/debate/common/themes.jsx
@@ -42,7 +42,7 @@ class Themes extends React.Component {
                   return (
                     <Col xs={12} sm={6} md={3} className={this.getColClassNames(index)} key={index}>
                       <ThematicPreview
-                        imgUrl={thematic.imgUrl}
+                        imgUrl={thematic.img ? thematic.img.externalUrl : ''}
                         numPosts={thematic.numPosts}
                         numContributors={thematic.numContributors}
                         link={`${get('debate', { slug: slug, phase: identifier })}${get('theme', { themeId: thematic.id })}`}

--- a/assembl/static2/js/app/components/debate/multiColumns/multiColumns.jsx
+++ b/assembl/static2/js/app/components/debate/multiColumns/multiColumns.jsx
@@ -7,7 +7,8 @@ import { orderPostsByMessageClassifier, getSynthesisTitle } from './utils';
 export default ({
   messageColumns,
   posts,
-  idea,
+  ideaId,
+  ideaTitle,
   width,
   lang,
   contentLocaleMapping,
@@ -24,7 +25,7 @@ export default ({
       {Object.keys(columnsArray).map((classifier, index) => {
         const synthesisProps = showSynthesis && {
           classifier: classifier,
-          synthesisTitle: getSynthesisTitle(classifier, messageColumns[index].name, idea.title),
+          synthesisTitle: getSynthesisTitle(classifier, messageColumns[index].name, ideaTitle),
           synthesisBody: messageColumns[index].header || I18n.t('multiColumns.synthesis.noSynthesisYet'),
           hyphenStyle: { borderTopColor: messageColumns[index].color }
         };
@@ -40,9 +41,9 @@ export default ({
             data={columnsArray[classifier]}
             initialRowIndex={initialRowIndex}
             noRowsRenderer={noRowsRenderer}
-            ideaId={idea.id}
+            ideaId={ideaId}
             refetchIdea={refetchIdea}
-            ideaTitle={idea.title}
+            ideaTitle={ideaTitle}
             identifier={identifier}
             debateData={debateData}
           />

--- a/assembl/static2/js/app/components/debate/multiColumns/tabbedColumns.jsx
+++ b/assembl/static2/js/app/components/debate/multiColumns/tabbedColumns.jsx
@@ -23,7 +23,8 @@ export default class TabbedColumns extends React.Component {
       messageColumns,
       initialRowIndex,
       noRowsRenderer,
-      idea,
+      ideaId,
+      ideaTitle,
       refetchIdea,
       showSynthesis,
       identifier,
@@ -38,7 +39,7 @@ export default class TabbedColumns extends React.Component {
     );
     const synthesisProps = showSynthesis && {
       classifier: activeKey,
-      synthesisTitle: getSynthesisTitle(activeKey, messageColumns[index].name, idea.title),
+      synthesisTitle: getSynthesisTitle(activeKey, messageColumns[index].name, ideaTitle),
       synthesisBody: messageColumns[index].header || I18n.t('multiColumns.synthesis.noSynthesisYet'),
       hyphenStyle: { borderTopColor: messageColumns[index].color }
     };
@@ -62,7 +63,7 @@ export default class TabbedColumns extends React.Component {
                   }}
                   disabled={isActive}
                 >
-                  {getTabTitle(classifier, messageColumn.name, idea.title)}
+                  {getTabTitle(classifier, messageColumn.name, ideaTitle)}
                 </button>
               </div>
             );
@@ -79,9 +80,9 @@ export default class TabbedColumns extends React.Component {
             data={columnsArray[activeKey]}
             initialRowIndex={initialRowIndex}
             noRowsRenderer={noRowsRenderer}
-            ideaId={idea.id}
+            ideaId={ideaId}
             refetchIdea={refetchIdea}
-            ideaTitle={idea.title}
+            ideaTitle={ideaTitle}
             identifier={identifier}
             debateData={debateData}
           />

--- a/assembl/static2/js/app/components/debate/thread/threadView.jsx
+++ b/assembl/static2/js/app/components/debate/thread/threadView.jsx
@@ -11,7 +11,7 @@ class ThreadView extends React.Component {
   render() {
     const {
       isUserConnected,
-      idea,
+      ideaId,
       contentLocaleMapping,
       refetchIdea,
       lang,
@@ -25,7 +25,7 @@ class ThreadView extends React.Component {
     return (
       <div className="overflow-x">
         {(!isUserConnected || connectedUserCan(Permissions.ADD_POST)) && !isPhaseCompleted
-          ? <TopPostFormContainer ideaId={idea.id} refetchIdea={refetchIdea} />
+          ? <TopPostFormContainer ideaId={ideaId} refetchIdea={refetchIdea} />
           : null}
         <Grid fluid className="background-grey">
           <div className="max-container background-grey">

--- a/assembl/static2/js/app/components/home/themes.jsx
+++ b/assembl/static2/js/app/components/home/themes.jsx
@@ -41,7 +41,7 @@ class Themes extends React.Component {
                         key={index}
                       >
                         <ThematicPreview
-                          imgUrl={idea.imgUrl}
+                          imgUrl={idea.img ? idea.img.externalUrl : ''}
                           numPosts={idea.nbPosts}
                           numContributors={idea.nbContributors}
                           link={

--- a/assembl/static2/js/app/graphql/AllIdeasQuery.graphql
+++ b/assembl/static2/js/app/graphql/AllIdeasQuery.graphql
@@ -7,7 +7,9 @@ query AllIdeasQuery($lang: String!, $identifier: String!) {
       numPosts
       numContributors
       numChildren(identifier: $identifier)
-      imgUrl
+      img {
+        externalUrl
+      }
       order
       parentId
     }

--- a/assembl/static2/js/app/graphql/DebateThematicsQuery.graphql
+++ b/assembl/static2/js/app/graphql/DebateThematicsQuery.graphql
@@ -7,7 +7,9 @@ query DebateThematicsQuery($lang: String!, $identifier: String!) {
       description(lang: $lang)
       numPosts
       numContributors
-      imgUrl
+      img {
+        externalUrl
+      }
     }
   }
 }

--- a/assembl/static2/js/app/graphql/IdeaQuery.graphql
+++ b/assembl/static2/js/app/graphql/IdeaQuery.graphql
@@ -5,7 +5,9 @@ query Idea($lang: String!, $id: ID!) {
       title(lang: $lang)
       synthesisTitle(lang: $lang)
       description(lang: $lang)
-      imgUrl
+      img {
+        externalUrl
+      }
       announcement {
         title(lang: $lang)
         body(lang: $lang)

--- a/assembl/static2/js/app/graphql/RootIdeasQuery.graphql
+++ b/assembl/static2/js/app/graphql/RootIdeasQuery.graphql
@@ -8,7 +8,9 @@ query RootIdeasQuery($lang: String!) {
           description(lang: $lang)
           numPosts
           numContributors
-          imgUrl
+          img {
+            externalUrl
+          }
         }
       }
     }

--- a/assembl/static2/js/app/graphql/ThematicQuery.graphql
+++ b/assembl/static2/js/app/graphql/ThematicQuery.graphql
@@ -2,8 +2,10 @@ query ThematicQuery($lang: String!, $id: ID!) {
   thematic: node(id: $id) {
     ... on Thematic {
       title(lang: $lang)
-      imgMimetype
-      imgUrl
+      img {
+        externalUrl
+        mimeType
+      }
       id
       video(lang: $lang) {
         title

--- a/assembl/static2/js/app/graphql/ThematicsQuery.graphql
+++ b/assembl/static2/js/app/graphql/ThematicsQuery.graphql
@@ -5,8 +5,10 @@ query ThematicsQuery($identifier: String!) {
       localeCode
       value
     }
-    imgMimetype
-    imgUrl
+    img {
+      externalUrl
+      mimeType
+    }
     video {
       titleEntries {
         localeCode

--- a/assembl/static2/js/app/graphql/mutations/createThematic.graphql
+++ b/assembl/static2/js/app/graphql/mutations/createThematic.graphql
@@ -8,7 +8,10 @@ mutation createThematic(
   createThematic(identifier: $identifier, image: $image, titleEntries: $titleEntries, questions: $questions, video: $video) {
     thematic {
       title
-      imgUrl
+      img {
+        externalUrl
+        mimeType
+      }
       video {
         title
         descriptionTop

--- a/assembl/static2/js/app/graphql/mutations/updateThematic.graphql
+++ b/assembl/static2/js/app/graphql/mutations/updateThematic.graphql
@@ -16,7 +16,9 @@ mutation updateThematic(
   ) {
     thematic {
       title
-      imgUrl
+      img {
+        externalUrl
+      }
       video {
         title
         descriptionTop

--- a/assembl/static2/js/app/pages/idea.jsx
+++ b/assembl/static2/js/app/pages/idea.jsx
@@ -153,10 +153,8 @@ class Idea extends React.Component {
     const childProps = {
       identifier: identifier,
       debateData: debateData,
-      idea: {
-        id: id,
-        title: title
-      },
+      ideaId: id,
+      ideaTitle: title,
       ideaWithPostsData: ideaWithPostsData,
       isUserConnected: getConnectedUserId(),
       contentLocaleMapping: contentLocaleMapping,

--- a/assembl/static2/js/app/pages/idea.jsx
+++ b/assembl/static2/js/app/pages/idea.jsx
@@ -61,6 +61,7 @@ class Idea extends React.Component {
     super(props);
     this.getTopPosts = this.getTopPosts.bind(this);
   }
+
   componentWillReceiveProps(nextProps) {
     if (nextProps.ideaWithPostsData.idea !== this.props.ideaWithPostsData.idea) {
       this.updateContentLocaleMappingFromProps(nextProps);
@@ -113,6 +114,7 @@ class Idea extends React.Component {
     }
     return null;
   };
+
   getTopPosts() {
     const { ideaWithPostsData, routerParams, debateData } = this.props;
     if (!ideaWithPostsData.idea) return [];
@@ -124,17 +126,18 @@ class Idea extends React.Component {
     });
     return topPosts;
   }
+
   render() {
-    const { contentLocaleMapping, lang, ideaData, ideaWithPostsData, identifier, debateData } = this.props;
+    const { contentLocaleMapping, debateData, lang, ideaLoading, ideaWithPostsData, identifier } = this.props;
     const refetchIdea = ideaWithPostsData.refetch;
-    if (ideaData.loading) {
+    if (ideaLoading) {
       return (
         <div className="idea">
           <Loader />
         </div>
       );
     }
-    const { idea } = ideaData;
+    const { announcement, id, headerImgUrl, synthesisTitle, title } = this.props;
     const isMultiColumn = ideaWithPostsData.loading ? undefined : ideaWithPostsData.idea.messageColumns.length > 0;
     const messageColumns = ideaWithPostsData.loading
       ? undefined
@@ -148,9 +151,12 @@ class Idea extends React.Component {
         return 0;
       });
     const childProps = {
-      idea: idea,
       identifier: identifier,
       debateData: debateData,
+      idea: {
+        id: id,
+        title: title
+      },
       ideaWithPostsData: ideaWithPostsData,
       isUserConnected: getConnectedUserId(),
       contentLocaleMapping: contentLocaleMapping,
@@ -166,14 +172,14 @@ class Idea extends React.Component {
     const view = isMultiColumn ? <ColumnsView {...childProps} /> : <ThreadView {...childProps} />;
     return (
       <div className="idea">
-        <Header title={idea.title} synthesisTitle={idea.synthesisTitle} imgUrl={idea.imgUrl} identifier={identifier} />
+        <Header title={title} synthesisTitle={synthesisTitle} imgUrl={headerImgUrl} identifier={identifier} />
         <section className="post-section">
           {!ideaWithPostsData.loading &&
-            idea.announcement &&
+            announcement &&
             <Grid fluid className="background-light">
               <div className="max-container">
                 <div className="content-section">
-                  <Announcement ideaWithPostsData={ideaWithPostsData} announcementContent={idea.announcement} />
+                  <Announcement ideaWithPostsData={ideaWithPostsData} announcementContent={announcement} />
                 </div>
               </div>
             </Grid>}
@@ -205,9 +211,31 @@ const mapDispatchToProps = (dispatch) => {
 export default compose(
   connect(mapStateToProps, mapDispatchToProps),
   graphql(IdeaWithPostsQuery, { name: 'ideaWithPostsData' }),
-  graphql(IdeaQuery, { name: 'ideaData', options: { notifyOnNetworkStatusChange: true } })
-  // ideaData.loading stays to true when switching interface language (IdeaQuery is using lang variable)
-  // This is an issue in apollo-client, adding notifyOnNetworkStatusChange: true is a workaround,
-  // downgrading to apollo-client 1.8.1 should works too.
-  // See https://github.com/apollographql/apollo-client/issues/1186#issuecomment-327161526
+  graphql(IdeaQuery, {
+    options: { notifyOnNetworkStatusChange: true },
+    // ideaData.loading stays to true when switching interface language (IdeaQuery is using lang variable)
+    // This is an issue in apollo-client, adding notifyOnNetworkStatusChange: true is a workaround,
+    // downgrading to apollo-client 1.8.1 should works too.
+    // See https://github.com/apollographql/apollo-client/issues/1186#issuecomment-327161526
+    props: ({ data }) => {
+      if (data.loading) {
+        return {
+          ideaLoading: true
+        };
+      }
+      if (data.error) {
+        return {
+          ideaHasErrors: true
+        };
+      }
+
+      return {
+        announcement: data.idea.announcement,
+        id: data.idea.id,
+        title: data.idea.title,
+        synthesisTitle: data.idea.synthesisTitle,
+        headerImgUrl: data.idea.img ? data.idea.img.externalUrl : ''
+      };
+    }
+  })
 )(Idea);

--- a/assembl/static2/js/app/pages/survey.jsx
+++ b/assembl/static2/js/app/pages/survey.jsx
@@ -1,10 +1,11 @@
+// @flow
 import React from 'react';
-import { PropTypes } from 'prop-types';
 import { connect } from 'react-redux';
 import { compose, graphql } from 'react-apollo';
 import { browserHistory } from 'react-router';
 import { Translate } from 'react-redux-i18n';
 import { Grid, Button } from 'react-bootstrap';
+import type { Map } from 'immutable';
 
 import { updateContentLocale } from '../actions/contentLocaleActions';
 import withLoadingIndicator from '../components/common/withLoadingIndicator';
@@ -17,16 +18,58 @@ import { getIfPhaseCompletedByIdentifier } from '../utils/timeline';
 import ThematicQuery from '../graphql/ThematicQuery.graphql';
 import { displayAlert } from '../utils/utilityManager';
 
-class Survey extends React.Component {
+type PostNode = {
+  node: {
+    id: string,
+    originalLocale: string
+  }
+};
+
+type QuestionType = {
+  id: string,
+  posts: {
+    edges: Array<PostNode>
+  },
+  title: string
+};
+
+type SurveyProps = {
+  debate: {
+    debateData: {
+      timeline: string
+    }
+  },
+  defaultContentLocaleMapping: Map,
+  hasErrors: boolean,
+  imgUrl: string,
+  loading: boolean,
+  media: Object, // TODO: we should add a type for media/video and use it everywhere
+  questions: Array<QuestionType>,
+  refetchThematic: Function,
+  title: string,
+  updateContentLocaleMapping: Function
+};
+
+type SurveyState = {
+  isScroll: boolean,
+  moreProposals: boolean,
+  questionIndex: number | null,
+  showModal: boolean
+};
+
+class Survey extends React.Component<*, SurveyProps, SurveyState> {
+  props: SurveyProps;
+  state: SurveyState;
+  unlisten: Function;
+
   constructor(props) {
     super(props);
     this.state = {
+      isScroll: false,
       moreProposals: false,
-      showModal: false
+      showModal: false,
+      questionIndex: null
     };
-    this.showMoreProposals = this.showMoreProposals.bind(this);
-    this.getIfProposals = this.getIfProposals.bind(this);
-    this.scrollToQuestion = this.scrollToQuestion.bind(this);
   }
 
   componentWillMount() {
@@ -40,7 +83,7 @@ class Survey extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.data.thematic !== this.props.data.thematic) {
+    if (nextProps.questions !== this.props.questions) {
       this.updateContentLocaleMappingFromProps(nextProps);
     }
   }
@@ -50,52 +93,51 @@ class Survey extends React.Component {
   }
 
   updateContentLocaleMappingFromProps(props) {
-    const { data, defaultContentLocaleMapping, updateContentLocaleMapping } = props;
-    if (!data.loading) {
-      const contentLocaleMappingData = {};
-      const questions = data.thematic.questions;
-      questions.forEach((question) => {
-        question.posts.edges.forEach((edge) => {
-          const post = edge.node;
-          const { id, originalLocale } = post;
-          const contentLocale = defaultContentLocaleMapping.get(originalLocale, originalLocale);
-          contentLocaleMappingData[id] = {
-            contentLocale: contentLocale,
-            originalLocale: originalLocale
-          };
-        });
+    const { defaultContentLocaleMapping, updateContentLocaleMapping, questions } = props;
+    const contentLocaleMappingData = {};
+    questions.forEach((question) => {
+      question.posts.edges.forEach((edge) => {
+        const post = edge.node;
+        const { id, originalLocale } = post;
+        const contentLocale = defaultContentLocaleMapping.get(originalLocale, originalLocale);
+        contentLocaleMappingData[id] = {
+          contentLocale: contentLocale,
+          originalLocale: originalLocale
+        };
       });
+    });
 
-      updateContentLocaleMapping(contentLocaleMappingData);
-    }
+    updateContentLocaleMapping(contentLocaleMappingData);
   }
 
-  getIfProposals(questions) {
-    this.questions = questions;
-    if (!this.questions) return false;
+  getIfProposals = (questions) => {
+    if (!questions) return false;
     let isProposals = false;
-    this.questions.forEach((question) => {
+    questions.forEach((question) => {
       if (question.posts.edges.length > 0) isProposals = true;
     });
     return isProposals;
-  }
-  showMoreProposals() {
+  };
+
+  showMoreProposals = () => {
     this.setState({
       moreProposals: true
     });
-  }
-  scrollToQuestion(isScroll, questionIndex) {
+  };
+
+  scrollToQuestion = (isScroll, questionIndex) => {
     this.setState({
       isScroll: isScroll,
       questionIndex: questionIndex
     });
-  }
+  };
+
   render() {
-    if (this.props.data.error) {
+    if (this.props.hasError) {
       displayAlert('danger', 'An error occured, please reload the page');
       return null;
     }
-    const { thematic: { imgUrl, questions, title, video: media } } = this.props.data;
+    const { imgUrl, media, questions, refetchThematic, title } = this.props;
     const { debateData } = this.props.debate;
     const isPhaseCompleted = getIfPhaseCompletedByIdentifier(debateData.timeline, 'survey');
     return (
@@ -113,7 +155,7 @@ class Survey extends React.Component {
                     key={index}
                     questionId={question.id}
                     scrollToQuestion={this.scrollToQuestion}
-                    refetchTheme={this.props.data.refetch}
+                    refetchTheme={refetchThematic}
                   />
                 );
               })}
@@ -145,7 +187,7 @@ class Survey extends React.Component {
                             moreProposals={this.state.moreProposals}
                             questionIndex={index + 1}
                             key={index}
-                            refetchTheme={this.props.data.refetch}
+                            refetchTheme={refetchThematic}
                           />
                         );
                       })}
@@ -166,14 +208,6 @@ class Survey extends React.Component {
   }
 }
 
-Survey.propTypes = {
-  data: PropTypes.shape({
-    loading: PropTypes.bool.isRequired,
-    error: PropTypes.object,
-    thematic: PropTypes.Array
-  }).isRequired
-};
-
 const mapStateToProps = (state) => {
   return {
     debate: state.debate,
@@ -192,6 +226,32 @@ const mapDispatchToProps = (dispatch) => {
 
 export default compose(
   connect(mapStateToProps, mapDispatchToProps),
-  graphql(ThematicQuery),
+  graphql(ThematicQuery, {
+    props: ({ data }) => {
+      if (data.loading) {
+        return {
+          loading: true
+        };
+      }
+
+      if (data.error) {
+        return {
+          hasErrors: true
+        };
+      }
+
+      const { thematic: { img, questions, refetch, title, video: media } } = data;
+
+      return {
+        hasErrors: false,
+        imgUrl: img.externalUrl,
+        loading: false,
+        media: media,
+        questions: questions,
+        refetchThematic: refetch,
+        title: title
+      };
+    }
+  }),
   withLoadingIndicator({ color: 'black' })
 )(Survey);

--- a/assembl/static2/js/app/pages/survey.jsx
+++ b/assembl/static2/js/app/pages/survey.jsx
@@ -133,7 +133,7 @@ class Survey extends React.Component<*, SurveyProps, SurveyState> {
   };
 
   render() {
-    if (this.props.hasError) {
+    if (this.props.hasErrors) {
       displayAlert('danger', 'An error occured, please reload the page');
       return null;
     }

--- a/assembl/static2/js/app/reducers/adminReducer.js
+++ b/assembl/static2/js/app/reducers/adminReducer.js
@@ -53,7 +53,9 @@ export const thematicsById = (state = Map(), action) => {
   case 'CREATE_NEW_THEMATIC': {
     const emptyThematic = Map({
       toDelete: false,
-      imgUrl: null,
+      img: Map({
+        externalUrl: ''
+      }),
       isNew: true,
       questions: List(),
       titleEntries: List(),
@@ -80,7 +82,7 @@ export const thematicsById = (state = Map(), action) => {
       return titleEntries.setIn([titleEntryIndex, 'value'], action.value);
     });
   case 'UPDATE_THEMATIC_IMG_URL':
-    return state.setIn([action.id, 'imgUrl'], action.value);
+    return state.setIn([action.id, 'img', 'externalUrl'], action.value);
   case 'UPDATE_THEMATIC_TITLE': {
     const entries = state.getIn([action.id, 'titleEntries']);
     const index = entries.findIndex((e) => {

--- a/assembl/static2/js/app/reducers/adminReducer.js
+++ b/assembl/static2/js/app/reducers/adminReducer.js
@@ -174,7 +174,9 @@ export const languagePreferences = (state = List(), action) => {
     return state;
   case 'REMOVE_LANGUAGE_PREFERENCE':
     if (hasLocale(action.locale, state)) {
-      const i = state.findIndex((a) => { return a === action.locale; });
+      const i = state.findIndex((a) => {
+        return a === action.locale;
+      });
       return state.delete(i);
     }
     return state;
@@ -191,7 +193,6 @@ export const discussionLanguagePreferencesHasChanged = (state = false, action) =
     return state;
   }
 };
-
 
 export default combineReducers({
   selectedLocale: selectedLocale,

--- a/assembl/static2/tests/unit/reducers/adminReducer.spec.js
+++ b/assembl/static2/tests/unit/reducers/adminReducer.spec.js
@@ -128,7 +128,9 @@ describe('Admin reducers', () => {
           id: '-278290',
           isNew: true,
           toDelete: false,
-          imgUrl: null,
+          img: {
+            externalUrl: ''
+          },
           questions: [],
           titleEntries: [],
           video: null
@@ -167,6 +169,26 @@ describe('Admin reducers', () => {
               titleEntries: [{ localeCode: 'en', value: 'How?' }, { localeCode: 'fr', value: 'Comment?' }]
             }
           ]
+        }
+      });
+      const newState = thematicsById(oldState, action);
+      expect(newState).toEqual(expected);
+    });
+
+    it('should handle UPDATE_THEMATIC_IMG_URL action type', () => {
+      const action = { id: '1', value: 'http://example.com/toto.png', type: 'UPDATE_THEMATIC_IMG_URL' };
+      const oldState = fromJS({
+        1: {
+          img: {
+            externalUrl: ''
+          }
+        }
+      });
+      const expected = fromJS({
+        1: {
+          img: {
+            externalUrl: 'http://example.com/toto.png'
+          }
         }
       });
       const newState = thematicsById(oldState, action);

--- a/assembl/tests/views_tests/test_graphql.py
+++ b/assembl/tests/views_tests/test_graphql.py
@@ -313,8 +313,10 @@ mutation myFirstMutation($img:String) {
             id,
             title(lang:"fr"),
             identifier,
-            imgUrl
-            imgMimetype
+            img {
+                externalUrl
+                mimeType
+            }
         }
     }
 }
@@ -333,8 +335,8 @@ mutation myFirstMutation($img:String) {
 #                u'imgUrl': u'http://localhost:6543/data/Discussion/8/documents/1/data'
 #    }}}
 #    just assert we have the ends correct:
-    assert res.data['createThematic']['thematic']['imgUrl'].endswith('/documents/1/data')
-    assert res.data['createThematic']['thematic']['imgMimetype'] == 'image/png'
+    assert res.data['createThematic']['thematic']['img']['externalUrl'].endswith('/documents/1/data')
+    assert res.data['createThematic']['thematic']['img']['mimeType'] == 'image/png'
     thematic_id = res.data['createThematic']['thematic']['id']
 
     # and update it to change the image
@@ -359,13 +361,17 @@ mutation myFirstMutation($img:String, $thematicId:ID!) {
         thematic {
             title(lang:"fr"),
             identifier,
-            imgUrl
+            img {
+                externalUrl
+                mimeType
+            }
         }
     }
 }
 """, context_value=graphql_request, variable_values={"thematicId": thematic_id,
                                                      "img": u"variables.img"})
-    assert res.data['updateThematic']['thematic']['imgUrl'].endswith('/documents/2/data')
+    assert res.data['updateThematic']['thematic']['img']['externalUrl'].endswith('/documents/2/data')
+    assert res.data['updateThematic']['thematic']['img']['mimeType'] == 'image/png'
 
 
 def test_mutation_create_thematic_multilang_explicit_en(graphql_request):

--- a/assembl/tests/views_tests/test_graphql_ideas.py
+++ b/assembl/tests/views_tests/test_graphql_ideas.py
@@ -203,7 +203,9 @@ query Idea($lang: String!, $id: ID!) {
       title(lang: $lang)
       synthesisTitle(lang: $lang)
       description(lang: $lang)
-      imgUrl
+      img {
+        externalUrl
+      }
     }
   }
 }
@@ -216,8 +218,9 @@ query Idea($lang: String!, $id: ID!) {
             u'title': u'Understanding the dynamics and issues',
             u'synthesisTitle': u'What you need to know',
             u'description': u'',
-            u'imgUrl': None
-    }}
+            u"img": None
+        }
+    }
 
 
 def test_extracts_on_post(admin_user, graphql_request, discussion, top_post_in_thread_phase):


### PR DESCRIPTION
See comments on #207 for the reason of this PR.
We no longer have `imgUrl` on idea/thematic schemas, we have to use `img: { externalUrl, mimeType }` instead. I also replaced proptypes by flow types on `Survey` component and added the possibily to use `withLoadingIndicator` HOC with `loading` prop directly instead of `data.loading` (in case we use the `props` option on `graphql()`.

**Warning: Please do not merge this PR before the next production deployment**