### PR TITLE
piwik tracking: measure more precisely the time spent by visitors on …

### DIFF
--- a/production.ini
+++ b/production.ini
@@ -369,6 +369,7 @@ web_analytics_piwik_script = <!-- Piwik -->
 
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
+      _paq.push(['enableHeartBeatTimer', 10]);
       (function() {
         var u="//%(piwik_host)s/";
         _paq.push(['setTrackerUrl', u+'piwik.php']);


### PR DESCRIPTION
…the last page of their visit (including single page visits). See https://developer.piwik.org/guides/tracking-javascript-guide#accurately-measure-the-time-spent-on-each-page

This is for DEVAS-973