### PR TITLE
Transform url into links an youtube videos in posts body

### DIFF
--- a/assembl/static2/.flowconfig
+++ b/assembl/static2/.flowconfig
@@ -7,6 +7,7 @@
 [include]
 
 [libs]
+flow/
 
 [lints]
 

--- a/assembl/static2/flow/linkify.js
+++ b/assembl/static2/flow/linkify.js
@@ -1,4 +1,4 @@
 // @flow
-declare module 'flow' {
+declare module 'linkify' {
   declare module.exports: any;
 }

--- a/assembl/static2/flow/linkify.js
+++ b/assembl/static2/flow/linkify.js
@@ -1,0 +1,4 @@
+// @flow
+declare module 'flow' {
+  declare module.exports: any;
+}

--- a/assembl/static2/js/app/components/debate/survey/post.jsx
+++ b/assembl/static2/js/app/components/debate/survey/post.jsx
@@ -19,6 +19,7 @@ import StatisticsDoughnut from '../common/statisticsDoughnut';
 import PostTranslate from '../common/translations/postTranslate';
 import { EXTRA_SMALL_SCREEN_WIDTH } from '../../../constants';
 import withLoadingIndicator from '../../common/withLoadingIndicator';
+import { transformLinksInHtml } from '../../../utils/linkify';
 
 class Post extends React.Component {
   constructor(props) {
@@ -155,7 +156,7 @@ class Post extends React.Component {
           />
           <div
             className={`body ${post.bodyMimeType === 'text/plain' ? 'pre-wrap' : ''}`}
-            dangerouslySetInnerHTML={{ __html: body }}
+            dangerouslySetInnerHTML={{ __html: transformLinksInHtml(body) }}
           />
           <div className="sentiments">
             <div className="sentiment-label">

--- a/assembl/static2/js/app/components/debate/thread/post.jsx
+++ b/assembl/static2/js/app/components/debate/thread/post.jsx
@@ -16,6 +16,7 @@ import withLoadingIndicator from '../../../components/common/withLoadingIndicato
 import { DeletedPublicationStates, PublicationStates } from '../../../constants';
 import Nuggets from './nuggets';
 import hashLinkScroll from '../../../utils/hashLinkScroll';
+import { transformLinksInHtml } from '../../../utils/linkify';
 
 export const PostFolded = ({ nbPosts }) => {
   return <Translate value="debate.thread.foldedPostLink" count={nbPosts} />;
@@ -256,7 +257,7 @@ export class EmptyPost extends React.PureComponent {
               </h3>
               <div
                 className={`body ${bodyMimeType === 'text/plain' ? 'pre-wrap' : ''}`}
-                dangerouslySetInnerHTML={{ __html: body }}
+                dangerouslySetInnerHTML={{ __html: transformLinksInHtml(body) }}
                 ref={this.recomputeTreeHeightOnImagesLoad}
               />
 

--- a/assembl/static2/js/app/utils/linkify.js
+++ b/assembl/static2/js/app/utils/linkify.js
@@ -1,0 +1,39 @@
+// @flow
+import linkifyHtml from 'linkifyjs/html';
+import * as linkify from 'linkifyjs';
+
+export function transformLinksInHtml(html: string): string {
+  const linksToReplace = linkify
+    .find(html)
+    .map((link) => {
+      const url = link.href;
+      if (url.startsWith('https://www.youtube.com') || url.startsWith('https://youtube.com')) {
+        const re = /(.*watch\?v=(.*?))([\s<,;].*)/;
+        const result = url.match(re);
+        if (result) {
+          const videoUrl = result[1];
+          const videoId = result[2];
+          const rest = result[3];
+          const embedUrl = `https://www.youtube.com/embed/${videoId}`;
+          const embeddedIFrame = `<div><iframe title="" src="${embedUrl}" frameborder="0" allowfullscreen></iframe></div>`;
+          return {
+            origin: url,
+            dest: videoUrl + embeddedIFrame + rest
+          };
+        }
+      }
+
+      return null;
+    })
+    // remove null values
+    .filter((link) => {
+      return link;
+    });
+
+  let transformedHtml = html;
+  linksToReplace.forEach((linkToReplace) => {
+    transformedHtml = html.replace(linkToReplace.origin, linkToReplace.dest);
+  });
+
+  return linkifyHtml(transformedHtml);
+}

--- a/assembl/static2/js/app/utils/linkify.js
+++ b/assembl/static2/js/app/utils/linkify.js
@@ -2,36 +2,52 @@
 import linkifyHtml from 'linkifyjs/html';
 import * as linkify from 'linkifyjs';
 
+type LinkToReplace = {
+  dest: string,
+  origin: string
+};
+
+type LinkifyLink = {
+  href: string,
+  type: string,
+  value: string
+};
+
 export function transformLinksInHtml(html: string): string {
-  const linksToReplace = linkify
+  const linksToReplace: Array<LinkToReplace> = linkify
     .find(html)
-    .map((link) => {
+    .map((link: LinkifyLink) => {
       const url = link.href;
-      if (url.startsWith('https://www.youtube.com') || url.startsWith('https://youtube.com')) {
-        const re = /(.*watch\?v=(.*?))([\s<,;].*)/;
-        const result = url.match(re);
-        if (result) {
-          const videoUrl = result[1];
-          const videoId = result[2];
-          const rest = result[3];
-          const embedUrl = `https://www.youtube.com/embed/${videoId}`;
-          const embeddedIFrame = `<div><iframe title="" src="${embedUrl}" frameborder="0" allowfullscreen></iframe></div>`;
-          return {
-            origin: url,
-            dest: videoUrl + embeddedIFrame + rest
-          };
-        }
+      // youtu.be
+      const dotBeRe = /(https?:\/\/\w*\.?youtu.be\/(.*?))([\s<,;].*)/;
+      let result = url.match(dotBeRe);
+      if (!result) {
+        // youtube.com
+        const dotComRe = /(https?:\/\/\w*\.?youtube\.com\/watch\?v=(.*?))([\s<,;].*)/;
+        result = url.match(dotComRe);
+      }
+
+      if (result) {
+        const videoUrl = result[1];
+        const videoId = result[2];
+        const rest = result[3];
+        const embedUrl = `https://www.youtube.com/embed/${videoId}`;
+        const embeddedIFrame = `<div><iframe title="" src="${embedUrl}" frameborder="0" allowfullscreen></iframe></div>`;
+        return {
+          origin: url,
+          dest: videoUrl + embeddedIFrame + rest
+        };
       }
 
       return null;
     })
     // remove null values
-    .filter((link) => {
+    .filter((link: LinkToReplace | null) => {
       return link;
     });
 
   let transformedHtml = html;
-  linksToReplace.forEach((linkToReplace) => {
+  linksToReplace.forEach((linkToReplace: LinkToReplace) => {
     transformedHtml = html.replace(linkToReplace.origin, linkToReplace.dest);
   });
 

--- a/assembl/static2/package.json
+++ b/assembl/static2/package.json
@@ -82,6 +82,7 @@
     "immutable": "~3.7.4",
     "isomorphic-fetch": "^2.2.1",
     "json-loader": "^0.5.4",
+    "linkifyjs": "^2.1.5",
     "lodash": "^4.17.4",
     "moment": "^2.18.1",
     "piwik-react-router": "assembl/piwik-react-router#skip_piwik_initialization",

--- a/assembl/static2/tests/unit/utils/linkify.spec.js
+++ b/assembl/static2/tests/unit/utils/linkify.spec.js
@@ -10,12 +10,32 @@ describe('transformLinksInHtml function', () => {
     expect(actual).toEqual(expected);
   });
 
-  it('should turn youtube links into embedded videos', () => {
+  it('should turn www.youtube.com links into embedded videos', () => {
     const input = '<p>Foobar: https://www.youtube.com/watch?v=foobar</p>';
     const actual = transformLinksInHtml(input);
     const expected =
       '<p>Foobar: <a href="https://www.youtube.com/watch?v=foobar" class="linkified"' +
       ' target="_blank">https://www.youtube.com/watch?v=foobar</a>' +
+      '<div><iframe title="" src="https://www.youtube.com/embed/foobar" frameborder="0" allowfullscreen=""></iframe></div></p>';
+    expect(actual).toEqual(expected);
+  });
+
+  it('should turn youtube.com links into embedded videos', () => {
+    const input = '<p>Foobar: https://youtube.com/watch?v=foobar</p>';
+    const actual = transformLinksInHtml(input);
+    const expected =
+      '<p>Foobar: <a href="https://youtube.com/watch?v=foobar" class="linkified"' +
+      ' target="_blank">https://youtube.com/watch?v=foobar</a>' +
+      '<div><iframe title="" src="https://www.youtube.com/embed/foobar" frameborder="0" allowfullscreen=""></iframe></div></p>';
+    expect(actual).toEqual(expected);
+  });
+
+  it('should turn youtu.be links into embedded videos', () => {
+    const input = '<p>Foobar: https://youtu.be/foobar</p>';
+    const actual = transformLinksInHtml(input);
+    const expected =
+      '<p>Foobar: <a href="https://youtu.be/foobar" class="linkified"' +
+      ' target="_blank">https://youtu.be/foobar</a>' +
       '<div><iframe title="" src="https://www.youtube.com/embed/foobar" frameborder="0" allowfullscreen=""></iframe></div></p>';
     expect(actual).toEqual(expected);
   });

--- a/assembl/static2/tests/unit/utils/linkify.spec.js
+++ b/assembl/static2/tests/unit/utils/linkify.spec.js
@@ -1,0 +1,22 @@
+import { transformLinksInHtml } from '../../../js/app/utils/linkify';
+
+describe('transformLinksInHtml function', () => {
+  it('should transform links in an html string', () => {
+    const input = '<p>Foobar http://www.example.com/ and text after</p>';
+    const actual = transformLinksInHtml(input);
+    const expected =
+      '<p>Foobar <a href="http://www.example.com/" class="linkified" ' +
+      'target="_blank">http://www.example.com/</a> and text after</p>';
+    expect(actual).toEqual(expected);
+  });
+
+  it('should turn youtube links into embedded videos', () => {
+    const input = '<p>Foobar: https://www.youtube.com/watch?v=foobar</p>';
+    const actual = transformLinksInHtml(input);
+    const expected =
+      '<p>Foobar: <a href="https://www.youtube.com/watch?v=foobar" class="linkified"' +
+      ' target="_blank">https://www.youtube.com/watch?v=foobar</a>' +
+      '<div><iframe title="" src="https://www.youtube.com/embed/foobar" frameborder="0" allowfullscreen=""></iframe></div></p>';
+    expect(actual).toEqual(expected);
+  });
+});

--- a/assembl/static2/yarn.lock
+++ b/assembl/static2/yarn.lock
@@ -2621,6 +2621,18 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
+fbjs@^0.8.16:
+  version "0.8.16"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.9"
+
 fbjs@^0.8.7, fbjs@^0.8.9:
   version "0.8.14"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.14.tgz#d1dbe2be254c35a91e09f31f9cd50a40b2a0ed1c"
@@ -3816,6 +3828,10 @@ jest@^20.0.4:
   dependencies:
     jest-cli "^20.0.4"
 
+jquery@>=1.9.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.2.1.tgz#5c4d9de652af6cd0a770154a631bba12b015c787"
+
 js-base64@^2.1.8, js-base64@^2.1.9:
   version "2.1.9"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.1.9.tgz#f0e80ae039a4bd654b5f281fc93f04a914a7fcce"
@@ -3997,6 +4013,14 @@ levn@^0.3.0, levn@~0.3.0:
   dependencies:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
+
+linkifyjs@^2.1.5:
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/linkifyjs/-/linkifyjs-2.1.5.tgz#effc9f01e4aeafbbdbef21a45feab38b9516f93e"
+  optionalDependencies:
+    jquery ">=1.9.0"
+    react ">=0.14.0"
+    react-dom ">=0.14.0"
 
 load-json-file@^1.0.0:
   version "1.1.0"
@@ -5250,6 +5274,14 @@ prop-types@15.x, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, pr
     fbjs "^0.8.9"
     loose-envify "^1.3.1"
 
+prop-types@^15.6.0:
+  version "15.6.0"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 proxy-addr@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-1.1.4.tgz#27e545f6960a44a627d9b44467e35c1b6b4ce2f3"
@@ -5485,6 +5517,15 @@ react-deep-force-update@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/react-deep-force-update/-/react-deep-force-update-2.0.1.tgz#4f7f6c12c3e7de42f345992a3c518236fa1ecad3"
 
+react-dom@>=0.14.0:
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.0.0.tgz#9cc3079c3dcd70d4c6e01b84aab2a7e34c303f58"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+
 react-dom@^15.4.1:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.6.1.tgz#2cb0ed4191038e53c209eb3a79a23e2a4cf99470"
@@ -5631,6 +5672,15 @@ react@15.5.4:
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
     prop-types "^15.5.7"
+
+react@>=0.14.0:
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.0.0.tgz#ce7df8f1941b036f02b2cca9dbd0cb1f0e855e2d"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
 
 react@^15.4.1:
   version "15.6.1"


### PR DESCRIPTION
for youtube videos it is a quickfix that should probably be replaced by something more generic. I took a look at https://www.npmjs.com/package/oembed-all but it does not seem easy to integrate in our use case (we have raw html as input). 
I think that when we will add links management to the rich text editor, we will not need this anymore as we should probably create the good HTML markup from draft-js entities.