### PR TITLE
Fix v1 synthesis second try

### DIFF
--- a/assembl/static/js/app/models/langstring.js
+++ b/assembl/static/js/app/models/langstring.js
@@ -400,7 +400,11 @@ var LangString = Base.Model.extend({
    * @function app.models.langstrings.LangString.bestValue
    */
   bestValue: function(langPrefs) {
-    return this.best(langPrefs).get("value");
+    var bestLangString = this.best(langPrefs);
+    if (!bestLangString){
+      throw new Error("Malformed langstring: it seems empty but shouldn't.");
+    }
+    return bestLangString.get("value"); //
   },
   /**
    * Determines the best value, favouring interface over user prefs.

--- a/assembl/static/js/app/models/langstring.js
+++ b/assembl/static/js/app/models/langstring.js
@@ -404,7 +404,7 @@ var LangString = Base.Model.extend({
     if (!bestLangString){
       throw new Error("Malformed langstring: it seems empty but shouldn't.");
     }
-    return bestLangString.get("value"); //
+    return bestLangString.get("value");
   },
   /**
    * Determines the best value, favouring interface over user prefs.

--- a/assembl/static/js/app/views/ideaInSynthesis.js
+++ b/assembl/static/js/app/views/ideaInSynthesis.js
@@ -155,10 +155,7 @@ var IdeaInSynthesisView = Marionette.LayoutView.extend({
 
       return {
         id: this.model.getId(),
-        editing: this.editing,
-        longTitle: this.model.getLongTitleDisplayText(this.translationData),
         authors: _.uniq(this.authors),
-        subject: longTitle ? longTitle.bestValue(this.translationData) : '',
         canEdit: this.canEdit(),
         isPrimaryNavigationPanel: this.getPanel().isPrimaryNavigationPanel(),
         ctxNumMessages: i18n.sprintf(i18n.ngettext(

--- a/assembl/static/js/app/views/ideaInSynthesis.js
+++ b/assembl/static/js/app/views/ideaInSynthesis.js
@@ -92,15 +92,22 @@ var IdeaInSynthesisView = Marionette.LayoutView.extend({
           that.render();
         }
       }
+
+      Promise.join(collectionManager.getUserLanguagePreferencesPromise(Ctx),
+        function(translationData){
+          console.log("received translationData! translationData:", translationData);
+          that.translationData = translationData;
+          that.render();
+        }
+      );
+
       // idea is either a tombstone or from a different collection; get the original
       Promise.join(
           collectionManager.getAllIdeasCollectionPromise(),
-          collectionManager.getUserLanguagePreferencesPromise(Ctx),
-          function(allIdeasCollection, translationData) {
+          function(allIdeasCollection) {
         if (!that.isViewDestroyed()) {
           var idea = that.model,
           original_idea = undefined;
-          that.translationData = translationData;
           if (that.synthesis.get('is_next_synthesis')) {
             original_idea = allIdeasCollection.get(that.model.id);
           }
@@ -196,6 +203,10 @@ var IdeaInSynthesisView = Marionette.LayoutView.extend({
    * renders the ckEditor if there is one editable field
    */
   renderCKEditorIdea: function() {
+    if (!this.translationData){
+      return;
+    }
+
     var model = this.model.getLongTitleDisplayText(this.translationData);
 
     var ideaSynthesis = new CKEditorLSField({
@@ -215,6 +226,7 @@ var IdeaInSynthesisView = Marionette.LayoutView.extend({
   /**
    * renders the reply interface
    */
+  /* This method has been commented out because "Currently disabled, but will be revived at some point"
   renderReplyView: function() {
       var that = this,
       partialCtx = "synthesis-idea-" + this.model.getId(),
@@ -245,6 +257,7 @@ var IdeaInSynthesisView = Marionette.LayoutView.extend({
 
       this.$('.synthesisIdea-replybox').html(replyView.render().el);
     },
+  */
 
   /**
    *  Focus on the reply box, and open it if closed

--- a/assembl/static/js/app/views/ideaInSynthesis.js
+++ b/assembl/static/js/app/views/ideaInSynthesis.js
@@ -95,7 +95,6 @@ var IdeaInSynthesisView = Marionette.LayoutView.extend({
 
       Promise.join(collectionManager.getUserLanguagePreferencesPromise(Ctx),
         function(translationData){
-          console.log("received translationData! translationData:", translationData);
           that.translationData = translationData;
           that.render();
         }

--- a/assembl/static/js/app/views/messageSend.js
+++ b/assembl/static/js/app/views/messageSend.js
@@ -168,6 +168,7 @@ var messageSendView = Marionette.LayoutView.extend({
     }
     var show_cancel_button = ('show_cancel_button' in this.options) ? this.options.show_cancel_button : false;
     var reply_idea = ('reply_idea' in this.options) ? this.options.reply_idea : null;
+    var reply_idea_title = reply_idea ? reply_idea.getShortTitleDisplayText(this.translationData) : null;
     var reply_message_id = ('reply_message_id' in this.options) ? this.options.reply_message_id : null;
     var show_target_context_with_choice = ('show_target_context_with_choice' in this.options) ? this.options.show_target_context_with_choice : null;
     var message_send_title = this.options.message_send_title;
@@ -193,7 +194,7 @@ var messageSendView = Marionette.LayoutView.extend({
       msg_in_progress_body: this.options.msg_in_progress_body,
       msg_in_progress_title: this.options.msg_in_progress_title,
       reply_idea: reply_idea,
-      reply_idea_title: reply_idea.getShortTitleDisplayText(this.translationData),
+      reply_idea_title: reply_idea_title,
       show_cancel_button: show_cancel_button,
       reply_message_id: reply_message_id,
       show_target_context_with_choice: show_target_context_with_choice,

--- a/assembl/static/js/app/views/messageSend.js
+++ b/assembl/static/js/app/views/messageSend.js
@@ -189,7 +189,6 @@ var messageSendView = Marionette.LayoutView.extend({
       allow_setting_subject: this.options.allow_setting_subject || this.options.allow_setting_subject,
       cancel_button_label: this.options.cancel_button_label ? this.options.cancel_button_label : i18n.gettext('Cancel'),
       send_button_label: this.options.send_button_label ? this.options.send_button_label : i18n.gettext('Send'),
-      subject_label: this.options.subject_label ? this.options.subject_label : i18n.gettext('Subject:'),
       canPost: canPost,
       msg_in_progress_body: this.options.msg_in_progress_body,
       msg_in_progress_title: this.options.msg_in_progress_title,
@@ -197,8 +196,7 @@ var messageSendView = Marionette.LayoutView.extend({
       reply_idea_title: reply_idea_title,
       show_cancel_button: show_cancel_button,
       reply_message_id: reply_message_id,
-      show_target_context_with_choice: show_target_context_with_choice,
-      enable_button: this.options.enable_button
+      show_target_context_with_choice: show_target_context_with_choice
     }
   },
 


### PR DESCRIPTION
This fixes some v1 frontend errors when trying to read a synthesis. When trying to read a badly formed synthesis which has empty langstrings, there are still other errors (which is "normal" up to a certain point).