### PR TITLE
Update eslint and change arrow-body-style rule

### DIFF
--- a/assembl/static2/.eslintrc.json
+++ b/assembl/static2/.eslintrc.json
@@ -31,7 +31,7 @@
     "no-mixed-operators": 0,
     "no-console": 2,
     "func-names": ["warn", "never"],
-    "arrow-body-style": ["error", "always"],
+    "arrow-body-style": ["error", "as-needed"],
     "comma-dangle": ["warn", "never"],
     "indent": ["warn", 2],
     "eol-last": ["error", "never"],

--- a/assembl/static2/.eslintrc.json
+++ b/assembl/static2/.eslintrc.json
@@ -36,6 +36,7 @@
     "indent": ["warn", 2],
     "eol-last": ["error", "never"],
     "linebreak-style": ["warn", "unix"],
+    "lines-between-class-members": 2,
     "quotes": ["error", "single"],
     "semi": ["error", "always"],
     "object-shorthand": ["error", "never"]

--- a/assembl/static2/js/app/actions/adminActions/adminSections.js
+++ b/assembl/static2/js/app/actions/adminActions/adminSections.js
@@ -1,46 +1,37 @@
 // @flow
 import * as actionTypes from '../actionTypes';
 
-export const updateSections = (sections: actionTypes.SectionsArray): actionTypes.UpdateSections => {
-  return {
-    sections: sections,
-    type: actionTypes.UPDATE_SECTIONS
-  };
-};
+export const updateSections = (sections: actionTypes.SectionsArray): actionTypes.UpdateSections => ({
+  sections: sections,
+  type: actionTypes.UPDATE_SECTIONS
+});
 
-export const updateSectionTitle = (id: string, locale: string, value: string): actionTypes.UpdateSectionTitle => {
-  return {
-    id: id,
-    locale: locale,
-    value: value,
-    type: actionTypes.UPDATE_SECTION_TITLE
-  };
-};
+export const updateSectionTitle = (id: string, locale: string, value: string): actionTypes.UpdateSectionTitle => ({
+  id: id,
+  locale: locale,
+  value: value,
+  type: actionTypes.UPDATE_SECTION_TITLE
+});
 
-export const updateSectionUrl = (id: string, value: string): actionTypes.UpdateSectionUrl => {
-  return {
-    id: id,
-    value: value,
-    type: actionTypes.UPDATE_SECTION_URL
-  };
-};
+export const updateSectionUrl = (id: string, value: string): actionTypes.UpdateSectionUrl => ({
+  id: id,
+  value: value,
+  type: actionTypes.UPDATE_SECTION_URL
+});
 
-export const toggleExternalPage = (id: string): actionTypes.ToggleExternalPage => {
-  return { id: id, type: actionTypes.TOGGLE_EXTERNAL_PAGE };
-};
+export const toggleExternalPage = (id: string): actionTypes.ToggleExternalPage => ({
+  id: id,
+  type: actionTypes.TOGGLE_EXTERNAL_PAGE
+});
 
-export const createSection = (id: string, order: number): actionTypes.CreateSection => {
-  return { id: id, order: order, type: actionTypes.CREATE_SECTION };
-};
+export const createSection = (id: string, order: number): actionTypes.CreateSection => ({
+  id: id,
+  order: order,
+  type: actionTypes.CREATE_SECTION
+});
 
-export const deleteSection = (id: string): actionTypes.DeleteSection => {
-  return { id: id, type: actionTypes.DELETE_SECTION };
-};
+export const deleteSection = (id: string): actionTypes.DeleteSection => ({ id: id, type: actionTypes.DELETE_SECTION });
 
-export const moveSectionUp = (id: string): actionTypes.UpSection => {
-  return { id: id, type: actionTypes.MOVE_UP_SECTION };
-};
+export const moveSectionUp = (id: string): actionTypes.UpSection => ({ id: id, type: actionTypes.MOVE_UP_SECTION });
 
-export const moveSectionDown = (id: string): actionTypes.DownSection => {
-  return { id: id, type: actionTypes.MOVE_DOWN_SECTION };
-};
+export const moveSectionDown = (id: string): actionTypes.DownSection => ({ id: id, type: actionTypes.MOVE_DOWN_SECTION });

--- a/assembl/static2/js/app/actions/adminActions/index.js
+++ b/assembl/static2/js/app/actions/adminActions/index.js
@@ -1,106 +1,85 @@
-export const updateSelectedLocale = (newLocale) => {
-  return {
-    newLocale: newLocale,
-    type: 'UPDATE_SELECTED_LOCALE'
-  };
-};
+export const updateSelectedLocale = newLocale => ({
+  newLocale: newLocale,
+  type: 'UPDATE_SELECTED_LOCALE'
+});
 
-export const updateThematics = (thematics) => {
-  return {
-    thematics: thematics,
-    type: 'UPDATE_THEMATICS'
-  };
-};
+export const updateThematics = thematics => ({
+  thematics: thematics,
+  type: 'UPDATE_THEMATICS'
+});
 
-export const updateThematicImgUrl = (id, value) => {
-  return {
-    id: id,
-    value: value,
-    type: 'UPDATE_THEMATIC_IMG_URL'
-  };
-};
+export const updateThematicImgUrl = (id, value) => ({
+  id: id,
+  value: value,
+  type: 'UPDATE_THEMATIC_IMG_URL'
+});
 
-export const updateThematicTitle = (id, locale, value) => {
-  return {
-    id: id,
-    locale: locale,
-    value: value,
-    type: 'UPDATE_THEMATIC_TITLE'
-  };
-};
+export const updateThematicTitle = (id, locale, value) => ({
+  id: id,
+  locale: locale,
+  value: value,
+  type: 'UPDATE_THEMATIC_TITLE'
+});
 
-export const deleteThematic = (id) => {
-  return {
-    id: id,
-    type: 'DELETE_THEMATIC'
-  };
-};
+export const deleteThematic = id => ({
+  id: id,
+  type: 'DELETE_THEMATIC'
+});
 
-export const createNewThematic = (id) => {
-  return {
-    id: id,
-    type: 'CREATE_NEW_THEMATIC'
-  };
-};
+export const createNewThematic = id => ({
+  id: id,
+  type: 'CREATE_NEW_THEMATIC'
+});
 
-export const addQuestionToThematic = (id, locale) => {
-  return {
-    id: id,
-    locale: locale,
-    type: 'ADD_QUESTION_TO_THEMATIC'
-  };
-};
+export const addQuestionToThematic = (id, locale) => ({
+  id: id,
+  locale: locale,
+  type: 'ADD_QUESTION_TO_THEMATIC'
+});
 
-export const updateQuestionTitle = (thematicId, index, locale, value) => {
-  return {
-    thematicId: thematicId,
-    index: index,
-    locale: locale,
-    value: value,
-    type: 'UPDATE_QUESTION_TITLE'
-  };
-};
+export const updateQuestionTitle = (thematicId, index, locale, value) => ({
+  thematicId: thematicId,
+  index: index,
+  locale: locale,
+  value: value,
+  type: 'UPDATE_QUESTION_TITLE'
+});
 
-export const removeQuestion = (thematicId, index) => {
-  return {
-    thematicId: thematicId,
-    index: index,
-    type: 'REMOVE_QUESTION'
-  };
-};
+export const removeQuestion = (thematicId, index) => ({
+  thematicId: thematicId,
+  index: index,
+  type: 'REMOVE_QUESTION'
+});
 
-export const toggleVideo = (id) => {
-  return { id: id, type: 'TOGGLE_VIDEO' };
-};
+export const toggleVideo = id => ({ id: id, type: 'TOGGLE_VIDEO' });
 
-export const updateVideoHtmlCode = (id, value) => {
-  return { id: id, value: value, type: 'UPDATE_VIDEO_HTML_CODE' };
-};
+export const updateVideoHtmlCode = (id, value) => ({ id: id, value: value, type: 'UPDATE_VIDEO_HTML_CODE' });
 
-export const updateVideoDescriptionTop = (id, locale, value) => {
-  return { id: id, locale: locale, value: value, type: 'UPDATE_VIDEO_DESCRIPTION_TOP' };
-};
+export const updateVideoDescriptionTop = (id, locale, value) => ({
+  id: id,
+  locale: locale,
+  value: value,
+  type: 'UPDATE_VIDEO_DESCRIPTION_TOP'
+});
 
-export const updateVideoDescriptionBottom = (id, locale, value) => {
-  return { id: id, locale: locale, value: value, type: 'UPDATE_VIDEO_DESCRIPTION_BOTTOM' };
-};
+export const updateVideoDescriptionBottom = (id, locale, value) => ({
+  id: id,
+  locale: locale,
+  value: value,
+  type: 'UPDATE_VIDEO_DESCRIPTION_BOTTOM'
+});
 
-export const updateVideoDescriptionSide = (id, locale, value) => {
-  return { id: id, locale: locale, value: value, type: 'UPDATE_VIDEO_DESCRIPTION_SIDE' };
-};
+export const updateVideoDescriptionSide = (id, locale, value) => ({
+  id: id,
+  locale: locale,
+  value: value,
+  type: 'UPDATE_VIDEO_DESCRIPTION_SIDE'
+});
 
-export const updateVideoTitle = (id, locale, value) => {
-  return { id: id, locale: locale, value: value, type: 'UPDATE_VIDEO_TITLE' };
-};
+export const updateVideoTitle = (id, locale, value) => ({ id: id, locale: locale, value: value, type: 'UPDATE_VIDEO_TITLE' });
 
-export const addLanguagePreference = (locale) => {
-  return { locale: locale, selected: true, type: 'ADD_LANGUAGE_PREFERENCE' };
-};
+export const addLanguagePreference = locale => ({ locale: locale, selected: true, type: 'ADD_LANGUAGE_PREFERENCE' });
 
-export const removeLanguagePreference = (locale) => {
-  return { locale: locale, selected: false, type: 'REMOVE_LANGUAGE_PREFERENCE' };
-};
+export const removeLanguagePreference = locale => ({ locale: locale, selected: false, type: 'REMOVE_LANGUAGE_PREFERENCE' });
 
-export const languagePreferencesHasChanged = (state) => {
-  return { state: state, type: 'LANGUAGE_PREFERENCE_HAS_CHANGED' };
-};
+export const languagePreferencesHasChanged = state => ({ state: state, type: 'LANGUAGE_PREFERENCE_HAS_CHANGED' });

--- a/assembl/static2/js/app/actions/adminActions/legalNoticeAndTerms.js
+++ b/assembl/static2/js/app/actions/adminActions/legalNoticeAndTerms.js
@@ -1,18 +1,20 @@
 // @flow
 import * as actionTypes from '../actionTypes';
 
-export const updateLegalNoticeEntry = (locale: string, value: string): actionTypes.UpdateLegalNoticeEntry => {
-  return { locale: locale, value: value, type: actionTypes.UPDATE_LEGAL_NOTICE_ENTRY };
-};
+export const updateLegalNoticeEntry = (locale: string, value: string): actionTypes.UpdateLegalNoticeEntry => ({
+  locale: locale,
+  value: value,
+  type: actionTypes.UPDATE_LEGAL_NOTICE_ENTRY
+});
 
-export const updateTermsAndConditionsEntry = (locale: string, value: string): actionTypes.UpdateTermsAndConditionsEntry => {
-  return { locale: locale, value: value, type: actionTypes.UPDATE_TERMS_AND_CONDITIONS_ENTRY };
-};
+export const updateTermsAndConditionsEntry = (locale: string, value: string): actionTypes.UpdateTermsAndConditionsEntry => ({
+  locale: locale,
+  value: value,
+  type: actionTypes.UPDATE_TERMS_AND_CONDITIONS_ENTRY
+});
 
-export const updateLegalNoticeAndTerms = (value: Object): actionTypes.UpdateLegalNoticeAndTerms => {
-  return {
-    legalNoticeEntries: value.legalNoticeEntries,
-    termsAndConditionsEntries: value.termsAndConditionsEntries,
-    type: actionTypes.UPDATE_LEGAL_NOTICE_AND_TERMS
-  };
-};
+export const updateLegalNoticeAndTerms = (value: Object): actionTypes.UpdateLegalNoticeAndTerms => ({
+  legalNoticeEntries: value.legalNoticeEntries,
+  termsAndConditionsEntries: value.termsAndConditionsEntries,
+  type: actionTypes.UPDATE_LEGAL_NOTICE_AND_TERMS
+});

--- a/assembl/static2/js/app/actions/adminActions/resourcesCenter.js
+++ b/assembl/static2/js/app/actions/adminActions/resourcesCenter.js
@@ -1,85 +1,67 @@
 // @flow
 import * as actionTypes from '../actionTypes';
 
-export const createResource = (id: string, order: number): actionTypes.CreateResource => {
-  return { id: id, order: order, type: actionTypes.CREATE_RESOURCE };
-};
+export const createResource = (id: string, order: number): actionTypes.CreateResource => ({
+  id: id,
+  order: order,
+  type: actionTypes.CREATE_RESOURCE
+});
 
-export const deleteResource = (id: string): actionTypes.DeleteResource => {
-  return { id: id, type: actionTypes.DELETE_RESOURCE };
-};
+export const deleteResource = (id: string): actionTypes.DeleteResource => ({ id: id, type: actionTypes.DELETE_RESOURCE });
 
-export const updateResourceDocument = (id: string, value: string): actionTypes.UpdateResourceDocument => {
-  return {
-    id: id,
-    value: value,
-    type: actionTypes.UPDATE_RESOURCE_DOCUMENT
-  };
-};
+export const updateResourceDocument = (id: string, value: string): actionTypes.UpdateResourceDocument => ({
+  id: id,
+  value: value,
+  type: actionTypes.UPDATE_RESOURCE_DOCUMENT
+});
 
-export const updateResourceEmbedCode = (id: string, value: string): actionTypes.UpdateResourceEmbedCode => {
-  return {
-    id: id,
-    value: value,
-    type: actionTypes.UPDATE_RESOURCE_EMBED_CODE
-  };
-};
+export const updateResourceEmbedCode = (id: string, value: string): actionTypes.UpdateResourceEmbedCode => ({
+  id: id,
+  value: value,
+  type: actionTypes.UPDATE_RESOURCE_EMBED_CODE
+});
 
-export const updateResourceImage = (id: string, value: string): actionTypes.UpdateResourceImage => {
-  return {
-    id: id,
-    value: value,
-    type: actionTypes.UPDATE_RESOURCE_IMAGE
-  };
-};
+export const updateResourceImage = (id: string, value: string): actionTypes.UpdateResourceImage => ({
+  id: id,
+  value: value,
+  type: actionTypes.UPDATE_RESOURCE_IMAGE
+});
 
-export const updateResourceText = (id: string, locale: string, value: string): actionTypes.UpdateResourceText => {
-  return {
-    id: id,
-    locale: locale,
-    value: value,
-    type: actionTypes.UPDATE_RESOURCE_TEXT
-  };
-};
+export const updateResourceText = (id: string, locale: string, value: string): actionTypes.UpdateResourceText => ({
+  id: id,
+  locale: locale,
+  value: value,
+  type: actionTypes.UPDATE_RESOURCE_TEXT
+});
 
-export const updateResourceTitle = (id: string, locale: string, value: string): actionTypes.UpdateResourceTitle => {
-  return {
-    id: id,
-    locale: locale,
-    value: value,
-    type: actionTypes.UPDATE_RESOURCE_TITLE
-  };
-};
+export const updateResourceTitle = (id: string, locale: string, value: string): actionTypes.UpdateResourceTitle => ({
+  id: id,
+  locale: locale,
+  value: value,
+  type: actionTypes.UPDATE_RESOURCE_TITLE
+});
 
-export const updateResources = (resources: actionTypes.ResourcesArray): actionTypes.UpdateResources => {
-  return {
-    resources: resources,
-    type: actionTypes.UPDATE_RESOURCES
-  };
-};
+export const updateResources = (resources: actionTypes.ResourcesArray): actionTypes.UpdateResources => ({
+  resources: resources,
+  type: actionTypes.UPDATE_RESOURCES
+});
 
-export const updateResourcesCenterPageTitle = (locale: string, value: string): actionTypes.UpdateRCPageTitle => {
-  return {
-    locale: locale,
-    value: value,
-    type: actionTypes.UPDATE_RC_PAGE_TITLE
-  };
-};
+export const updateResourcesCenterPageTitle = (locale: string, value: string): actionTypes.UpdateRCPageTitle => ({
+  locale: locale,
+  value: value,
+  type: actionTypes.UPDATE_RC_PAGE_TITLE
+});
 
-export const updateResourcesCenterHeaderImage = (value: File): actionTypes.UpdateResourcesCenterHeaderImage => {
-  return {
-    value: value,
-    type: actionTypes.UPDATE_RC_HEADER_IMAGE
-  };
-};
+export const updateResourcesCenterHeaderImage = (value: File): actionTypes.UpdateResourcesCenterHeaderImage => ({
+  value: value,
+  type: actionTypes.UPDATE_RC_HEADER_IMAGE
+});
 
 export const updateResourcesCenterPage = (
   titleEntries: Array<any>,
   headerImage: File | null
-): actionTypes.UpdateResourcesCenterPage => {
-  return {
-    headerImage: headerImage,
-    titleEntries: titleEntries,
-    type: actionTypes.UPDATE_RC_PAGE
-  };
-};
+): actionTypes.UpdateResourcesCenterPage => ({
+  headerImage: headerImage,
+  titleEntries: titleEntries,
+  type: actionTypes.UPDATE_RC_PAGE
+});

--- a/assembl/static2/js/app/actions/authenticationActions.js
+++ b/assembl/static2/js/app/actions/authenticationActions.js
@@ -1,62 +1,48 @@
 import { signUp, changePasswordRequest } from '../services/authenticationService';
 
-const signupSuccess = () => {
-  return {
-    type: 'SIGNUP_SUCCESS'
-  };
-};
-const signupIncorrectPassword = () => {
-  return {
-    type: 'SIGNUP_INCORRECT_PASSWORD'
-  };
-};
-const signupGeneralError = (error) => {
-  return {
-    type: 'SIGNUP_GENERAL_ERROR',
-    error: error
-  };
-};
-export const signupAction = (payload) => {
-  return (dispatch) => {
-    return signUp(payload)
-      .then(() => {
-        dispatch(signupSuccess());
-      })
-      .catch((error) => {
-        /*
+const signupSuccess = () => ({
+  type: 'SIGNUP_SUCCESS'
+});
+const signupIncorrectPassword = () => ({
+  type: 'SIGNUP_INCORRECT_PASSWORD'
+});
+const signupGeneralError = error => ({
+  type: 'SIGNUP_GENERAL_ERROR',
+  error: error
+});
+export const signupAction = payload => dispatch =>
+  signUp(payload)
+    .then(() => {
+      dispatch(signupSuccess());
+    })
+    .catch((error) => {
+      /*
         The signup can either throw an exception, or the server responds
         with a valid error, response will be a JSON that can be parsed for further information.
         Can match errors with in `assembl.views.api2.auth.signup_error_types`
       */
-        let errorDispatch;
-        if (error instanceof Error) {
-          if (error.name === 'PasswordMismatchError') {
-            errorDispatch = dispatch(signupIncorrectPassword());
-          }
-        } else {
-          errorDispatch = dispatch(signupGeneralError(error));
+      let errorDispatch;
+      if (error instanceof Error) {
+        if (error.name === 'PasswordMismatchError') {
+          errorDispatch = dispatch(signupIncorrectPassword());
         }
-        return errorDispatch;
-      });
-  };
-};
+      } else {
+        errorDispatch = dispatch(signupGeneralError(error));
+      }
+      return errorDispatch;
+    });
 const passwordRequestSuccess = {
   type: 'REQUEST_PASSWORD_CHANGE_SUCCESS'
 };
-const passwordRequestError = (error) => {
-  return {
-    type: 'REQUEST_PASSWORD_CHANGE_ERROR',
-    data: error
-  };
-};
-export const requestPasswordChangeAction = (id, discussionSlug) => {
-  return (dispatch) => {
-    return changePasswordRequest(id, discussionSlug)
-      .then(() => {
-        dispatch(passwordRequestSuccess);
-      })
-      .catch((error) => {
-        dispatch(passwordRequestError(error));
-      });
-  };
-};
+const passwordRequestError = error => ({
+  type: 'REQUEST_PASSWORD_CHANGE_ERROR',
+  data: error
+});
+export const requestPasswordChangeAction = (id, discussionSlug) => dispatch =>
+  changePasswordRequest(id, discussionSlug)
+    .then(() => {
+      dispatch(passwordRequestSuccess);
+    })
+    .catch((error) => {
+      dispatch(passwordRequestError(error));
+    });

--- a/assembl/static2/js/app/actions/contentLocaleActions.js
+++ b/assembl/static2/js/app/actions/contentLocaleActions.js
@@ -7,28 +7,22 @@ import type {
   UpdateContentLocaleByOriginalLocale
 } from './actionTypes';
 
-export const updateContentLocaleById = (id: string, value: string): UpdateContentLocaleById => {
-  return {
-    type: UPDATE_CONTENT_LOCALE_BY_ID,
-    id: id,
-    value: value
-  };
-};
+export const updateContentLocaleById = (id: string, value: string): UpdateContentLocaleById => ({
+  type: UPDATE_CONTENT_LOCALE_BY_ID,
+  id: id,
+  value: value
+});
 
 export const updateContentLocaleByOriginalLocale = (
   originalLocale: string,
   value: string
-): UpdateContentLocaleByOriginalLocale => {
-  return {
-    type: UPDATE_CONTENT_LOCALE_BY_ORIGINAL_LOCALE,
-    originalLocale: originalLocale,
-    value: value
-  };
-};
+): UpdateContentLocaleByOriginalLocale => ({
+  type: UPDATE_CONTENT_LOCALE_BY_ORIGINAL_LOCALE,
+  originalLocale: originalLocale,
+  value: value
+});
 
-export const updateContentLocale = (data: ContentLocaleMapping): UpdateContentLocale => {
-  return {
-    type: UPDATE_CONTENT_LOCALE,
-    data: data
-  };
-};
+export const updateContentLocale = (data: ContentLocaleMapping): UpdateContentLocale => ({
+  type: UPDATE_CONTENT_LOCALE,
+  data: data
+});

--- a/assembl/static2/js/app/actions/contextActions.js
+++ b/assembl/static2/js/app/actions/contextActions.js
@@ -1,15 +1,12 @@
-const resolvedAddContext = (rootPath, debateId, connectedUserId, connectedUserName) => {
-  return {
-    type: 'ADD_CONTEXT',
-    rootPath: rootPath,
-    debateId: debateId,
-    connectedUserId: connectedUserId,
-    connectedUserName: connectedUserName
-  };
-};
+const resolvedAddContext = (rootPath, debateId, connectedUserId, connectedUserName) => ({
+  type: 'ADD_CONTEXT',
+  rootPath: rootPath,
+  debateId: debateId,
+  connectedUserId: connectedUserId,
+  connectedUserName: connectedUserName
+});
 
-export const addContext = (rootPath, debateId, connectedUserId, connectedUserName) => {
-  return function (dispatch) {
+export const addContext = (rootPath, debateId, connectedUserId, connectedUserName) =>
+  function (dispatch) {
     dispatch(resolvedAddContext(rootPath, debateId, connectedUserId, connectedUserName));
   };
-};

--- a/assembl/static2/js/app/actions/debateActions.js
+++ b/assembl/static2/js/app/actions/debateActions.js
@@ -1,33 +1,27 @@
 import { getDebateData } from '../services/debateService';
 
-const loadingDebateData = () => {
-  return {
-    type: 'FETCH_DEBATE_DATA',
-    debateData: null
-  };
-};
+const loadingDebateData = () => ({
+  type: 'FETCH_DEBATE_DATA',
+  debateData: null
+});
 
-const resolvedFetchDebateData = (debateData) => {
-  return {
-    type: 'RESOLVED_FETCH_DEBATE_DATA',
-    debateData: debateData
-  };
-};
+const resolvedFetchDebateData = debateData => ({
+  type: 'RESOLVED_FETCH_DEBATE_DATA',
+  debateData: debateData
+});
 
-const failedFetchDebateData = (error) => {
-  return {
-    type: 'FAILED_FETCH_DEBATE_DATA',
-    debateError: error
-  };
-};
+const failedFetchDebateData = error => ({
+  type: 'FAILED_FETCH_DEBATE_DATA',
+  debateError: error
+});
 
 // In future, if unauthorzed is supposed to be treated differently
 const unauthorizedDebateData = {
   type: 'UNAUTHORIZED_DEBATE_DATA'
 };
 
-export const fetchDebateData = (debateId) => {
-  return function (dispatch) {
+export const fetchDebateData = debateId =>
+  function (dispatch) {
     dispatch(loadingDebateData());
     return getDebateData(debateId).then(
       (debateData) => {
@@ -43,4 +37,3 @@ export const fetchDebateData = (debateId) => {
       }
     );
   };
-};

--- a/assembl/static2/js/app/actions/partnersActions.js
+++ b/assembl/static2/js/app/actions/partnersActions.js
@@ -1,28 +1,22 @@
 import { getPartners } from '../services/partnersService';
 
-const loadingPartners = () => {
-  return {
-    type: 'FETCH_PARTNERS',
-    partners: null
-  };
-};
+const loadingPartners = () => ({
+  type: 'FETCH_PARTNERS',
+  partners: null
+});
 
-const resolvedFetchPartners = (partners) => {
-  return {
-    type: 'RESOLVED_FETCH_PARTNERS',
-    partners: partners
-  };
-};
+const resolvedFetchPartners = partners => ({
+  type: 'RESOLVED_FETCH_PARTNERS',
+  partners: partners
+});
 
-const failedFetchPartners = (error) => {
-  return {
-    type: 'FAILED_FETCH_PARTNERS',
-    partnersError: error
-  };
-};
+const failedFetchPartners = error => ({
+  type: 'FAILED_FETCH_PARTNERS',
+  partnersError: error
+});
 
-export const fetchPartners = (debateId) => {
-  return function (dispatch) {
+export const fetchPartners = debateId =>
+  function (dispatch) {
     dispatch(loadingPartners());
     return getPartners(debateId)
       .then((partners) => {
@@ -32,4 +26,3 @@ export const fetchPartners = (debateId) => {
         dispatch(failedFetchPartners(error));
       });
   };
-};

--- a/assembl/static2/js/app/actions/phaseActions.js
+++ b/assembl/static2/js/app/actions/phaseActions.js
@@ -1,22 +1,16 @@
 // @flow
 
-export const updateCurrentPhaseIdentifier = (currentIdentifier: string) => {
-  return {
-    currentIdentifier: currentIdentifier,
-    type: 'ADD_CURRENT_PHASE_IDENTIFIER'
-  };
-};
+export const updateCurrentPhaseIdentifier = (currentIdentifier: string) => ({
+  currentIdentifier: currentIdentifier,
+  type: 'ADD_CURRENT_PHASE_IDENTIFIER'
+});
 
-export const updateQueryPhaseIdentifier = (queryIdentifier: string) => {
-  return {
-    queryIdentifier: queryIdentifier,
-    type: 'ADD_QUERY_PHASE_IDENTIFIER'
-  };
-};
+export const updateQueryPhaseIdentifier = (queryIdentifier: string) => ({
+  queryIdentifier: queryIdentifier,
+  type: 'ADD_QUERY_PHASE_IDENTIFIER'
+});
 
-export const addRedirectionToV1 = (redirectToV1: string) => {
-  return {
-    redirectToV1: redirectToV1,
-    type: 'REDIRECT_TO_V1'
-  };
-};
+export const addRedirectionToV1 = (redirectToV1: string) => ({
+  redirectToV1: redirectToV1,
+  type: 'REDIRECT_TO_V1'
+});

--- a/assembl/static2/js/app/actions/synthesisActions.js
+++ b/assembl/static2/js/app/actions/synthesisActions.js
@@ -1,28 +1,22 @@
 import { getSynthesis } from '../services/synthesisService';
 
-const loadingSynthesis = () => {
-  return {
-    type: 'FETCH_SYNTHESIS',
-    synthesis: null
-  };
-};
+const loadingSynthesis = () => ({
+  type: 'FETCH_SYNTHESIS',
+  synthesis: null
+});
 
-const resolvedFetchSynthesis = (synthesis) => {
-  return {
-    type: 'RESOLVED_FETCH_SYNTHESIS',
-    synthesis: synthesis
-  };
-};
+const resolvedFetchSynthesis = synthesis => ({
+  type: 'RESOLVED_FETCH_SYNTHESIS',
+  synthesis: synthesis
+});
 
-const failedFetchSynthesis = (error) => {
-  return {
-    type: 'FAILED_FETCH_SYNTHESIS',
-    synthesisError: error
-  };
-};
+const failedFetchSynthesis = error => ({
+  type: 'FAILED_FETCH_SYNTHESIS',
+  synthesisError: error
+});
 
-export const fetchSynthesis = (debateId) => {
-  return function (dispatch) {
+export const fetchSynthesis = debateId =>
+  function (dispatch) {
     dispatch(loadingSynthesis());
     return getSynthesis(debateId)
       .then((synthesis) => {
@@ -32,4 +26,3 @@ export const fetchSynthesis = (debateId) => {
         dispatch(failedFetchSynthesis(error));
       });
   };
-};

--- a/assembl/static2/js/app/app.jsx
+++ b/assembl/static2/js/app/app.jsx
@@ -18,6 +18,7 @@ class App extends React.Component {
     this.props.fetchDebateData(debateId);
     this.props.addContext(this.props.route.path, debateId, connectedUserId, connectedUserName);
   }
+
   componentDidUpdate() {
     const { debate, location, params } = this.props;
     if (!params.phase && !debate.debateLoading && location.pathname.split('/').indexOf('debate') > -1) {
@@ -25,6 +26,7 @@ class App extends React.Component {
       browserHistory.push(get('debate', { slug: params.slug, phase: currentPhaseIdentifier }));
     }
   }
+
   render() {
     const { debateData, debateLoading, debateError } = this.props.debate;
     return (
@@ -37,21 +39,17 @@ class App extends React.Component {
   }
 }
 
-const mapStateToProps = (state) => {
-  return {
-    debate: state.debate
-  };
-};
+const mapStateToProps = state => ({
+  debate: state.debate
+});
 
-const mapDispatchToProps = (dispatch) => {
-  return {
-    fetchDebateData: (debateId) => {
-      dispatch(fetchDebateData(debateId));
-    },
-    addContext: (path, debateId, connectedUserId, connectedUserName) => {
-      dispatch(addContext(path, debateId, connectedUserId, connectedUserName));
-    }
-  };
-};
+const mapDispatchToProps = dispatch => ({
+  fetchDebateData: (debateId) => {
+    dispatch(fetchDebateData(debateId));
+  },
+  addContext: (path, debateId, connectedUserId, connectedUserName) => {
+    dispatch(addContext(path, debateId, connectedUserId, connectedUserName));
+  }
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(App);

--- a/assembl/static2/js/app/client.js
+++ b/assembl/static2/js/app/client.js
@@ -25,18 +25,14 @@ const myFragmentMatcher = new IntrospectionFragmentMatcher({
 // for more info about customResolvers, read
 // http://dev.apollodata.com/react/query-splitting.html
 
-const dataIdFromObject = (o) => {
-  return o.id;
-};
+const dataIdFromObject = o => o.id;
 
 const client = new ApolloClient({
   fragmentMatcher: myFragmentMatcher,
   dataIdFromObject: dataIdFromObject,
   customResolvers: {
     Query: {
-      node: (_, args) => {
-        return toIdValue(dataIdFromObject({ id: args.id }));
-      }
+      node: (_, args) => toIdValue(dataIdFromObject({ id: args.id }))
     }
   },
   networkInterface: createNetworkInterface({

--- a/assembl/static2/js/app/components/administration/discussion/editSectionForm.jsx
+++ b/assembl/static2/js/app/components/administration/discussion/editSectionForm.jsx
@@ -107,28 +107,14 @@ const mapStateToProps = (state, { id, locale }) => {
   };
 };
 
-const mapDispatchToProps = (dispatch, { id, locale }) => {
-  return {
-    handleTitleChange: (e) => {
-      return dispatch(updateSectionTitle(id, locale, e.target.value));
-    },
-    handleUrlChange: (e) => {
-      return dispatch(updateSectionUrl(id, e.target.value));
-    },
-    toggleExternalPageField: () => {
-      return dispatch(toggleExternalPage(id));
-    },
-    handleDeleteClick: () => {
-      return dispatch(deleteSection(id));
-    },
-    handleUpClick: () => {
-      return dispatch(moveSectionUp(id));
-    },
-    handleDownClick: () => {
-      return dispatch(moveSectionDown(id));
-    }
-  };
-};
+const mapDispatchToProps = (dispatch, { id, locale }) => ({
+  handleTitleChange: e => dispatch(updateSectionTitle(id, locale, e.target.value)),
+  handleUrlChange: e => dispatch(updateSectionUrl(id, e.target.value)),
+  toggleExternalPageField: () => dispatch(toggleExternalPage(id)),
+  handleDeleteClick: () => dispatch(deleteSection(id)),
+  handleUpClick: () => dispatch(moveSectionUp(id)),
+  handleDownClick: () => dispatch(moveSectionDown(id))
+});
 
 export { DumbEditSectionForm };
 

--- a/assembl/static2/js/app/components/administration/discussion/languageSection.jsx
+++ b/assembl/static2/js/app/components/administration/discussion/languageSection.jsx
@@ -46,11 +46,7 @@ class LanguageSection extends React.Component {
 
     // Manage toggling of checkbox states from the store
     const totalLocaleList = List(Object.keys(this.state.localeState));
-    const currentSelectedLocaleList = totalLocaleList
-      .filter((locale) => {
-        return this.state.localeState[locale].selected;
-      })
-      .sort();
+    const currentSelectedLocaleList = totalLocaleList.filter(locale => this.state.localeState[locale].selected).sort();
     const newLocalePreferences = nextProps.discussionLanguagePreferences.sort();
     // Only update the state if there is a change in language preferences
     if (!currentSelectedLocaleList.equals(newLocalePreferences)) {
@@ -96,9 +92,7 @@ class LanguageSection extends React.Component {
                   checked={currentLocale === locale ? true : localeData.selected}
                   key={locale}
                   value={locale}
-                  onChange={(e) => {
-                    return this.toggleLocale(e.target.value);
-                  }}
+                  onChange={e => this.toggleLocale(e.target.value)}
                 >
                   {localeData.name}
                 </Checkbox>
@@ -111,37 +105,31 @@ class LanguageSection extends React.Component {
   }
 }
 
-const mapStateToProps = ({ admin: { discussionLanguagePreferences }, i18n }) => {
-  return {
-    i18n: i18n,
-    discussionLanguagePreferences: discussionLanguagePreferences
-  };
-};
+const mapStateToProps = ({ admin: { discussionLanguagePreferences }, i18n }) => ({
+  i18n: i18n,
+  discussionLanguagePreferences: discussionLanguagePreferences
+});
 
-const mapDispatchToProps = (dispatch) => {
-  return {
-    addLocaleToStore: (locale) => {
-      dispatch(addLanguagePreference(locale));
-    },
-    removeLocaleFromStore: (locale) => {
-      dispatch(removeLanguagePreference(locale));
-    },
-    signalLocaleChanged: (state) => {
-      dispatch(languagePreferencesHasChanged(state));
-    }
-  };
-};
+const mapDispatchToProps = dispatch => ({
+  addLocaleToStore: (locale) => {
+    dispatch(addLanguagePreference(locale));
+  },
+  removeLocaleFromStore: (locale) => {
+    dispatch(removeLanguagePreference(locale));
+  },
+  signalLocaleChanged: (state) => {
+    dispatch(languagePreferencesHasChanged(state));
+  }
+});
 
 export default compose(
   connect(mapStateToProps, mapDispatchToProps),
   graphql(getAllPreferenceLanguage, {
-    options: (props) => {
-      return {
-        variables: {
-          inLocale: props.i18n.locale
-        }
-      };
-    }
+    options: props => ({
+      variables: {
+        inLocale: props.i18n.locale
+      }
+    })
   }),
   withLoadingIndicator()
 )(LanguageSection);

--- a/assembl/static2/js/app/components/administration/discussion/legalNoticeAndTermsForm.jsx
+++ b/assembl/static2/js/app/components/administration/discussion/legalNoticeAndTermsForm.jsx
@@ -67,15 +67,9 @@ const mapStateToProps = (state: RootReducer, { locale }: LegalNoticeAndTermsForm
   };
 };
 
-const mapDispatchToProps = (dispatch: Function, { locale }: LegalNoticeAndTermsFormProps) => {
-  return {
-    updateLegalNotice: (value: string) => {
-      return dispatch(actions.updateLegalNoticeEntry(locale, value));
-    },
-    updateTermsAndConditions: (value: string) => {
-      return dispatch(actions.updateTermsAndConditionsEntry(locale, value));
-    }
-  };
-};
+const mapDispatchToProps = (dispatch: Function, { locale }: LegalNoticeAndTermsFormProps) => ({
+  updateLegalNotice: (value: string) => dispatch(actions.updateLegalNoticeEntry(locale, value)),
+  updateTermsAndConditions: (value: string) => dispatch(actions.updateTermsAndConditionsEntry(locale, value))
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(DumbLegalNoticeAndTermsForm);

--- a/assembl/static2/js/app/components/administration/discussion/manageSectionsForm.jsx
+++ b/assembl/static2/js/app/components/administration/discussion/manageSectionsForm.jsx
@@ -16,30 +16,23 @@ type ManageSectionFormProps = {
   createSection: Function
 };
 
-const DumbManageSectionsForm = ({ sections, selectedLocale, createSection }: ManageSectionFormProps) => {
-  return (
-    <div className="admin-box">
-      <SectionTitle title={I18n.t('administration.sections.sectionsTitle')} annotation={I18n.t('administration.annotation')} />
-      <div className="admin-content">
-        <form>
-          {sections.map((id, index) => {
-            return <EditSectionForm key={id} id={id} index={index} locale={selectedLocale} nbSections={sections.size} />;
-          })}
-          <OverlayTrigger placement="top" overlay={addSectionTooltip}>
-            <div
-              onClick={() => {
-                return createSection(sections.size);
-              }}
-              className="plus margin-l"
-            >
-              +
-            </div>
-          </OverlayTrigger>
-        </form>
-      </div>
+const DumbManageSectionsForm = ({ sections, selectedLocale, createSection }: ManageSectionFormProps) => (
+  <div className="admin-box">
+    <SectionTitle title={I18n.t('administration.sections.sectionsTitle')} annotation={I18n.t('administration.annotation')} />
+    <div className="admin-content">
+      <form>
+        {sections.map((id, index) => (
+          <EditSectionForm key={id} id={id} index={index} locale={selectedLocale} nbSections={sections.size} />
+        ))}
+        <OverlayTrigger placement="top" overlay={addSectionTooltip}>
+          <div onClick={() => createSection(sections.size)} className="plus margin-l">
+            +
+          </div>
+        </OverlayTrigger>
+      </form>
     </div>
-  );
-};
+  </div>
+);
 
 const mapStateToProps = (state) => {
   const { sectionsInOrder } = state.admin.sections;
@@ -49,14 +42,12 @@ const mapStateToProps = (state) => {
   };
 };
 
-const mapDispatchToProps = (dispatch) => {
-  return {
-    createSection: (nextOrder) => {
-      const newId = Math.round(Math.random() * -1000000).toString();
-      return dispatch(actions.createSection(newId, nextOrder));
-    }
-  };
-};
+const mapDispatchToProps = dispatch => ({
+  createSection: (nextOrder) => {
+    const newId = Math.round(Math.random() * -1000000).toString();
+    return dispatch(actions.createSection(newId, nextOrder));
+  }
+});
 
 export { DumbManageSectionsForm };
 

--- a/assembl/static2/js/app/components/administration/languageMenu.jsx
+++ b/assembl/static2/js/app/components/administration/languageMenu.jsx
@@ -35,20 +35,16 @@ const LanguageMenu = ({ changeLocale, selectedLocale, discussionPreferences, vis
         <div className="language-menu">
           <OverlayTrigger placement="top" overlay={languageTooltip}>
             <div>
-              {discussionPreferences.map((key, index) => {
-                return (
-                  <div
-                    onClick={() => {
-                      return changeLocale(key);
-                    }}
-                    id={key}
-                    className={selectedLocale === key ? 'flag-container active' : 'flag-container'}
-                    key={index}
-                  >
-                    <Flag locale={key} />
-                  </div>
-                );
-              })}
+              {discussionPreferences.map((key, index) => (
+                <div
+                  onClick={() => changeLocale(key)}
+                  id={key}
+                  className={selectedLocale === key ? 'flag-container active' : 'flag-container'}
+                  key={index}
+                >
+                  <Flag locale={key} />
+                </div>
+              ))}
             </div>
           </OverlayTrigger>
         </div>
@@ -59,20 +55,16 @@ const LanguageMenu = ({ changeLocale, selectedLocale, discussionPreferences, vis
   return <span />;
 };
 
-const mapStateToProps = (state) => {
-  return {
-    translations: state.i18n.translations,
-    selectedLocale: state.admin.selectedLocale,
-    discussionPreferences: state.admin.discussionLanguagePreferences
-  };
-};
+const mapStateToProps = state => ({
+  translations: state.i18n.translations,
+  selectedLocale: state.admin.selectedLocale,
+  discussionPreferences: state.admin.discussionLanguagePreferences
+});
 
-const mapDispatchToProps = (dispatch) => {
-  return {
-    changeLocale: (newLocale) => {
-      dispatch(updateSelectedLocale(newLocale));
-    }
-  };
-};
+const mapDispatchToProps = dispatch => ({
+  changeLocale: (newLocale) => {
+    dispatch(updateSelectedLocale(newLocale));
+  }
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(LanguageMenu);

--- a/assembl/static2/js/app/components/administration/menu.jsx
+++ b/assembl/static2/js/app/components/administration/menu.jsx
@@ -51,48 +51,46 @@ class Menu extends React.Component {
           </Link>
         </li>
         {timeline
-          ? timeline.map((phase, phaseIndex) => {
-            return (
-              <li className="menu-item" key={phaseIndex}>
-                <Link
-                  to={`${get('administration', slug)}${get('adminPhase', { ...slug, phase: phase.identifier })}`}
-                  activeClassName="active"
-                >
-                  {phase.title.entries.map((entry, index) => {
-                    if (entry['@language'] === locale) {
-                      return (
-                        <span key={index}>
-                          <Translate value="administration.menu.phase" count={phaseIndex + 1} description={entry.value} />
-                        </span>
-                      );
-                    }
+          ? timeline.map((phase, phaseIndex) => (
+            <li className="menu-item" key={phaseIndex}>
+              <Link
+                to={`${get('administration', slug)}${get('adminPhase', { ...slug, phase: phase.identifier })}`}
+                activeClassName="active"
+              >
+                {phase.title.entries.map((entry, index) => {
+                  if (entry['@language'] === locale) {
+                    return (
+                      <span key={index}>
+                        <Translate value="administration.menu.phase" count={phaseIndex + 1} description={entry.value} />
+                      </span>
+                    );
+                  }
 
-                    return null;
+                  return null;
+                })}
+              </Link>
+              {translations[locale].administration[phase.identifier] && (
+                <ul className={phase.identifier === requestedPhase ? 'shown admin-menu2' : 'hidden admin-menu2'}>
+                  {Object.keys(translations[locale].administration[phase.identifier]).map((index) => {
+                    const section = translations[locale].administration[phase.identifier][index];
+                    return (
+                      <li key={index}>
+                        <Link
+                          to={`${get('administration', slug)}${get('adminPhase', {
+                            ...slug,
+                            phase: phase.identifier
+                          })}?section=${parseInt(index, 10) + 1}`}
+                          activeClassName="active"
+                        >
+                          {section}
+                        </Link>
+                      </li>
+                    );
                   })}
-                </Link>
-                {translations[locale].administration[phase.identifier] && (
-                  <ul className={phase.identifier === requestedPhase ? 'shown admin-menu2' : 'hidden admin-menu2'}>
-                    {Object.keys(translations[locale].administration[phase.identifier]).map((index) => {
-                      const section = translations[locale].administration[phase.identifier][index];
-                      return (
-                        <li key={index}>
-                          <Link
-                            to={`${get('administration', slug)}${get('adminPhase', {
-                              ...slug,
-                              phase: phase.identifier
-                            })}?section=${parseInt(index, 10) + 1}`}
-                            activeClassName="active"
-                          >
-                            {section}
-                          </Link>
-                        </li>
-                      );
-                    })}
-                  </ul>
-                )}
-              </li>
-            );
-          })
+                </ul>
+              )}
+            </li>
+          ))
           : null}
       </ul>
     );

--- a/assembl/static2/js/app/components/administration/navbar.jsx
+++ b/assembl/static2/js/app/components/administration/navbar.jsx
@@ -15,12 +15,14 @@ class Navbar extends React.Component {
     };
     this.goToSection = this.goToSection.bind(this);
   }
+
   componentWillReceiveProps(nextProps) {
     this.setState({
       currentStep: nextProps.currentStep,
       totalSteps: nextProps.totalSteps
     });
   }
+
   goToSection(stepNb) {
     const slug = { slug: getDiscussionSlug() };
     const { phaseIdentifier } = this.props;
@@ -31,6 +33,7 @@ class Navbar extends React.Component {
       currentStep: stepNb
     });
   }
+
   render() {
     const barWidth = calculatePercentage(this.state.currentStep, this.state.totalSteps);
     return (

--- a/assembl/static2/js/app/components/administration/resourcesCenter/editResourceForm.jsx
+++ b/assembl/static2/js/app/components/administration/resourcesCenter/editResourceForm.jsx
@@ -128,27 +128,15 @@ const mapStateToProps = (state, { id, locale }) => {
   };
 };
 
-const mapDispatchToProps = (dispatch, { id, locale }) => {
-  return {
-    handleDocumentChange: (value) => {
-      return dispatch(updateResourceDocument(id, value));
-    },
-    handleEmbedCodeChange: (e) => {
-      return dispatch(updateResourceEmbedCode(id, e.target.value));
-    },
-    handleImageChange: (value) => {
-      dispatch(updateResourceImage(id, value));
-    },
-    handleTextChange: (value) => {
-      return dispatch(updateResourceText(id, locale, value));
-    },
-    handleTitleChange: (e) => {
-      return dispatch(updateResourceTitle(id, locale, e.target.value));
-    },
-    markAsToDelete: () => {
-      return dispatch(deleteResource(id));
-    }
-  };
-};
+const mapDispatchToProps = (dispatch, { id, locale }) => ({
+  handleDocumentChange: value => dispatch(updateResourceDocument(id, value)),
+  handleEmbedCodeChange: e => dispatch(updateResourceEmbedCode(id, e.target.value)),
+  handleImageChange: (value) => {
+    dispatch(updateResourceImage(id, value));
+  },
+  handleTextChange: value => dispatch(updateResourceText(id, locale, value)),
+  handleTitleChange: e => dispatch(updateResourceTitle(id, locale, e.target.value)),
+  markAsToDelete: () => dispatch(deleteResource(id))
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(EditResourceForm);

--- a/assembl/static2/js/app/components/administration/resourcesCenter/manageResourcesForm.jsx
+++ b/assembl/static2/js/app/components/administration/resourcesCenter/manageResourcesForm.jsx
@@ -6,42 +6,29 @@ import * as actions from '../../../actions/adminActions/resourcesCenter';
 import { createResourceTooltip } from '../../common/tooltips';
 import EditResourceForm from './editResourceForm';
 
-const ManageResourcesForm = ({ createResource, resources, selectedLocale }) => {
-  return (
-    <div>
-      {resources.map((id) => {
-        return <EditResourceForm key={id} id={id} locale={selectedLocale} />;
-      })}
-      <OverlayTrigger placement="top" overlay={createResourceTooltip}>
-        <div
-          onClick={() => {
-            return createResource(resources.size + 1);
-          }}
-          className="plus margin-l"
-        >
-          +
-        </div>
-      </OverlayTrigger>
-    </div>
-  );
-};
+const ManageResourcesForm = ({ createResource, resources, selectedLocale }) => (
+  <div>
+    {resources.map(id => <EditResourceForm key={id} id={id} locale={selectedLocale} />)}
+    <OverlayTrigger placement="top" overlay={createResourceTooltip}>
+      <div onClick={() => createResource(resources.size + 1)} className="plus margin-l">
+        +
+      </div>
+    </OverlayTrigger>
+  </div>
+);
 
 const mapStateToProps = (state) => {
   const { resourcesInOrder, resourcesById } = state.admin.resourcesCenter;
   return {
-    resources: resourcesInOrder.filter((id) => {
-      return !resourcesById.get(id).get('toDelete');
-    })
+    resources: resourcesInOrder.filter(id => !resourcesById.get(id).get('toDelete'))
   };
 };
 
-const mapDispatchToProps = (dispatch) => {
-  return {
-    createResource: (nextOrder) => {
-      const newId = Math.round(Math.random() * -1000000).toString();
-      return dispatch(actions.createResource(newId, nextOrder));
-    }
-  };
-};
+const mapDispatchToProps = dispatch => ({
+  createResource: (nextOrder) => {
+    const newId = Math.round(Math.random() * -1000000).toString();
+    return dispatch(actions.createResource(newId, nextOrder));
+  }
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(ManageResourcesForm);

--- a/assembl/static2/js/app/components/administration/resourcesCenter/pageForm.jsx
+++ b/assembl/static2/js/app/components/administration/resourcesCenter/pageForm.jsx
@@ -57,16 +57,10 @@ const mapStateToProps = (state, { selectedLocale }) => {
   };
 };
 
-const mapDispatchToProps = (dispatch, { selectedLocale }) => {
-  return {
-    handleHeaderImageChange: (value) => {
-      return dispatch(updateResourcesCenterHeaderImage(value));
-    },
-    handlePageTitleChange: (e) => {
-      return dispatch(updateResourcesCenterPageTitle(selectedLocale, e.target.value));
-    }
-  };
-};
+const mapDispatchToProps = (dispatch, { selectedLocale }) => ({
+  handleHeaderImageChange: value => dispatch(updateResourcesCenterHeaderImage(value)),
+  handlePageTitleChange: e => dispatch(updateResourcesCenterPageTitle(selectedLocale, e.target.value))
+});
 
 export { DumbPageForm };
 

--- a/assembl/static2/js/app/components/administration/saveButton.jsx
+++ b/assembl/static2/js/app/components/administration/saveButton.jsx
@@ -38,18 +38,14 @@ const getMutationsPromises = (params) => {
       const payload = {
         variables: variablesCreator(item, index)
       };
-      const p1 = () => {
-        return createMutation(payload);
-      };
+      const p1 = () => createMutation(payload);
       promises.push(p1);
     } else if (item.toDelete && !item.isNew) {
       // delete item
       const payload = {
         variables: deleteVariablesCreator(item)
       };
-      const p3 = () => {
-        return deleteMutation(payload);
-      };
+      const p3 = () => deleteMutation(payload);
       promises.push(p3);
     } else {
       // update item
@@ -58,9 +54,7 @@ const getMutationsPromises = (params) => {
       const payload = {
         variables: variables
       };
-      const p2 = () => {
-        return updateMutation(payload);
-      };
+      const p2 = () => updateMutation(payload);
       promises.push(p2);
     }
   });
@@ -78,51 +72,39 @@ function convertVideoDescriptionsToHTML(video) {
 }
 
 /* Create variables for createThematic and updateThematic mutations */
-const createVariablesForThematicMutation = (thematic) => {
-  return {
-    identifier: 'survey',
-    titleEntries: thematic.titleEntries,
-    // If thematic.img.externalUrl is an object, it means it's a File.
-    // We need to send image: null if we didn't change the image.
-    image: thematic.img && typeof thematic.img.externalUrl === 'object' ? thematic.img.externalUrl : null,
-    // if video is null, pass {} to remove all video fields on server side
-    video: thematic.video === null ? {} : convertVideoDescriptionsToHTML(thematic.video),
-    questions: thematic.questions
-  };
-};
+const createVariablesForThematicMutation = thematic => ({
+  identifier: 'survey',
+  titleEntries: thematic.titleEntries,
+  // If thematic.img.externalUrl is an object, it means it's a File.
+  // We need to send image: null if we didn't change the image.
+  image: thematic.img && typeof thematic.img.externalUrl === 'object' ? thematic.img.externalUrl : null,
+  // if video is null, pass {} to remove all video fields on server side
+  video: thematic.video === null ? {} : convertVideoDescriptionsToHTML(thematic.video),
+  questions: thematic.questions
+});
 
-const createVariablesForDeleteThematicMutation = (thematic) => {
-  return {
-    thematicId: thematic.id
-  };
-};
+const createVariablesForDeleteThematicMutation = thematic => ({
+  thematicId: thematic.id
+});
 
-const createVariablesForResourceMutation = (resource) => {
-  return {
-    doc: resource.doc && typeof resource.doc.externalUrl === 'object' ? resource.doc.externalUrl : null,
-    embedCode: resource.embedCode,
-    image: resource.img && typeof resource.img.externalUrl === 'object' ? resource.img.externalUrl : null,
-    textEntries: convertEntriesToHTML(resource.textEntries),
-    titleEntries: resource.titleEntries
-  };
-};
+const createVariablesForResourceMutation = resource => ({
+  doc: resource.doc && typeof resource.doc.externalUrl === 'object' ? resource.doc.externalUrl : null,
+  embedCode: resource.embedCode,
+  image: resource.img && typeof resource.img.externalUrl === 'object' ? resource.img.externalUrl : null,
+  textEntries: convertEntriesToHTML(resource.textEntries),
+  titleEntries: resource.titleEntries
+});
 
-const createVariablesForDeleteResourceMutation = (resource) => {
-  return { resourceId: resource.id };
-};
+const createVariablesForDeleteResourceMutation = resource => ({ resourceId: resource.id });
 
-const createVariablesForSectionMutation = (section) => {
-  return {
-    type: section.type,
-    url: section.url,
-    order: section.order,
-    titleEntries: section.titleEntries
-  };
-};
+const createVariablesForSectionMutation = section => ({
+  type: section.type,
+  url: section.url,
+  order: section.order,
+  titleEntries: section.titleEntries
+});
 
-const createVariablesForDeleteSectionMutation = (section) => {
-  return { sectionId: section.id };
-};
+const createVariablesForDeleteSectionMutation = section => ({ sectionId: section.id });
 
 const SaveButton = ({
   i18n,
@@ -350,36 +332,28 @@ const mapStateToProps = ({
   return {
     resourcesCenterPage: page,
     resourcesHaveChanged: resourcesHaveChanged,
-    resources: resourcesInOrder.map((id) => {
-      return resourcesById.get(id).toJS();
-    }),
+    resources: resourcesInOrder.map(id => resourcesById.get(id).toJS()),
     thematicsHaveChanged: thematicsHaveChanged,
-    thematics: thematicsInOrder.toArray().map((id) => {
-      return thematicsById.get(id).toJS();
-    }),
+    thematics: thematicsInOrder.toArray().map(id => thematicsById.get(id).toJS()),
     preferences: discussionLanguagePreferences,
     i18n: i18n,
     languagePreferenceHasChanged: discussionLanguagePreferencesHasChanged,
     sectionsHaveChanged: sectionsHaveChanged,
     sections: sectionsById
-      .mapKeys((id, section) => {
-        return section.set('order', sectionsInOrder.indexOf(id));
-      }) // fix order of sections
+      .mapKeys((id, section) => section.set('order', sectionsInOrder.indexOf(id))) // fix order of sections
       .valueSeq() // convert to array of Map
       .toJS(), // convert to array of objects
     legalNoticeAndTerms: legalNoticeAndTerms
   };
 };
 
-const mapDispatchToProps = (dispatch) => {
-  return {
-    resetLanguagePreferenceChanged: () => {
-      dispatch(languagePreferencesHasChanged(false));
-    },
-    changeLocale: (newLocale) => {
-      dispatch(updateSelectedLocale(newLocale));
-    }
-  };
-};
+const mapDispatchToProps = dispatch => ({
+  resetLanguagePreferenceChanged: () => {
+    dispatch(languagePreferencesHasChanged(false));
+  },
+  changeLocale: (newLocale) => {
+    dispatch(updateSelectedLocale(newLocale));
+  }
+});
 
 export default compose(connect(mapStateToProps, mapDispatchToProps), withApollo)(SaveButtonWithMutations);

--- a/assembl/static2/js/app/components/administration/sectionTitle.jsx
+++ b/assembl/static2/js/app/components/administration/sectionTitle.jsx
@@ -6,14 +6,12 @@ type SectionTitleProps = {
   annotation: string
 };
 
-const SectionTitle = ({ title, annotation }: SectionTitleProps) => {
-  return (
-    <div>
-      <h3 className="dark-title-3">{title}</h3>
-      <div className="box-hyphen" />
-      <div className="annotation">{annotation}</div>
-    </div>
-  );
-};
+const SectionTitle = ({ title, annotation }: SectionTitleProps) => (
+  <div>
+    <h3 className="dark-title-3">{title}</h3>
+    <div className="box-hyphen" />
+    <div className="annotation">{annotation}</div>
+  </div>
+);
 
 export default SectionTitle;

--- a/assembl/static2/js/app/components/administration/survey/exportSection.jsx
+++ b/assembl/static2/js/app/components/administration/survey/exportSection.jsx
@@ -12,9 +12,7 @@ import DiscussionPreferenceLanguage from '../../../graphql/DiscussionPreferenceL
 
 class ExportSection extends React.Component {
   static ExportLanguageDropDown = ({ languages, onSelect, activeKey }) => {
-    const activeLanguage = languages.filter((language) => {
-      return language.locale === activeKey;
-    })[0];
+    const activeLanguage = languages.filter(language => language.locale === activeKey)[0];
     return (
       <FormControl
         className="export-language-dropdown"
@@ -24,27 +22,30 @@ class ExportSection extends React.Component {
         }}
         value={activeLanguage.locale}
       >
-        {languages.map((lang) => {
-          return (
-            <option key={`locale-${lang.locale}`} value={lang.locale}>
-              {lang.name}
-            </option>
-          );
-        })}
+        {languages.map(lang => (
+          <option key={`locale-${lang.locale}`} value={lang.locale}>
+            {lang.name}
+          </option>
+        ))}
       </FormControl>
     );
   };
+
   state = { exportLocale: null, translate: false };
+
   componentWillMount() {
     const { toggleLanguageMenu } = this.props;
     toggleLanguageMenu(false);
   }
+
   selectExportLocale = (locale) => {
     this.setState({ exportLocale: locale });
   };
+
   toggleTranslation = (shouldTranslate) => {
     this.setState({ translate: shouldTranslate });
   };
+
   render() {
     const { data: { discussionPreferences: { languages } } } = this.props;
     const { translate } = this.state;
@@ -91,21 +92,17 @@ class ExportSection extends React.Component {
   }
 }
 
-const mapStateToProps = ({ i18n }) => {
-  return {
-    i18n: i18n
-  };
-};
+const mapStateToProps = ({ i18n }) => ({
+  i18n: i18n
+});
 
 export default compose(
   connect(mapStateToProps),
   graphql(DiscussionPreferenceLanguage, {
-    options: ({ i18n: { locale } }) => {
-      return {
-        variables: {
-          inLocale: locale
-        }
-      };
-    }
+    options: ({ i18n: { locale } }) => ({
+      variables: {
+        inLocale: locale
+      }
+    })
   })
 )(ExportSection);

--- a/assembl/static2/js/app/components/administration/survey/mediaForm.jsx
+++ b/assembl/static2/js/app/components/administration/survey/mediaForm.jsx
@@ -18,9 +18,7 @@ import {
 } from '../../../actions/adminActions';
 import FormControlWithLabel from '../../common/formControlWithLabel';
 
-const relativeURL = (uRL) => {
-  return uRL.match(/^https?:\/\/.*?(\/.*)$/)[1];
-};
+const relativeURL = uRL => uRL.match(/^https?:\/\/.*?(\/.*)$/)[1];
 
 class MediaForm extends React.Component {
   constructor() {
@@ -78,9 +76,7 @@ class MediaForm extends React.Component {
                 required
                 type="text"
                 value={title}
-                onChange={(e) => {
-                  return updateTitle(e.target.value);
-                }}
+                onChange={e => updateTitle(e.target.value)}
               />
               <FormControlWithLabel
                 componentClass="textarea"
@@ -111,9 +107,7 @@ class MediaForm extends React.Component {
                 type="text"
                 label={mediaLinkPh}
                 value={htmlCode}
-                onChange={(e) => {
-                  return updateHtmlCode(e.target.value);
-                }}
+                onChange={e => updateHtmlCode(e.target.value)}
               />
               <div className="admin-help">
                 <Translate value="administration.videoHelp" />
@@ -172,28 +166,14 @@ export const mapStateToProps = ({ admin: { thematicsById } }, { thematicId, sele
   };
 };
 
-export const mapDispatchToProps = (dispatch, { selectedLocale, thematicId }) => {
-  return {
-    toggle: () => {
-      return dispatch(toggleVideo(thematicId));
-    },
-    updateHtmlCode: (value) => {
-      return dispatch(updateVideoHtmlCode(thematicId, value));
-    },
-    updateDescriptionTop: (value) => {
-      return dispatch(updateVideoDescriptionTop(thematicId, selectedLocale, value));
-    },
-    updateDescriptionBottom: (value) => {
-      return dispatch(updateVideoDescriptionBottom(thematicId, selectedLocale, value));
-    },
-    updateDescriptionSide: (value) => {
-      return dispatch(updateVideoDescriptionSide(thematicId, selectedLocale, value));
-    },
-    updateTitle: (value) => {
-      return dispatch(updateVideoTitle(thematicId, selectedLocale, value));
-    }
-  };
-};
+export const mapDispatchToProps = (dispatch, { selectedLocale, thematicId }) => ({
+  toggle: () => dispatch(toggleVideo(thematicId)),
+  updateHtmlCode: value => dispatch(updateVideoHtmlCode(thematicId, value)),
+  updateDescriptionTop: value => dispatch(updateVideoDescriptionTop(thematicId, selectedLocale, value)),
+  updateDescriptionBottom: value => dispatch(updateVideoDescriptionBottom(thematicId, selectedLocale, value)),
+  updateDescriptionSide: value => dispatch(updateVideoDescriptionSide(thematicId, selectedLocale, value)),
+  updateTitle: value => dispatch(updateVideoTitle(thematicId, selectedLocale, value))
+});
 
 export default compose(connect(mapStateToProps, mapDispatchToProps), graphql(uploadDocumentMutation, { name: 'uploadDocument' }))(
   MediaForm

--- a/assembl/static2/js/app/components/administration/survey/questionSection.jsx
+++ b/assembl/static2/js/app/components/administration/survey/questionSection.jsx
@@ -72,15 +72,9 @@ class QuestionSection extends React.Component {
   }
 }
 
-const mapStateToProps = ({ admin: { thematicsById, thematicsInOrder, selectedLocale } }) => {
-  return {
-    thematics: thematicsInOrder
-      .filter((id) => {
-        return !thematicsById.getIn([id, 'toDelete']);
-      })
-      .toArray(),
-    selectedLocale: selectedLocale
-  };
-};
+const mapStateToProps = ({ admin: { thematicsById, thematicsInOrder, selectedLocale } }) => ({
+  thematics: thematicsInOrder.filter(id => !thematicsById.getIn([id, 'toDelete'])).toArray(),
+  selectedLocale: selectedLocale
+});
 
 export default connect(mapStateToProps)(QuestionSection);

--- a/assembl/static2/js/app/components/administration/survey/questionTitle.jsx
+++ b/assembl/static2/js/app/components/administration/survey/questionTitle.jsx
@@ -8,9 +8,7 @@ import FormControlWithLabel from '../../common/formControlWithLabel';
 import { deleteQuestionTooltip } from '../../common/tooltips';
 
 const QuestionsTitle = ({ titleEntries, qIndex, remove, selectedLocale, updateTitle }) => {
-  const titleEntry = titleEntries.find((entry) => {
-    return entry.localeCode === selectedLocale;
-  });
+  const titleEntry = titleEntries.find(entry => entry.localeCode === selectedLocale);
   const title = titleEntry ? titleEntry.value : '';
   const label = `${I18n.t('administration.question_label')} ${qIndex + 1} ${selectedLocale.toUpperCase()}`;
   return (
@@ -21,9 +19,7 @@ const QuestionsTitle = ({ titleEntries, qIndex, remove, selectedLocale, updateTi
         label={label}
         required
         value={title}
-        onChange={(e) => {
-          return updateTitle(e.target.value);
-        }}
+        onChange={e => updateTitle(e.target.value)}
       />
       <div className="pointer right margin-s">
         <OverlayTrigger placement="top" overlay={deleteQuestionTooltip}>
@@ -36,14 +32,8 @@ const QuestionsTitle = ({ titleEntries, qIndex, remove, selectedLocale, updateTi
   );
 };
 
-export const mapDispatchToProps = (dispatch, { thematicId, qIndex, selectedLocale }) => {
-  return {
-    updateTitle: (value) => {
-      return dispatch(updateQuestionTitle(thematicId, qIndex, selectedLocale, value));
-    },
-    remove: () => {
-      return dispatch(removeQuestion(thematicId, qIndex));
-    }
-  };
-};
+export const mapDispatchToProps = (dispatch, { thematicId, qIndex, selectedLocale }) => ({
+  updateTitle: value => dispatch(updateQuestionTitle(thematicId, qIndex, selectedLocale, value)),
+  remove: () => dispatch(removeQuestion(thematicId, qIndex))
+});
 export default connect(null, mapDispatchToProps)(QuestionsTitle);

--- a/assembl/static2/js/app/components/administration/survey/questionsForm.jsx
+++ b/assembl/static2/js/app/components/administration/survey/questionsForm.jsx
@@ -6,48 +6,38 @@ import { addQuestionTooltip } from '../../common/tooltips';
 import QuestionTitle from './questionTitle';
 import { addQuestionToThematic } from '../../../actions/adminActions';
 
-const QuestionsForm = ({ addQuestion, selectedLocale, thematicId, questions }) => {
-  return (
-    <div className={thematicId ? 'form-container' : 'hidden'}>
-      <div className="margin-xl">
-        {questions.map((question, index) => {
-          return (
-            <FormGroup key={index}>
-              <QuestionTitle
-                thematicId={thematicId}
-                qIndex={index}
-                titleEntries={question.titleEntries}
-                selectedLocale={selectedLocale}
-              />
-            </FormGroup>
-          );
-        })}
-        <OverlayTrigger placement="top" overlay={addQuestionTooltip}>
-          <div onClick={addQuestion} className="plus margin-l">
-            +
-          </div>
-        </OverlayTrigger>
-      </div>
+const QuestionsForm = ({ addQuestion, selectedLocale, thematicId, questions }) => (
+  <div className={thematicId ? 'form-container' : 'hidden'}>
+    <div className="margin-xl">
+      {questions.map((question, index) => (
+        <FormGroup key={index}>
+          <QuestionTitle
+            thematicId={thematicId}
+            qIndex={index}
+            titleEntries={question.titleEntries}
+            selectedLocale={selectedLocale}
+          />
+        </FormGroup>
+      ))}
+      <OverlayTrigger placement="top" overlay={addQuestionTooltip}>
+        <div onClick={addQuestion} className="plus margin-l">
+          +
+        </div>
+      </OverlayTrigger>
     </div>
-  );
-};
+  </div>
+);
 
-export const mapStateToProps = ({ admin: { thematicsById, thematicsInOrder } }, { thematicId }) => {
-  return {
-    thematics: thematicsInOrder,
-    questions: thematicsById
-      .get(thematicId)
-      .get('questions')
-      .toJS()
-  };
-};
+export const mapStateToProps = ({ admin: { thematicsById, thematicsInOrder } }, { thematicId }) => ({
+  thematics: thematicsInOrder,
+  questions: thematicsById
+    .get(thematicId)
+    .get('questions')
+    .toJS()
+});
 
-export const mapDispatchToProps = (dispatch, { thematicId, selectedLocale }) => {
-  return {
-    addQuestion: () => {
-      return dispatch(addQuestionToThematic(thematicId, selectedLocale));
-    }
-  };
-};
+export const mapDispatchToProps = (dispatch, { thematicId, selectedLocale }) => ({
+  addQuestion: () => dispatch(addQuestionToThematic(thematicId, selectedLocale))
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(QuestionsForm);

--- a/assembl/static2/js/app/components/administration/survey/themeForm.jsx
+++ b/assembl/static2/js/app/components/administration/survey/themeForm.jsx
@@ -24,9 +24,7 @@ export const DumbThemeCreationForm = ({
     return null;
   }
 
-  const handleTitleChange = (e) => {
-    return updateTitle(selectedLocale, e.target.value);
-  };
+  const handleTitleChange = e => updateTitle(selectedLocale, e.target.value);
 
   const handleImageChange = (file) => {
     updateImgUrl(file);
@@ -70,18 +68,16 @@ const mapStateToProps = ({ admin: { thematicsById } }, { id, selectedLocale }) =
   };
 };
 
-const mapDispatchToProps = (dispatch, { id }) => {
-  return {
-    markAsToDelete: () => {
-      dispatch(deleteThematic(id));
-    },
-    updateImgUrl: (value) => {
-      dispatch(updateThematicImgUrl(id, value));
-    },
-    updateTitle: (locale, value) => {
-      dispatch(updateThematicTitle(id, locale, value));
-    }
-  };
-};
+const mapDispatchToProps = (dispatch, { id }) => ({
+  markAsToDelete: () => {
+    dispatch(deleteThematic(id));
+  },
+  updateImgUrl: (value) => {
+    dispatch(updateThematicImgUrl(id, value));
+  },
+  updateTitle: (locale, value) => {
+    dispatch(updateThematicTitle(id, locale, value));
+  }
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(DumbThemeCreationForm);

--- a/assembl/static2/js/app/components/administration/survey/themeSection.jsx
+++ b/assembl/static2/js/app/components/administration/survey/themeSection.jsx
@@ -13,6 +13,7 @@ class ThemeSection extends React.Component {
     const { toggleLanguageMenu } = this.props;
     toggleLanguageMenu(true);
   }
+
   render() {
     const { addThematic, selectedLocale, thematics } = this.props;
     return (
@@ -20,9 +21,7 @@ class ThemeSection extends React.Component {
         <SectionTitle title={I18n.t('administration.survey.0')} annotation={I18n.t('administration.annotation')} />
         <div className="admin-content">
           <form>
-            {thematics.map((id, idx) => {
-              return <ThemeForm key={id} id={id} index={idx} selectedLocale={selectedLocale} />;
-            })}
+            {thematics.map((id, idx) => <ThemeForm key={id} id={id} index={idx} selectedLocale={selectedLocale} />)}
             <OverlayTrigger placement="top" overlay={addThematicTooltip}>
               <div onClick={addThematic} className="plus margin-l">
                 +
@@ -35,22 +34,16 @@ class ThemeSection extends React.Component {
   }
 }
 
-const mapStateToProps = ({ admin: { thematicsById, thematicsInOrder, selectedLocale } }) => {
-  return {
-    thematics: thematicsInOrder.filter((id) => {
-      return !thematicsById.getIn([id, 'toDelete']);
-    }),
-    selectedLocale: selectedLocale
-  };
-};
+const mapStateToProps = ({ admin: { thematicsById, thematicsInOrder, selectedLocale } }) => ({
+  thematics: thematicsInOrder.filter(id => !thematicsById.getIn([id, 'toDelete'])),
+  selectedLocale: selectedLocale
+});
 
-const mapDispatchToProps = (dispatch) => {
-  return {
-    addThematic: () => {
-      const newThemeId = Math.round(Math.random() * -1000000).toString();
-      dispatch(createNewThematic(newThemeId));
-    }
-  };
-};
+const mapDispatchToProps = dispatch => ({
+  addThematic: () => {
+    const newThemeId = Math.round(Math.random() * -1000000).toString();
+    dispatch(createNewThematic(newThemeId));
+  }
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(ThemeSection);

--- a/assembl/static2/js/app/components/common/attachFileForm.jsx
+++ b/assembl/static2/js/app/components/common/attachFileForm.jsx
@@ -15,7 +15,9 @@ type AttachFileFormState = {
 
 class AttachFileForm extends React.Component<*, AttachFileFormProps, AttachFileFormState> {
   props: AttachFileFormProps;
+
   state: AttachFileFormState;
+
   fileInput: HTMLInputElement;
 
   constructor() {

--- a/assembl/static2/js/app/components/common/attachments.jsx
+++ b/assembl/static2/js/app/components/common/attachments.jsx
@@ -22,27 +22,25 @@ type AttachmentsProps = {
 
 const DEFAULT_FILENAME = 'file';
 
-const Attachments = ({ attachments }: AttachmentsProps) => {
-  return (
-    <div className="attachments">
-      {attachments.map((attachment) => {
-        const { externalUrl, mimeType, title } = attachment.document;
-        if (mimeType && mimeType.startsWith('image/')) {
-          return null;
-        }
+const Attachments = ({ attachments }: AttachmentsProps) => (
+  <div className="attachments">
+    {attachments.map((attachment) => {
+      const { externalUrl, mimeType, title } = attachment.document;
+      if (mimeType && mimeType.startsWith('image/')) {
+        return null;
+      }
 
-        return (
-          <div className="attachment" key={attachment.id}>
-            <span className="assembl-icon-synthesis" />
-            <span className="title">{title || externalUrl}</span>
-            <a download={title || DEFAULT_FILENAME} href={externalUrl} type={mimeType} target="_blank" rel="noopener noreferrer">
-              <Translate value="common.attachments.download" />
-            </a>
-          </div>
-        );
-      })}
-    </div>
-  );
-};
+      return (
+        <div className="attachment" key={attachment.id}>
+          <span className="assembl-icon-synthesis" />
+          <span className="title">{title || externalUrl}</span>
+          <a download={title || DEFAULT_FILENAME} href={externalUrl} type={mimeType} target="_blank" rel="noopener noreferrer">
+            <Translate value="common.attachments.download" />
+          </a>
+        </div>
+      );
+    })}
+  </div>
+);
 
 export default Attachments;

--- a/assembl/static2/js/app/components/common/avatar.jsx
+++ b/assembl/static2/js/app/components/common/avatar.jsx
@@ -13,20 +13,24 @@ class ProfileIcon extends React.Component {
     super(props);
     this.setCurrentView = this.setCurrentView.bind(this);
   }
+
   componentWillMount() {
     this.setCurrentView();
   }
+
   componentWillReceiveProps(nextProps) {
     if (nextProps.location) {
       this.setState({ next: nextProps.location });
     }
   }
+
   setCurrentView() {
     const { location } = this.props;
     this.setState({
       next: location
     });
   }
+
   render() {
     const { slug, connectedUserId, displayName } = this.props;
     const dropdownUser = (
@@ -65,13 +69,11 @@ class ProfileIcon extends React.Component {
   }
 }
 
-const mapStateToProps = ({ context, debate }) => {
-  return {
-    slug: debate.debateData.slug,
-    connectedUserId: context.connectedUserId,
-    id: btoa(`AgentProfile:${context.connectedUserId}`)
-  };
-};
+const mapStateToProps = ({ context, debate }) => ({
+  slug: debate.debateData.slug,
+  connectedUserId: context.connectedUserId,
+  id: btoa(`AgentProfile:${context.connectedUserId}`)
+});
 
 export default compose(
   connect(mapStateToProps),

--- a/assembl/static2/js/app/components/common/boxWithHyphen.jsx
+++ b/assembl/static2/js/app/components/common/boxWithHyphen.jsx
@@ -21,23 +21,21 @@ type BoxWithHyphenProps = {
   title: string
 };
 
-const Box = ({ body, date, hyphenStyle, subject, title }: BoxProps) => {
-  return (
-    <div className="insert-box">
-      <h3 className="dark-title-4 ellipsis">
-        <div>{title}</div>
-        <div className="ellipsis margin-xs">{subject}</div>
-      </h3>
-      <div className="box-hyphen" style={hyphenStyle}>
-        &nbsp;
-      </div>
-      <div className="date">{date ? <Localize value={date} dateFormat="date.format2" /> : null}</div>
-      <div className="insert-content margin-s">
-        <p dangerouslySetInnerHTML={{ __html: body }} />
-      </div>
+const Box = ({ body, date, hyphenStyle, subject, title }: BoxProps) => (
+  <div className="insert-box">
+    <h3 className="dark-title-4 ellipsis">
+      <div>{title}</div>
+      <div className="ellipsis margin-xs">{subject}</div>
+    </h3>
+    <div className="box-hyphen" style={hyphenStyle}>
+      &nbsp;
     </div>
-  );
-};
+    <div className="date">{date ? <Localize value={date} dateFormat="date.format2" /> : null}</div>
+    <div className="insert-content margin-s">
+      <p dangerouslySetInnerHTML={{ __html: body }} />
+    </div>
+  </div>
+);
 
 class BoxWithHyphen extends React.Component<*, BoxWithHyphenProps, *> {
   render() {

--- a/assembl/static2/js/app/components/common/cardList.jsx
+++ b/assembl/static2/js/app/components/common/cardList.jsx
@@ -16,19 +16,17 @@ class CardList extends React.Component<void, CardListProps, void> {
     const { data, CardItem, itemClassName, classNameGenerator } = this.props;
     return (
       <Row className="no-margin">
-        {data.map((cardData, index) => {
-          return (
-            <Col
-              xs={12}
-              sm={6}
-              md={3}
-              className={classNameGenerator ? classNameGenerator(itemClassName, index) : itemClassName}
-              key={cardData.id || index}
-            >
-              <CardItem {...cardData} index={index} />
-            </Col>
-          );
-        })}
+        {data.map((cardData, index) => (
+          <Col
+            xs={12}
+            sm={6}
+            md={3}
+            className={classNameGenerator ? classNameGenerator(itemClassName, index) : itemClassName}
+            key={cardData.id || index}
+          >
+            <CardItem {...cardData} index={index} />
+          </Col>
+        ))}
       </Row>
     );
   }

--- a/assembl/static2/js/app/components/common/editAttachments.jsx
+++ b/assembl/static2/js/app/components/common/editAttachments.jsx
@@ -8,28 +8,21 @@ type EditAttachmentsProps = {
   onDelete: Function
 };
 
-const EditAttachments = ({ attachments, onDelete }: EditAttachmentsProps) => {
-  return (
-    <div className="attachments">
-      {attachments.map((attachment) => {
-        const { externalUrl, title } = attachment.document;
-        return (
-          <div className="attachment" key={attachment.entityKey}>
-            <span className="assembl-icon-text-attachment" />
-            <a href={externalUrl} target="_blank" rel="noopener noreferrer">
-              {title || externalUrl}
-            </a>
-            <span
-              className="assembl-icon-delete"
-              onMouseDown={() => {
-                return onDelete(attachment.document.id);
-              }}
-            />
-          </div>
-        );
-      })}
-    </div>
-  );
-};
+const EditAttachments = ({ attachments, onDelete }: EditAttachmentsProps) => (
+  <div className="attachments">
+    {attachments.map((attachment) => {
+      const { externalUrl, title } = attachment.document;
+      return (
+        <div className="attachment" key={attachment.entityKey}>
+          <span className="assembl-icon-text-attachment" />
+          <a href={externalUrl} target="_blank" rel="noopener noreferrer">
+            {title || externalUrl}
+          </a>
+          <span className="assembl-icon-delete" onMouseDown={() => onDelete(attachment.document.id)} />
+        </div>
+      );
+    })}
+  </div>
+);
 
 export default EditAttachments;

--- a/assembl/static2/js/app/components/common/fileUploader.jsx
+++ b/assembl/static2/js/app/components/common/fileUploader.jsx
@@ -25,8 +25,11 @@ type FileUploaderState = {
 */
 class FileUploader extends React.Component<Object, FileUploaderProps, FileUploaderState> {
   props: FileUploaderProps;
+
   state: FileUploaderState;
+
   fileInput: HTMLInputElement;
+
   preview: HTMLImageElement;
 
   static defaultProps = {

--- a/assembl/static2/js/app/components/common/footer.jsx
+++ b/assembl/static2/js/app/components/common/footer.jsx
@@ -24,13 +24,11 @@ class Footer extends React.Component {
                   <Translate value="footer.socialMedias" />
                 </p>
                 <div className="social-medias">
-                  {socialMedias.map((sMedia, index) => {
-                    return (
-                      <Link to={sMedia.url} target="_blank" key={index}>
-                        <i className={`assembl-icon-${sMedia.name}-circle`} />
-                      </Link>
-                    );
-                  })}
+                  {socialMedias.map((sMedia, index) => (
+                    <Link to={sMedia.url} target="_blank" key={index}>
+                      <i className={`assembl-icon-${sMedia.name}-circle`} />
+                    </Link>
+                  ))}
                 </div>
               </div>
             )}
@@ -71,20 +69,16 @@ class Footer extends React.Component {
   }
 }
 
-const mapStateToProps = (state) => {
-  return {
-    assemblVersion: state.context.assemblVersion,
-    debateData: state.debate.debateData,
-    lang: state.i18n.locale
-  };
-};
+const mapStateToProps = state => ({
+  assemblVersion: state.context.assemblVersion,
+  debateData: state.debate.debateData,
+  lang: state.i18n.locale
+});
 
 const withData = graphql(TabsConditionQuery, {
-  props: ({ data }) => {
-    return {
-      ...data
-    };
-  }
+  props: ({ data }) => ({
+    ...data
+  })
 });
 
 export default compose(connect(mapStateToProps), withData, withoutLoadingIndicator())(Footer);

--- a/assembl/static2/js/app/components/common/formControlWithLabel.jsx
+++ b/assembl/static2/js/app/components/common/formControlWithLabel.jsx
@@ -38,9 +38,7 @@ class FormControlWithLabel extends React.Component {
         rawContentState={value}
         placeholder={label}
         toolbarPosition="bottom"
-        updateContentState={(cs) => {
-          return onChange(cs);
-        }}
+        updateContentState={cs => onChange(cs)}
         withAttachmentButton={false}
       />
     );

--- a/assembl/static2/js/app/components/common/goUp.jsx
+++ b/assembl/static2/js/app/components/common/goUp.jsx
@@ -23,19 +23,13 @@ class GoUp extends React.Component {
     const threshold = document.body.scrollHeight - screenHeight - footerHeight;
     if (window.pageYOffset > screenHeight && window.pageYOffset < threshold) {
       // Show the button when we scrolled minimum the height of the window.
-      this.setState(() => {
-        return { isHidden: false, position: 'fixed' };
-      });
+      this.setState(() => ({ isHidden: false, position: 'fixed' }));
     } else if (window.pageYOffset >= threshold) {
       // At the end of the page, the button stays above the footer.
       // The container needs to have position:relative for it to work.
-      this.setState(() => {
-        return { isHidden: false, position: 'absolute' };
-      });
+      this.setState(() => ({ isHidden: false, position: 'absolute' }));
     } else {
-      this.setState(() => {
-        return { isHidden: true };
-      });
+      this.setState(() => ({ isHidden: true }));
     }
   }
 
@@ -43,11 +37,7 @@ class GoUp extends React.Component {
     return (
       <div className={`go-up ${this.state.isHidden ? 'hidden' : ''}`} style={{ position: this.state.position }}>
         <div>
-          <a
-            onClick={() => {
-              return window.scrollTo({ top: 0, left: 0, behavior: 'smooth' });
-            }}
-          >
+          <a onClick={() => window.scrollTo({ top: 0, left: 0, behavior: 'smooth' })}>
             <span className="assembl-icon-up-open">&nbsp;</span>
           </a>
         </div>

--- a/assembl/static2/js/app/components/common/header.jsx
+++ b/assembl/static2/js/app/components/common/header.jsx
@@ -41,11 +41,9 @@ class Header extends React.Component {
   }
 }
 
-const mapStateToProps = (state) => {
-  return {
-    debate: state.debate,
-    i18n: state.i18n
-  };
-};
+const mapStateToProps = state => ({
+  debate: state.debate,
+  i18n: state.i18n
+});
 
 export default connect(mapStateToProps)(Header);

--- a/assembl/static2/js/app/components/common/media.jsx
+++ b/assembl/static2/js/app/components/common/media.jsx
@@ -5,39 +5,31 @@ import { Grid, Col, Button, Image, ResponsiveEmbed } from 'react-bootstrap';
 import { displayModal } from '../../utils/utilityManager';
 
 class Media extends React.Component {
-  static isValidDescription = (description) => {
-    return !!(description && description !== '<p></p>');
-  };
+  static isValidDescription = description => !!(description && description !== '<p></p>');
 
-  static Title = ({ value }) => {
-    return (
-      <div className="media-title-section">
-        <div className="title-hyphen">&nbsp;</div>
-        <h1 className="dark-title-1">{value || I18n.t('debate.survey.titleVideo')}</h1>
+  static Title = ({ value }) => (
+    <div className="media-title-section">
+      <div className="title-hyphen">&nbsp;</div>
+      <h1 className="dark-title-1">{value || I18n.t('debate.survey.titleVideo')}</h1>
+    </div>
+  );
+
+  static SideDescription = ({ content }) => (
+    <div className="media-description">
+      <div className="media-description-icon">
+        <span className="assembl-icon-pepite color2">&nbsp;</span>
       </div>
-    );
-  };
+      <div className="description-txt" dangerouslySetInnerHTML={{ __html: content }} />
+      <div className="box-hyphen left">&nbsp;</div>
+    </div>
+  );
 
-  static SideDescription = ({ content }) => {
-    return (
-      <div className="media-description">
-        <div className="media-description-icon">
-          <span className="assembl-icon-pepite color2">&nbsp;</span>
-        </div>
-        <div className="description-txt" dangerouslySetInnerHTML={{ __html: content }} />
-        <div className="box-hyphen left">&nbsp;</div>
-      </div>
-    );
-  };
+  static TopDescription = ({ content }) => (
+    <div className="media-description-layer media-description-top" dangerouslySetInnerHTML={{ __html: content }} />
+  );
 
-  static TopDescription = ({ content }) => {
-    return <div className="media-description-layer media-description-top" dangerouslySetInnerHTML={{ __html: content }} />;
-  };
-
-  static ImageModal = (content) => {
-    return () => {
-      displayModal(null, content, false, null, null, true, 'large');
-    };
+  static ImageModal = content => () => {
+    displayModal(null, content, false, null, null, true, 'large');
   };
 
   static Content = ({ content }) => {
@@ -60,9 +52,9 @@ class Media extends React.Component {
     );
   };
 
-  static BottomDescription = ({ content }) => {
-    return <div className="media-description-layer media-description-bottom" dangerouslySetInnerHTML={{ __html: content }} />;
-  };
+  static BottomDescription = ({ content }) => (
+    <div className="media-description-layer media-description-bottom" dangerouslySetInnerHTML={{ __html: content }} />
+  );
 
   render() {
     const { title, descriptionTop, descriptionBottom, descriptionSide, htmlCode, noTitle } = this.props;

--- a/assembl/static2/js/app/components/common/modal.jsx
+++ b/assembl/static2/js/app/components/common/modal.jsx
@@ -13,25 +13,30 @@ class AssemblModal extends React.Component {
     this.open = this.open.bind(this);
     this.goToUrl = this.goToUrl.bind(this);
   }
+
   componentWillReceiveProps(nextProps) {
     this.setState({
       showModal: nextProps.showModal
     });
   }
+
   close() {
     this.setState({
       showModal: false
     });
   }
+
   open() {
     this.setState({
       showModal: true
     });
   }
+
   goToUrl(url) {
     this.url = url;
     window.location = this.url;
   }
+
   render() {
     const { content, title, body, footer, footerTxt, button, bsSize } = this.state;
     if (content) {

--- a/assembl/static2/js/app/components/common/nuggetsManager.js
+++ b/assembl/static2/js/app/components/common/nuggetsManager.js
@@ -4,26 +4,28 @@ import range from 'lodash/range';
 
 import Nuggets from '../debate/thread/nuggets';
 
-const indexNotFound = (index) => {
-  return index === -1;
-};
+const indexNotFound = index => index === -1;
 
 class NuggetsManager {
   nuggetsList: Array<Nuggets>;
+
   constructor() {
     this.nuggetsList = [];
   }
+
   add(nuggets: Nuggets) {
     this.nuggetsList.push(nuggets);
     this.sort();
     this.update();
   }
+
   update = () => {
     this.nuggetsList.reduce((previous, nuggets) => {
       nuggets.updateTop(previous);
       return nuggets;
     }, null);
   };
+
   remove(nuggets: Nuggets) {
     const index = this.nuggetsList.indexOf(nuggets);
     if (indexNotFound(index)) {
@@ -31,6 +33,7 @@ class NuggetsManager {
     }
     delete this.nuggetsList[index];
   }
+
   sort() {
     this.nuggetsList.sort((a, b) => {
       const aLevel = a.props.completeLevel.split('-');

--- a/assembl/static2/js/app/components/common/richTextEditor/attachmentsPlugin.jsx
+++ b/assembl/static2/js/app/components/common/richTextEditor/attachmentsPlugin.jsx
@@ -224,8 +224,8 @@ const plugin = {
         const variables = {
           file: entity.data.file
         };
-        uploadDocumentsPromise = uploadDocumentsPromise.then(() => {
-          return uploadDocument({ variables: variables }).then((res) => {
+        uploadDocumentsPromise = uploadDocumentsPromise.then(() =>
+          uploadDocument({ variables: variables }).then((res) => {
             if (res && res.data) {
               const doc = res.data.uploadDocument.document;
               documentIds.push(doc.id);
@@ -238,21 +238,22 @@ const plugin = {
                 mimeType: mimeType
               });
             }
-          });
-        });
+          })
+        );
       } else {
         documentIds.push(entity.data.id);
       }
     });
 
-    return uploadDocumentsPromise.then(() => {
-      return new Promise((resolve) => {
-        resolve({
-          contentState: convertToRaw(contentState),
-          documentIds: documentIds
-        });
-      });
-    });
+    return uploadDocumentsPromise.then(
+      () =>
+        new Promise((resolve) => {
+          resolve({
+            contentState: convertToRaw(contentState),
+            documentIds: documentIds
+          });
+        })
+    );
   }
 };
 

--- a/assembl/static2/js/app/components/common/richTextEditor/index.jsx
+++ b/assembl/static2/js/app/components/common/richTextEditor/index.jsx
@@ -41,8 +41,11 @@ function customBlockRenderer(block) {
 
 export default class RichTextEditor extends React.Component<Object, RichTextEditorProps, RichTextEditorState> {
   editor: HTMLDivElement;
+
   props: RichTextEditorProps;
+
   state: RichTextEditorState;
+
   static defaultProps: Object;
 
   static defaultProps = {
@@ -69,9 +72,7 @@ export default class RichTextEditor extends React.Component<Object, RichTextEdit
     }
   }
 
-  getCurrentRawContentState = () => {
-    return convertToRaw(this.state.editorState.getCurrentContent());
-  };
+  getCurrentRawContentState = () => convertToRaw(this.state.editorState.getCurrentContent());
 
   onBlur = () => {
     this.setState(
@@ -133,9 +134,7 @@ export default class RichTextEditor extends React.Component<Object, RichTextEdit
 
   getCharCount(editorState: EditorState): number {
     // this code is "borrowed" from the draft-js counter plugin
-    const decodeUnicode = (str) => {
-      return punycode.ucs2.decode(str);
-    }; // func to handle unicode characters
+    const decodeUnicode = str => punycode.ucs2.decode(str); // func to handle unicode characters
     const plainText = editorState.getCurrentContent().getPlainText('');
     const regex = /(?:\r\n|\r|\n)/g; // new line, carriage return, line feed
     const cleanString = plainText.replace(regex, '').trim(); // replace above characters w/ nothing
@@ -161,9 +160,7 @@ export default class RichTextEditor extends React.Component<Object, RichTextEdit
   focusEditor = (): void => {
     // Hacky: Wait to focus the editor so we don't lose selection.
     // The toolbar actions don't work at all without this.
-    setTimeout(() => {
-      return this.editor.focus();
-    }, 50);
+    setTimeout(() => this.editor.focus(), 50);
   };
 
   renderRemainingChars = (): React.Element<*> => {

--- a/assembl/static2/js/app/components/common/richTextEditor/toolbar.jsx
+++ b/assembl/static2/js/app/components/common/richTextEditor/toolbar.jsx
@@ -26,8 +26,11 @@ type ToolbarState = {
 
 class Toolbar extends React.Component<void, ToolbarProps, ToolbarState> {
   props: ToolbarProps;
+
   state: ToolbarState;
+
   currentStyle: DraftInlineStyle;
+
   currentBlockType: DraftBlockType;
 
   constructor() {
@@ -82,9 +85,7 @@ class Toolbar extends React.Component<void, ToolbarProps, ToolbarState> {
     }
     case 'block-type': {
       isActive = config.style === this.currentBlockType;
-      onToggle = () => {
-        return this.toggleBlockType(config.style);
-      };
+      onToggle = () => this.toggleBlockType(config.style);
       break;
     }
     default:
@@ -147,11 +148,7 @@ class Toolbar extends React.Component<void, ToolbarProps, ToolbarState> {
     this.currentBlockType = this.getCurrentBlockType();
     return (
       <div className="editor-toolbar">
-        <div className="btn-group">
-          {buttonsConfig.map((buttonConfig) => {
-            return this.renderButton(buttonConfig);
-          })}
-        </div>
+        <div className="btn-group">{buttonsConfig.map(buttonConfig => this.renderButton(buttonConfig))}</div>
 
         {withAttachmentButton ? (
           <div className="btn-group">

--- a/assembl/static2/js/app/components/common/screenDimensions.jsx
+++ b/assembl/static2/js/app/components/common/screenDimensions.jsx
@@ -10,26 +10,26 @@ class ResizeListener extends React.Component {
     updateScreenDimensions();
     window.addEventListener('resize', updateScreenDimensions);
   }
+
   componentWillUnmount() {
     window.removeEventListener('resize', this.props.updateScreenDimensions);
   }
+
   render() {
     // This prevents the component from having more than one child
     return React.Children.only(this.props.children);
   }
 }
 
-export const ScreenDimensionsProvider = connect(null, (dispatch) => {
-  return {
-    updateScreenDimensions: () => {
-      dispatch({
-        type: 'UPDATE_SCREEN_DIMENSIONS',
-        newWidth: window.innerWidth,
-        newHeight: window.innerHeight
-      });
-    }
-  };
-})(ResizeListener);
+export const ScreenDimensionsProvider = connect(null, dispatch => ({
+  updateScreenDimensions: () => {
+    dispatch({
+      type: 'UPDATE_SCREEN_DIMENSIONS',
+      newWidth: window.innerWidth,
+      newHeight: window.innerHeight
+    });
+  }
+}))(ResizeListener);
 
 /* remove this block when we update flow */
 
@@ -47,27 +47,18 @@ type AnyComponent = ComponentType<any>;
 /* end of block to be removed */
 
 // HOC
-export const withScreenWidth = (WrappedComponent: AnyComponent) => {
-  return connect(({ screenWidth }) => {
-    return {
-      screenWidth: screenWidth
-    };
-  })(WrappedComponent);
-};
+export const withScreenWidth = (WrappedComponent: AnyComponent) =>
+  connect(({ screenWidth }) => ({
+    screenWidth: screenWidth
+  }))(WrappedComponent);
 
-export const withScreenHeight = (WrappedComponent: AnyComponent) => {
-  return connect(({ screenHeight }) => {
-    return {
-      screenHeight: screenHeight
-    };
-  })(WrappedComponent);
-};
+export const withScreenHeight = (WrappedComponent: AnyComponent) =>
+  connect(({ screenHeight }) => ({
+    screenHeight: screenHeight
+  }))(WrappedComponent);
 
-export const withScreenDimensions = (WrappedComponent: AnyComponent) => {
-  return connect(({ screenWidth, screenHeight }) => {
-    return {
-      screenWidth: screenWidth,
-      screenHeight: screenHeight
-    };
-  })(WrappedComponent);
-};
+export const withScreenDimensions = (WrappedComponent: AnyComponent) =>
+  connect(({ screenWidth, screenHeight }) => ({
+    screenWidth: screenWidth,
+    screenHeight: screenHeight
+  }))(WrappedComponent);

--- a/assembl/static2/js/app/components/common/scrollOnePageButton.jsx
+++ b/assembl/static2/js/app/components/common/scrollOnePageButton.jsx
@@ -2,10 +2,8 @@ import React from 'react';
 import { isMobile } from '../../utils/globalFunctions';
 import { withScreenHeight } from '../common/screenDimensions';
 
-const scrollOnePageDown = (screenHeight) => {
-  return () => {
-    window.scrollTo({ top: screenHeight, left: 0, behavior: 'smooth' });
-  };
+const scrollOnePageDown = screenHeight => () => {
+  window.scrollTo({ top: screenHeight, left: 0, behavior: 'smooth' });
 };
 
 export const DumbScrollOnePageButton = ({ hidden, screenHeight }) => {

--- a/assembl/static2/js/app/components/common/section.jsx
+++ b/assembl/static2/js/app/components/common/section.jsx
@@ -14,44 +14,36 @@ type SectionProps = {
   translate: boolean
 };
 
-const level1 = (title, index, translate) => {
-  return (
-    <div>
-      <div className="title-hyphen">&nbsp;</div>
-      <h1 className="section-title section-title1 dark-title-1">
-        {index ? <span className="section-title-index">{index}</span> : null}
-        {translate ? <Translate value={title} /> : title}
-      </h1>
-    </div>
-  );
-};
-
-const level2 = (title, index, translate) => {
-  return (
-    <h2 className="section-title section-title-2 dark-title-1">
+const level1 = (title, index, translate) => (
+  <div>
+    <div className="title-hyphen">&nbsp;</div>
+    <h1 className="section-title section-title1 dark-title-1">
       {index ? <span className="section-title-index">{index}</span> : null}
       {translate ? <Translate value={title} /> : title}
-    </h2>
-  );
-};
+    </h1>
+  </div>
+);
 
-const level3 = (title, index, translate) => {
-  return (
-    <h3 className="section-title section-title-3 dark-title-1">
-      {index ? <span className="section-title-index">{index}</span> : null}
-      {translate ? <Translate value={title} /> : title}
-    </h3>
-  );
-};
+const level2 = (title, index, translate) => (
+  <h2 className="section-title section-title-2 dark-title-1">
+    {index ? <span className="section-title-index">{index}</span> : null}
+    {translate ? <Translate value={title} /> : title}
+  </h2>
+);
 
-const levelN = (title, index, translate) => {
-  return (
-    <h3 className="section-title section-title-3 dark-title-1">
-      {index ? <span className="section-title-index">{index}</span> : null}
-      {translate ? <Translate value={title} /> : title}
-    </h3>
-  );
-};
+const level3 = (title, index, translate) => (
+  <h3 className="section-title section-title-3 dark-title-1">
+    {index ? <span className="section-title-index">{index}</span> : null}
+    {translate ? <Translate value={title} /> : title}
+  </h3>
+);
+
+const levelN = (title, index, translate) => (
+  <h3 className="section-title section-title-3 dark-title-1">
+    {index ? <span className="section-title-index">{index}</span> : null}
+    {translate ? <Translate value={title} /> : title}
+  </h3>
+);
 
 const LEVELS = [level1, level2, level3];
 

--- a/assembl/static2/js/app/components/common/socialShare.jsx
+++ b/assembl/static2/js/app/components/common/socialShare.jsx
@@ -31,6 +31,7 @@ export default class SocialShare extends React.Component {
       copied: false
     };
   }
+
   render() {
     const { url, onClose, social } = this.props;
     const SocialNetworks = [
@@ -43,11 +44,9 @@ export default class SocialShare extends React.Component {
         Component: TelegramShareButton,
         iconName: 'telegram'
       }
-    ].map(({ Component, iconName }, index) => {
-      return (
-        <SuperShareButton Component={Component} Icon={generateShareIcon(iconName)} url={url} onClose={onClose} key={index} />
-      );
-    });
+    ].map(({ Component, iconName }, index) => (
+      <SuperShareButton Component={Component} Icon={generateShareIcon(iconName)} url={url} onClose={onClose} key={index} />
+    ));
 
     return (
       <div className="share-buttons-container">
@@ -60,12 +59,7 @@ export default class SocialShare extends React.Component {
             </div>
           </div>
         )}
-        <CopyToClipboard
-          text={url}
-          onCopy={() => {
-            return this.setState({ copied: true });
-          }}
-        >
+        <CopyToClipboard text={url} onCopy={() => this.setState({ copied: true })}>
           <button className="btn btn-default btn-copy">
             {this.state.copied ? I18n.t('debate.linkCopied') : I18n.t('debate.copyLink')}
           </button>

--- a/assembl/static2/js/app/components/common/switchButton.jsx
+++ b/assembl/static2/js/app/components/common/switchButton.jsx
@@ -17,6 +17,7 @@ type Props = {
 
 class SwitchButton extends React.Component<Object, Props, any> {
   static defaultProps: Object;
+
   static defaultProps = {
     id: '',
     name: 'switch-button',

--- a/assembl/static2/js/app/components/common/textWithHeaderPage.jsx
+++ b/assembl/static2/js/app/components/common/textWithHeaderPage.jsx
@@ -28,11 +28,9 @@ const DumbTextWithHeaderPage = (props: TextWithHeaderPageProps) => {
   );
 };
 
-const mapStateToProps = (state) => {
-  return {
-    debateData: state.debate.debateData
-  };
-};
+const mapStateToProps = state => ({
+  debateData: state.debate.debateData
+});
 
 export { DumbTextWithHeaderPage };
 

--- a/assembl/static2/js/app/components/common/tree.jsx
+++ b/assembl/static2/js/app/components/common/tree.jsx
@@ -46,9 +46,7 @@ class Child extends React.PureComponent {
   expandCollapse(event) {
     event.stopPropagation();
     this.setState(
-      (state) => {
-        return { expanded: !state.expanded };
-      },
+      state => ({ expanded: !state.expanded }),
       () => {
         this.resizeTreeHeight(0);
       }
@@ -269,58 +267,52 @@ class Tree extends React.Component {
     const { contentLocaleMapping, data, lang, noRowsRenderer } = this.props;
     return (
       <WindowScroller>
-        {({ height, isScrolling, onChildScroll, scrollTop }) => {
-          return (
-            <AutoSizer
-              disableHeight
-              onResize={() => {
-                this.cache.clearAll();
-                this.listRef.recomputeRowHeights();
-                this.nuggetsManager.update();
-              }}
-            >
-              {({ width }) => {
-                return (
-                  <List
-                    contentLocaleMapping={contentLocaleMapping}
-                    height={height}
-                    // pass lang to the List component to ensure that the rows are rendered again if we change the site language
-                    lang={lang}
-                    isScrolling={isScrolling}
-                    onScroll={onChildScroll}
-                    scrollTop={scrollTop}
-                    autoHeight
-                    rowHeight={this.cache.rowHeight}
-                    deferredMeasurementCache={this.cache}
-                    noRowsRenderer={noRowsRenderer}
-                    ref={(ref) => {
-                      // Add a guard because the List component's ref is recalculated many times onScroll
-                      // Causing other components that have listRef as prop to re-render 4x-6x times.
-                      if (!this.listRef) {
-                        this.listRef = ref;
-                      }
-                    }}
-                    rowCount={data.length}
-                    overscanIndicesGetter={this.overscanIndicesGetter}
-                    overscanRowCount={1}
-                    rowRenderer={this.cellRenderer}
-                    width={width}
-                    className="tree-list"
-                  />
-                );
-              }}
-            </AutoSizer>
-          );
-        }}
+        {({ height, isScrolling, onChildScroll, scrollTop }) => (
+          <AutoSizer
+            disableHeight
+            onResize={() => {
+              this.cache.clearAll();
+              this.listRef.recomputeRowHeights();
+              this.nuggetsManager.update();
+            }}
+          >
+            {({ width }) => (
+              <List
+                contentLocaleMapping={contentLocaleMapping}
+                height={height}
+                // pass lang to the List component to ensure that the rows are rendered again if we change the site language
+                lang={lang}
+                isScrolling={isScrolling}
+                onScroll={onChildScroll}
+                scrollTop={scrollTop}
+                autoHeight
+                rowHeight={this.cache.rowHeight}
+                deferredMeasurementCache={this.cache}
+                noRowsRenderer={noRowsRenderer}
+                ref={(ref) => {
+                  // Add a guard because the List component's ref is recalculated many times onScroll
+                  // Causing other components that have listRef as prop to re-render 4x-6x times.
+                  if (!this.listRef) {
+                    this.listRef = ref;
+                  }
+                }}
+                rowCount={data.length}
+                overscanIndicesGetter={this.overscanIndicesGetter}
+                overscanRowCount={1}
+                rowRenderer={this.cellRenderer}
+                width={width}
+                className="tree-list"
+              />
+            )}
+          </AutoSizer>
+        )}
       </WindowScroller>
     );
   }
 }
 
 Tree.defaultProps = {
-  InnerComponentFolded: () => {
-    return null;
-  }
+  InnerComponentFolded: () => null
 };
 
 export default Tree;

--- a/assembl/static2/js/app/components/common/txtAreaWithRemainingChars.jsx
+++ b/assembl/static2/js/app/components/common/txtAreaWithRemainingChars.jsx
@@ -12,25 +12,23 @@ export const TxtAreaWithRemainingChars = ({
   handleInputFocus,
   domId,
   textareaRef
-}) => {
-  return (
-    <div>
-      {value ? <div className="form-label">{label}</div> : null}
-      <FormControl
-        className="txt-area"
-        componentClass="textarea"
-        placeholder={label}
-        maxLength={maxLength}
-        rows={rows}
-        value={value}
-        onFocus={handleInputFocus || null}
-        onChange={handleTxtChange}
-        id={domId || 'txtarea'}
-        inputRef={textareaRef}
-      />
-      <div className="annotation margin-xs">
-        <Translate value="debate.remaining_x_characters" nbCharacters={remainingChars < 10000 ? remainingChars : maxLength} />
-      </div>
+}) => (
+  <div>
+    {value ? <div className="form-label">{label}</div> : null}
+    <FormControl
+      className="txt-area"
+      componentClass="textarea"
+      placeholder={label}
+      maxLength={maxLength}
+      rows={rows}
+      value={value}
+      onFocus={handleInputFocus || null}
+      onChange={handleTxtChange}
+      id={domId || 'txtarea'}
+      inputRef={textareaRef}
+    />
+    <div className="annotation margin-xs">
+      <Translate value="debate.remaining_x_characters" nbCharacters={remainingChars < 10000 ? remainingChars : maxLength} />
     </div>
-  );
-};
+  </div>
+);

--- a/assembl/static2/js/app/components/common/visibilityComponent.jsx
+++ b/assembl/static2/js/app/components/common/visibilityComponent.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-const VisibilityComponent = ({ classname, isVisible, children }) => {
-  return <div className={isVisible ? classname : 'hidden'}>{children}</div>;
-};
+const VisibilityComponent = ({ classname, isVisible, children }) => (
+  <div className={isVisible ? classname : 'hidden'}>{children}</div>
+);
 
 export default VisibilityComponent;

--- a/assembl/static2/js/app/components/common/withLoadingIndicator.jsx
+++ b/assembl/static2/js/app/components/common/withLoadingIndicator.jsx
@@ -5,15 +5,11 @@
 import React from 'react';
 import Loader from './loader';
 
-const withLoadingIndicator = (loaderProps = {}) => {
-  return (WrappedComponent) => {
-    return (props) => {
-      if (props.loading || (props.data && props.data.loading)) {
-        return <Loader {...loaderProps} />;
-      }
-      return <WrappedComponent {...props} />;
-    };
-  };
+const withLoadingIndicator = (loaderProps = {}) => WrappedComponent => (props) => {
+  if (props.loading || (props.data && props.data.loading)) {
+    return <Loader {...loaderProps} />;
+  }
+  return <WrappedComponent {...props} />;
 };
 
 export default withLoadingIndicator;

--- a/assembl/static2/js/app/components/common/withoutLoadingIndicator.jsx
+++ b/assembl/static2/js/app/components/common/withoutLoadingIndicator.jsx
@@ -4,15 +4,11 @@
 */
 import React from 'react';
 
-const withoutLoadingIndicator = () => {
-  return (WrappedComponent) => {
-    return (props) => {
-      if (props.loading || (props.data && props.data.loading)) {
-        return null;
-      }
-      return <WrappedComponent {...props} />;
-    };
-  };
+const withoutLoadingIndicator = () => WrappedComponent => (props) => {
+  if (props.loading || (props.data && props.data.loading)) {
+    return null;
+  }
+  return <WrappedComponent {...props} />;
 };
 
 export default withoutLoadingIndicator;

--- a/assembl/static2/js/app/components/debate/common/announcement.jsx
+++ b/assembl/static2/js/app/components/debate/common/announcement.jsx
@@ -10,13 +10,11 @@ import Media from '../../common/media';
 import { CountablePublicationStates } from '../../../constants';
 import PostsAndContributorsCount from '../../common/postsAndContributorsCount';
 
-export const createTooltip = (sentiment: SentimentDefinition, count: number) => {
-  return (
-    <Tooltip id={`${sentiment.camelType}Tooltip`} className="no-arrow-tooltip">
-      {count} <Translate value={`debate.${sentiment.camelType}`} />
-    </Tooltip>
-  );
-};
+export const createTooltip = (sentiment: SentimentDefinition, count: number) => (
+  <Tooltip id={`${sentiment.camelType}Tooltip`} className="no-arrow-tooltip">
+    {count} <Translate value={`debate.${sentiment.camelType}`} />
+  </Tooltip>
+);
 
 type SentimentsCounts = {
   [string]: {
@@ -36,27 +34,24 @@ export const getSentimentsCount = (posts: Posts) => {
   });
 
   return posts.edges
-    .filter(({ node: { publicationState } }) => {
-      return Object.keys(CountablePublicationStates).indexOf(publicationState) > -1;
-    })
-    .reduce((result, { node: { sentimentCounts } }) => {
-      return Object.keys(result).reduce((naziLinter, key) => {
-        const postCounts = naziLinter;
-        postCounts[key].count += sentimentCounts[key];
-        return postCounts;
-      }, result);
-    }, counters);
+    .filter(({ node: { publicationState } }) => Object.keys(CountablePublicationStates).indexOf(publicationState) > -1)
+    .reduce(
+      (result, { node: { sentimentCounts } }) =>
+        Object.keys(result).reduce((naziLinter, key) => {
+          const postCounts = naziLinter;
+          postCounts[key].count += sentimentCounts[key];
+          return postCounts;
+        }, result),
+      counters
+    );
 };
 
-export const createDoughnutElements = (sentimentCounts: SentimentsCounts) => {
-  return Object.keys(sentimentCounts).map((key) => {
-    return {
-      color: sentimentCounts[key].color,
-      count: sentimentCounts[key].count,
-      Tooltip: createTooltip(sentimentCounts[key], sentimentCounts[key].count)
-    };
-  });
-};
+export const createDoughnutElements = (sentimentCounts: SentimentsCounts) =>
+  Object.keys(sentimentCounts).map(key => ({
+    color: sentimentCounts[key].color,
+    count: sentimentCounts[key].count,
+    Tooltip: createTooltip(sentimentCounts[key], sentimentCounts[key].count)
+  }));
 
 const dirtySplitHack = (announcementContent) => {
   const body = announcementContent.body;
@@ -80,11 +75,10 @@ const dirtySplitHack = (announcementContent) => {
 class Announcement extends React.Component {
   getColumnInfos() {
     const { messageColumns } = this.props.ideaWithPostsData.idea;
-    const columnsArray = messageColumns.map((col) => {
-      return { count: col.numPosts, color: col.color, name: col.name };
-    });
+    const columnsArray = messageColumns.map(col => ({ count: col.numPosts, color: col.color, name: col.name }));
     return columnsArray;
   }
+
   render = () => {
     const { ideaWithPostsData: { idea }, announcementContent, isMultiColumns } = this.props;
     const { numContributors, numPosts, posts } = idea;
@@ -110,13 +104,11 @@ class Announcement extends React.Component {
             </div>
             {isMultiColumns ? (
               <div className="announcement-numbers-multicol">
-                {columnInfos.map((col, index) => {
-                  return (
-                    <div style={{ color: col.color }} key={`col-${index}`}>
-                      {col.count} <span className="col-announcement-count">{col.name}</span>
-                    </div>
-                  );
-                })}
+                {columnInfos.map((col, index) => (
+                  <div style={{ color: col.color }} key={`col-${index}`}>
+                    {col.count} <span className="col-announcement-count">{col.name}</span>
+                  </div>
+                ))}
                 <div className="color">
                   {numContributors} <span className="assembl-icon-profil" />
                 </div>

--- a/assembl/static2/js/app/components/debate/common/chatbot.jsx
+++ b/assembl/static2/js/app/components/debate/common/chatbot.jsx
@@ -19,15 +19,12 @@ class Chatbot extends React.Component {
       };
     };
   };
-  render = () => {
-    return false;
-  };
+
+  render = () => false;
 }
 
-const mapStateToProps = (state) => {
-  return {
-    args: state.debate.debateData.motionChatbot
-  };
-};
+const mapStateToProps = state => ({
+  args: state.debate.debateData.motionChatbot
+});
 
 export default connect(mapStateToProps)(Chatbot);

--- a/assembl/static2/js/app/components/debate/common/deletedPost.jsx
+++ b/assembl/static2/js/app/components/debate/common/deletedPost.jsx
@@ -10,21 +10,19 @@ type DeletedPostProps = {
   deletedBy: DeletedByType
 };
 
-const DeletedPost = ({ id, subject, deletedBy }: DeletedPostProps): React.Element<*> => {
-  return (
-    <div className="posts deleted-post" id={id}>
-      <div className="box">
-        <Row className="post-row">
-          <Col xs={12} md={12} className="post-left">
-            <h3 className="dark-title-3">{subject}</h3>
-            <div className="body">
-              <Translate value={deletedBy === 'user' ? 'debate.thread.postDeletedByUser' : 'debate.thread.postDeletedByAdmin'} />
-            </div>
-          </Col>
-        </Row>
-      </div>
+const DeletedPost = ({ id, subject, deletedBy }: DeletedPostProps): React.Element<*> => (
+  <div className="posts deleted-post" id={id}>
+    <div className="box">
+      <Row className="post-row">
+        <Col xs={12} md={12} className="post-left">
+          <h3 className="dark-title-3">{subject}</h3>
+          <div className="body">
+            <Translate value={deletedBy === 'user' ? 'debate.thread.postDeletedByUser' : 'debate.thread.postDeletedByAdmin'} />
+          </div>
+        </Col>
+      </Row>
     </div>
-  );
-};
+  </div>
+);
 
 export default DeletedPost;

--- a/assembl/static2/js/app/components/debate/common/editPostForm.jsx
+++ b/assembl/static2/js/app/components/debate/common/editPostForm.jsx
@@ -36,6 +36,7 @@ type EditPostFormState = {
 
 class EditPostForm extends React.PureComponent<void, EditPostFormProps, EditPostFormState> {
   props: EditPostFormProps;
+
   state: EditPostFormState;
 
   constructor(props: EditPostFormProps) {

--- a/assembl/static2/js/app/components/debate/common/ideaPreview.jsx
+++ b/assembl/static2/js/app/components/debate/common/ideaPreview.jsx
@@ -15,55 +15,53 @@ const IdeaPreview = ({
   ideaId,
   ideaLevel,
   ideaIndex
-}) => {
-  return (
-    <div
-      className={
-        selectedIdeasId.indexOf(ideaId) > -1
-          ? `illustration-box idea-preview idea-preview-level-${ideaLevel} idea-preview-selected`
-          : `illustration-box idea-preview idea-preview-level-${ideaLevel}`
-      }
-    >
-      <div className="image-box" style={imgUrl ? { backgroundImage: `url(${imgUrl})` } : null} />
-      <div className="content-box" to={link}>
-        <h3 className="light-title-3 center">{title}</h3>
-        <div className="access-discussion">
-          <div className="see-discussion">
-            <Link to={link}>
-              <Translate value="debate.thread.goToIdea" />
-            </Link>
-          </div>
-          {numChildren ? (
-            <div>
-              <div>/</div>
-              <div
-                className="see-sub-ideas"
-                onClick={() => {
-                  setSelectedIdeas(ideaId, ideaLevel, ideaIndex);
-                  const scrollPosition = document.documentElement.scrollTop || document.body.scrollTop;
-                  const scrollValue = scrollPosition + 500;
-                  setTimeout(() => {
-                    window.scrollTo({ top: scrollValue, left: 0, behavior: 'smooth' });
-                  }, 500);
-                }}
-              >
-                <Translate value="debate.thread.seeSubIdeas" count={numChildren} />
-              </div>
+}) => (
+  <div
+    className={
+      selectedIdeasId.indexOf(ideaId) > -1
+        ? `illustration-box idea-preview idea-preview-level-${ideaLevel} idea-preview-selected`
+        : `illustration-box idea-preview idea-preview-level-${ideaLevel}`
+    }
+  >
+    <div className="image-box" style={imgUrl ? { backgroundImage: `url(${imgUrl})` } : null} />
+    <div className="content-box" to={link}>
+      <h3 className="light-title-3 center">{title}</h3>
+      <div className="access-discussion">
+        <div className="see-discussion">
+          <Link to={link}>
+            <Translate value="debate.thread.goToIdea" />
+          </Link>
+        </div>
+        {numChildren ? (
+          <div>
+            <div>/</div>
+            <div
+              className="see-sub-ideas"
+              onClick={() => {
+                setSelectedIdeas(ideaId, ideaLevel, ideaIndex);
+                const scrollPosition = document.documentElement.scrollTop || document.body.scrollTop;
+                const scrollValue = scrollPosition + 500;
+                setTimeout(() => {
+                  window.scrollTo({ top: scrollValue, left: 0, behavior: 'smooth' });
+                }, 500);
+              }}
+            >
+              <Translate value="debate.thread.seeSubIdeas" count={numChildren} />
             </div>
-          ) : (
-            <div />
-          )}
-        </div>
-        <div className="selected-idea-arrow">
-          <span className="assembl-icon-down-open" />
-        </div>
-        <Statistic numPosts={numPosts} numContributors={numContributors} />
+          </div>
+        ) : (
+          <div />
+        )}
       </div>
-      <div className="color-box">&nbsp;</div>
-      <div className="box-hyphen">&nbsp;</div>
-      <div className="box-hyphen rotate-hyphen">&nbsp;</div>
+      <div className="selected-idea-arrow">
+        <span className="assembl-icon-down-open" />
+      </div>
+      <Statistic numPosts={numPosts} numContributors={numContributors} />
     </div>
-  );
-};
+    <div className="color-box">&nbsp;</div>
+    <div className="box-hyphen">&nbsp;</div>
+    <div className="box-hyphen rotate-hyphen">&nbsp;</div>
+  </div>
+);
 
 export default IdeaPreview;

--- a/assembl/static2/js/app/components/debate/common/ideas.jsx
+++ b/assembl/static2/js/app/components/debate/common/ideas.jsx
@@ -11,6 +11,7 @@ class Ideas extends React.Component {
     this.getIdeaChildren = this.getIdeaChildren.bind(this);
     this.setSelectedIdeas = this.setSelectedIdeas.bind(this);
   }
+
   setSelectedIdeas(selectedIdeaId, ideaLevel, ideaIndex) {
     const nbLevel = this.state.selectedIdeasId.length;
     const ideasArray = this.state.selectedIdeasId;
@@ -28,12 +29,12 @@ class Ideas extends React.Component {
       });
     }
   }
+
   getIdeaChildren(selectedIdeaId) {
     const { ideas } = this.props;
-    return ideas.filter((idea) => {
-      return idea.parentId === selectedIdeaId;
-    });
+    return ideas.filter(idea => idea.parentId === selectedIdeaId);
   }
+
   render() {
     const { identifier } = this.props;
     return (
@@ -47,20 +48,18 @@ class Ideas extends React.Component {
               </h1>
             </div>
             <div className="content-section">
-              {this.state.selectedIdeasId.map((ideaId, index) => {
-                return (
-                  <IdeasLevel
-                    ideas={this.getIdeaChildren(ideaId)}
-                    identifier={identifier}
-                    setSelectedIdeas={this.setSelectedIdeas}
-                    nbLevel={this.state.selectedIdeasId.length}
-                    ideaLevel={index + 1}
-                    key={index}
-                    selectedIdeasId={this.state.selectedIdeasId}
-                    selectedIdeaIndex={this.state.selectedIdeaIndex}
-                  />
-                );
-              })}
+              {this.state.selectedIdeasId.map((ideaId, index) => (
+                <IdeasLevel
+                  ideas={this.getIdeaChildren(ideaId)}
+                  identifier={identifier}
+                  setSelectedIdeas={this.setSelectedIdeas}
+                  nbLevel={this.state.selectedIdeasId.length}
+                  ideaLevel={index + 1}
+                  key={index}
+                  selectedIdeasId={this.state.selectedIdeasId}
+                  selectedIdeaIndex={this.state.selectedIdeaIndex}
+                />
+              ))}
             </div>
           </div>
         </Grid>

--- a/assembl/static2/js/app/components/debate/common/ideasLevel.jsx
+++ b/assembl/static2/js/app/components/debate/common/ideasLevel.jsx
@@ -41,6 +41,7 @@ class IdeasLevel extends React.Component {
   componentDidMount() {
     this.runFirstTransition();
   }
+
   componentWillReceiveProps(nextProps) {
     if (nextProps.screenWidth !== this.props.screenWidth) this.updateDimensions();
     const { ideaLevel, nbLevel, selectedIdeaIndex } = nextProps;
@@ -55,13 +56,16 @@ class IdeasLevel extends React.Component {
       }, 500);
     }
   }
+
   componentWillUnmount() {
     this.timeouts.forEach(clearTimeout);
     this.timeouts = [];
   }
+
   setTimeout = (func, duration) => {
     this.timeouts.push(setTimeout(func, duration));
   };
+
   setDimensions = () => {
     const { screenWidth } = this.props;
     if (screenWidth > APP_CONTAINER_MAX_WIDTH) {
@@ -84,6 +88,7 @@ class IdeasLevel extends React.Component {
       }
     }
   };
+
   updateDimensions = () => {
     this.setState(
       {
@@ -93,6 +98,7 @@ class IdeasLevel extends React.Component {
       this.setDimensions
     );
   };
+
   getColClassNames(index) {
     const { ideaLevel } = this.props;
     const isFirsStepActif = ideaLevel <= 1;
@@ -105,6 +111,7 @@ class IdeasLevel extends React.Component {
       { 'theme-inline': !isFirsStepActif }
     );
   }
+
   getRightOverflowValue() {
     const { screenWidth } = this.props;
     const { sliderContainerWidth, ideaPreviewWidth } = this.state;
@@ -127,15 +134,18 @@ class IdeasLevel extends React.Component {
     }
     return rightOverflowValue;
   }
+
   getSliderWidth() {
     const { ideas } = this.props;
     const { ideaPreviewWidth } = this.state;
     return ideas.length * ideaPreviewWidth;
   }
+
   getSliderHiddenWidth() {
     const { sliderContainerWidth } = this.state;
     return this.getSliderWidth() - sliderContainerWidth;
   }
+
   getLastMovingValue() {
     const { ideas } = this.props;
     const { ideaPreviewWidth } = this.state;
@@ -144,6 +154,7 @@ class IdeasLevel extends React.Component {
     }
     return ideaPreviewWidth - this.getRightOverflowValue() / 2;
   }
+
   moveToSelectedIdea(selectedIdeaIndex) {
     const { ideas } = this.props;
     const { sliderLeftPosition, ideaPreviewWidth } = this.state;
@@ -164,6 +175,7 @@ class IdeasLevel extends React.Component {
       this.setState({ sliderLeftPosition: left });
     }
   }
+
   runFirstTransition() {
     const { nbLevel } = this.props;
     const themes = document.getElementById('row-1').getElementsByClassName('theme');
@@ -175,19 +187,23 @@ class IdeasLevel extends React.Component {
       }, 10);
     }
   }
+
   runBottomTransition(sliderMarginTop, duration) {
     this.setTimeout(() => {
       this.setState({ sliderMarginTop: sliderMarginTop });
     }, duration);
   }
+
   isLeftLimitReached() {
     const { sliderLeftPosition } = this.state;
     return sliderLeftPosition === this.getLastMovingValue();
   }
+
   isRightLimitReached() {
     const { sliderLeftPosition } = this.state;
     return sliderLeftPosition >= this.getSliderHiddenWidth();
   }
+
   handleClickArrowLeft() {
     const { ideas } = this.props;
     const { sliderCount, sliderLeftPosition, ideaPreviewWidth } = this.state;
@@ -206,6 +222,7 @@ class IdeasLevel extends React.Component {
     this.setState({ sliderCount: count });
     this.setState({ sliderLeftPosition: left });
   }
+
   handleClickArrowRight() {
     const { ideas } = this.props;
     const { sliderCount, sliderLeftPosition, ideaPreviewWidth } = this.state;
@@ -222,6 +239,7 @@ class IdeasLevel extends React.Component {
     this.setState({ sliderCount: count });
     this.setState({ sliderLeftPosition: left });
   }
+
   render() {
     const { ideas, identifier, setSelectedIdeas, nbLevel, ideaLevel, selectedIdeasId } = this.props;
     const { sliderLeftPosition, sliderCount, sliderContainerWidth, ideaPreviewWidth, sliderMarginTop } = this.state;
@@ -265,37 +283,35 @@ class IdeasLevel extends React.Component {
           }
         >
           <Row id={`row-${ideaLevel}`} className={nbLevel > 1 ? 'no-margin row-inline' : 'no-margin'}>
-            {ideas.map((idea, index) => {
-              return (
-                <Col
-                  xs={xsCol}
-                  sm={smCol}
-                  md={mdCol}
-                  key={index}
-                  className={this.getColClassNames(index)}
-                  style={nbLevel > 1 ? { width: ideaPreviewWidth } : {}}
-                >
-                  <IdeaPreview
-                    imgUrl={idea.img ? idea.img.externalUrl : ''}
-                    numPosts={idea.numPosts}
-                    numContributors={idea.numContributors}
-                    numChildren={idea.numChildren}
-                    link={`${getRoute('debate', { slug: slug, phase: identifier })}${getRoute('theme', { themeId: idea.id })}`}
-                    title={truncate(idea.title, {
-                      length: stringMaxLength(ideaLevel),
-                      separator: ' ',
-                      omission: '...'
-                    })}
-                    description={idea.description}
-                    setSelectedIdeas={setSelectedIdeas}
-                    ideaId={idea.id}
-                    ideaLevel={ideaLevel}
-                    selectedIdeasId={selectedIdeasId}
-                    ideaIndex={index}
-                  />
-                </Col>
-              );
-            })}
+            {ideas.map((idea, index) => (
+              <Col
+                xs={xsCol}
+                sm={smCol}
+                md={mdCol}
+                key={index}
+                className={this.getColClassNames(index)}
+                style={nbLevel > 1 ? { width: ideaPreviewWidth } : {}}
+              >
+                <IdeaPreview
+                  imgUrl={idea.img ? idea.img.externalUrl : ''}
+                  numPosts={idea.numPosts}
+                  numContributors={idea.numContributors}
+                  numChildren={idea.numChildren}
+                  link={`${getRoute('debate', { slug: slug, phase: identifier })}${getRoute('theme', { themeId: idea.id })}`}
+                  title={truncate(idea.title, {
+                    length: stringMaxLength(ideaLevel),
+                    separator: ' ',
+                    omission: '...'
+                  })}
+                  description={idea.description}
+                  setSelectedIdeas={setSelectedIdeas}
+                  ideaId={idea.id}
+                  ideaLevel={ideaLevel}
+                  selectedIdeasId={selectedIdeasId}
+                  ideaIndex={index}
+                />
+              </Col>
+            ))}
           </Row>
         </div>
         <VisibilityComponent isVisible={isArrowVisible && nbLevel > 1 && !isRightLimitReached} classname="slider-arrow-container">

--- a/assembl/static2/js/app/components/debate/common/overflowMenu.jsx
+++ b/assembl/static2/js/app/components/debate/common/overflowMenu.jsx
@@ -31,12 +31,7 @@ const confirmModal = (postId, client) => {
 
 const getOverflowMenuForPost = (postId, userCanDeleteThisMessage, userCanEditThisMessage, client, handleEditClick) => {
   const deleteButton = (
-    <Link
-      className="overflow-menu-action"
-      onClick={() => {
-        return confirmModal(postId, client);
-      }}
-    >
+    <Link className="overflow-menu-action" onClick={() => confirmModal(postId, client)}>
       <span className="assembl-icon-delete" />
     </Link>
   );

--- a/assembl/static2/js/app/components/debate/common/postActions.jsx
+++ b/assembl/static2/js/app/components/debate/common/postActions.jsx
@@ -21,6 +21,7 @@ class PostActions extends React.Component {
     super(props);
     this.displayPhaseCompletedModal = this.displayPhaseCompletedModal.bind(this);
   }
+
   displayPhaseCompletedModal() {
     const body = (
       <div>
@@ -29,6 +30,7 @@ class PostActions extends React.Component {
     );
     displayModal(null, body, true, null, null, true);
   }
+
   render() {
     const {
       client,
@@ -83,14 +85,14 @@ class PostActions extends React.Component {
         <div className="post-icons">
           <div
             className="post-action"
-            onClick={() => {
-              return openShareModal({
+            onClick={() =>
+              openShareModal({
                 title: modalTitle,
                 routerParams: routerParams,
                 elementId: postId,
                 social: useSocial
-              });
-            }}
+              })
+            }
           >
             <ResponsiveOverlayTrigger placement={tooltipPlacement} tooltip={sharePostTooltip} component={shareIcon} />
           </div>

--- a/assembl/static2/js/app/components/debate/common/sentimentStats.jsx
+++ b/assembl/static2/js/app/components/debate/common/sentimentStats.jsx
@@ -3,31 +3,29 @@ import { Popover } from 'react-bootstrap';
 import Gauge from '../../svg/gauge';
 import sentimentDefinitions from './sentimentDefinitions';
 
-const getSentimentDetails = (totalSentimentsCount, sentimentCounts, mySentiment) => {
-  return (
-    <Popover id="sentiment-count-popover" className="sentiments-popover">
-      {sentimentDefinitions.map((sentiment) => {
-        const rectCounts = Math.round(sentimentCounts[sentiment.camelType] * 10 / totalSentimentsCount);
-        return (
-          <div className="gauge" key={sentiment.type}>
+const getSentimentDetails = (totalSentimentsCount, sentimentCounts, mySentiment) => (
+  <Popover id="sentiment-count-popover" className="sentiments-popover">
+    {sentimentDefinitions.map((sentiment) => {
+      const rectCounts = Math.round(sentimentCounts[sentiment.camelType] * 10 / totalSentimentsCount);
+      return (
+        <div className="gauge" key={sentiment.type}>
+          <div>
+            <div className={sentiment.type === mySentiment ? 'sentiment sentiment-active' : 'sentiment'}>
+              <sentiment.SvgComponent size={20} />
+            </div>
             <div>
-              <div className={sentiment.type === mySentiment ? 'sentiment sentiment-active' : 'sentiment'}>
-                <sentiment.SvgComponent size={20} />
-              </div>
-              <div>
-                <div className="gauge-count" style={{ color: sentiment.color }}>
-                  {sentimentCounts[sentiment.camelType]}
-                </div>
-              </div>
-              <div>
-                <Gauge rectCounts={rectCounts} color={sentiment.color} />
+              <div className="gauge-count" style={{ color: sentiment.color }}>
+                {sentimentCounts[sentiment.camelType]}
               </div>
             </div>
+            <div>
+              <Gauge rectCounts={rectCounts} color={sentiment.color} />
+            </div>
           </div>
-        );
-      })}
-    </Popover>
-  );
-};
+        </div>
+      );
+    })}
+  </Popover>
+);
 
 export default getSentimentDetails;

--- a/assembl/static2/js/app/components/debate/common/sentiments.jsx
+++ b/assembl/static2/js/app/components/debate/common/sentiments.jsx
@@ -89,24 +89,20 @@ const Sentiment = ({ sentimentCounts, mySentiment, sentiment, client, isSelected
   return <ResponsiveOverlayTrigger placement={placement} tooltip={sentiment.tooltip} component={sentimentComponent} />;
 };
 
-export default ({ sentimentCounts, mySentiment, client, postId, placement, isPhaseCompleted }) => {
-  return (
-    <div className="add-sentiment">
-      {sentimentDefinitions.map((sentiment) => {
-        return (
-          <Sentiment
-            key={sentiment.type}
-            sentimentCounts={sentimentCounts}
-            mySentiment={mySentiment}
-            sentiment={sentiment}
-            isSelected={mySentiment === sentiment.type}
-            postId={postId}
-            client={client}
-            placement={placement}
-            isPhaseCompleted={isPhaseCompleted}
-          />
-        );
-      })}
-    </div>
-  );
-};
+export default ({ sentimentCounts, mySentiment, client, postId, placement, isPhaseCompleted }) => (
+  <div className="add-sentiment">
+    {sentimentDefinitions.map(sentiment => (
+      <Sentiment
+        key={sentiment.type}
+        sentimentCounts={sentimentCounts}
+        mySentiment={mySentiment}
+        sentiment={sentiment}
+        isSelected={mySentiment === sentiment.type}
+        postId={postId}
+        client={client}
+        placement={placement}
+        isPhaseCompleted={isPhaseCompleted}
+      />
+    ))}
+  </div>
+);

--- a/assembl/static2/js/app/components/debate/common/statisticsDoughnut.jsx
+++ b/assembl/static2/js/app/components/debate/common/statisticsDoughnut.jsx
@@ -4,9 +4,7 @@ import { Translate } from 'react-redux-i18n';
 import Doughnut from '../../svg/doughnut';
 
 const StatisticsDoughnut = ({ elements, placement }) => {
-  const totalCount = elements.reduce((result, element) => {
-    return result + element.count;
-  }, 0);
+  const totalCount = elements.reduce((result, element) => result + element.count, 0);
   const placeAfter = placement === 'after';
   const className = placeAfter ? 'after' : 'superpose';
   return (

--- a/assembl/static2/js/app/components/debate/common/themes.jsx
+++ b/assembl/static2/js/app/components/debate/common/themes.jsx
@@ -10,6 +10,7 @@ class Themes extends React.Component {
     super(props);
     this.getColClassNames = this.getColClassNames.bind(this);
   }
+
   getColClassNames(index) {
     this.index = index;
     let styles = 'theme';
@@ -23,6 +24,7 @@ class Themes extends React.Component {
     }
     return styles;
   }
+
   render() {
     const { thematics, identifier } = this.props;
     const slug = getDiscussionSlug();
@@ -38,20 +40,18 @@ class Themes extends React.Component {
             </div>
             <div className="content-section">
               <Row className="no-margin">
-                {thematics.map((thematic, index) => {
-                  return (
-                    <Col xs={12} sm={6} md={3} className={this.getColClassNames(index)} key={index}>
-                      <ThematicPreview
-                        imgUrl={thematic.img ? thematic.img.externalUrl : ''}
-                        numPosts={thematic.numPosts}
-                        numContributors={thematic.numContributors}
-                        link={`${get('debate', { slug: slug, phase: identifier })}${get('theme', { themeId: thematic.id })}`}
-                        title={thematic.title}
-                        description={thematic.description}
-                      />
-                    </Col>
-                  );
-                })}
+                {thematics.map((thematic, index) => (
+                  <Col xs={12} sm={6} md={3} className={this.getColClassNames(index)} key={index}>
+                    <ThematicPreview
+                      imgUrl={thematic.img ? thematic.img.externalUrl : ''}
+                      numPosts={thematic.numPosts}
+                      numContributors={thematic.numContributors}
+                      link={`${get('debate', { slug: slug, phase: identifier })}${get('theme', { themeId: thematic.id })}`}
+                      title={thematic.title}
+                      description={thematic.description}
+                    />
+                  </Col>
+                ))}
               </Row>
             </div>
           </div>

--- a/assembl/static2/js/app/components/debate/common/topPostForm.jsx
+++ b/assembl/static2/js/app/components/debate/common/topPostForm.jsx
@@ -39,7 +39,9 @@ type TopPostFormState = {
 
 class TopPostForm extends React.Component<*, TopPostFormProps, TopPostFormState> {
   props: TopPostFormProps;
+
   state: TopPostFormState;
+
   formContainer: HTMLDivElement | void;
 
   static defaultProps = {
@@ -118,9 +120,7 @@ class TopPostForm extends React.Component<*, TopPostFormProps, TopPostFormState>
     }
   };
 
-  handleInputFocus = promptForLoginOr(() => {
-    return this.displayForm(true);
-  });
+  handleInputFocus = promptForLoginOr(() => this.displayForm(true));
 
   updateBody = (newValue) => {
     this.setState({
@@ -196,11 +196,9 @@ class TopPostForm extends React.Component<*, TopPostFormProps, TopPostFormState>
   }
 }
 
-const mapStateToProps = (state) => {
-  return {
-    contentLocale: state.i18n.locale
-  };
-};
+const mapStateToProps = state => ({
+  contentLocale: state.i18n.locale
+});
 
 export default compose(
   connect(mapStateToProps),

--- a/assembl/static2/js/app/components/debate/common/topPostFormContainer.jsx
+++ b/assembl/static2/js/app/components/debate/common/topPostFormContainer.jsx
@@ -12,6 +12,7 @@ class TopPostFormContainer extends React.Component {
     const { messageColumns = [], isColumnViewInline } = this.props;
     return classNames({ 'columns-view': messageColumns.length > 1 }, { 'columns-view-inline': isColumnViewInline });
   }
+
   getColumnsInfos() {
     const { messageColumns = [] } = this.props;
     let columnsInfos = [];
@@ -23,6 +24,7 @@ class TopPostFormContainer extends React.Component {
 
     return columnsInfos;
   }
+
   render() {
     const { ideaId, refetchIdea, messageColumns = [], isColumnViewInline } = this.props;
     const columnsInfos = this.getColumnsInfos();
@@ -31,61 +33,59 @@ class TopPostFormContainer extends React.Component {
         <div className="max-container">
           <Row>
             <div className={this.getClassNames()}>
-              {columnsInfos.map((column) => {
-                return (
-                  <Col
-                    xs={12}
-                    md={12 / columnsInfos.length}
-                    key={column.messageClassifier}
-                    style={isColumnViewInline ? { width: MIN_WIDTH_COLUMN } : {}}
+              {columnsInfos.map(column => (
+                <Col
+                  xs={12}
+                  md={12 / columnsInfos.length}
+                  key={column.messageClassifier}
+                  style={isColumnViewInline ? { width: MIN_WIDTH_COLUMN } : {}}
+                >
+                  <div
+                    className="top-post-form"
+                    style={messageColumns.length > 1 ? { backgroundColor: `rgba(${hexToRgb(column.color)},0.2)` } : {}}
                   >
-                    <div
-                      className="top-post-form"
-                      style={messageColumns.length > 1 ? { backgroundColor: `rgba(${hexToRgb(column.color)},0.2)` } : {}}
-                    >
-                      <Row>
-                        <Col
-                          xs={12}
-                          sm={messageColumns.length > 1 ? 10 : 3}
-                          md={messageColumns.length > 1 ? 10 : 2}
-                          smOffset={messageColumns.length > 1 ? 1 : 1}
-                          mdOffset={messageColumns.length > 1 ? 1 : 2}
-                          className="no-padding"
-                        >
-                          <div className="start-discussion-container">
-                            <div className="start-discussion-icon">
-                              <span className="assembl-icon-discussion color" />
-                            </div>
-                            <div
-                              className={
-                                messageColumns.length > 1 ? 'start-discussion start-discussion-multicol' : 'start-discussion'
-                              }
-                            >
-                              <h3 className="dark-title-3 no-margin">
-                                {messageColumns.length > 1 ? column.name : <Translate value="debate.thread.startDiscussion" />}
-                              </h3>
-                            </div>
+                    <Row>
+                      <Col
+                        xs={12}
+                        sm={messageColumns.length > 1 ? 10 : 3}
+                        md={messageColumns.length > 1 ? 10 : 2}
+                        smOffset={messageColumns.length > 1 ? 1 : 1}
+                        mdOffset={messageColumns.length > 1 ? 1 : 2}
+                        className="no-padding"
+                      >
+                        <div className="start-discussion-container">
+                          <div className="start-discussion-icon">
+                            <span className="assembl-icon-discussion color" />
                           </div>
-                        </Col>
-                        <Col
-                          xs={12}
-                          sm={messageColumns.length > 1 ? 10 : 7}
-                          md={messageColumns.length > 1 ? 10 : 6}
-                          mdOffset={messageColumns.length > 1 ? 1 : 0}
-                          className="no-padding"
-                        >
-                          <TopPostForm
-                            ideaId={ideaId}
-                            refetchIdea={refetchIdea}
-                            ideaOnColumn={messageColumns.length > 1}
-                            messageClassifier={column.messageClassifier || null}
-                          />
-                        </Col>
-                      </Row>
-                    </div>
-                  </Col>
-                );
-              })}
+                          <div
+                            className={
+                              messageColumns.length > 1 ? 'start-discussion start-discussion-multicol' : 'start-discussion'
+                            }
+                          >
+                            <h3 className="dark-title-3 no-margin">
+                              {messageColumns.length > 1 ? column.name : <Translate value="debate.thread.startDiscussion" />}
+                            </h3>
+                          </div>
+                        </div>
+                      </Col>
+                      <Col
+                        xs={12}
+                        sm={messageColumns.length > 1 ? 10 : 7}
+                        md={messageColumns.length > 1 ? 10 : 6}
+                        mdOffset={messageColumns.length > 1 ? 1 : 0}
+                        className="no-padding"
+                      >
+                        <TopPostForm
+                          ideaId={ideaId}
+                          refetchIdea={refetchIdea}
+                          ideaOnColumn={messageColumns.length > 1}
+                          messageClassifier={column.messageClassifier || null}
+                        />
+                      </Col>
+                    </Row>
+                  </div>
+                </Col>
+              ))}
             </div>
           </Row>
         </div>

--- a/assembl/static2/js/app/components/debate/common/translations/cancelTranslationForm.jsx
+++ b/assembl/static2/js/app/components/debate/common/translations/cancelTranslationForm.jsx
@@ -20,6 +20,7 @@ type CancelTranslationFormState = {
 
 class CancelTranslationForm extends React.Component<*, CancelTranslationFormProps, CancelTranslationFormState> {
   props: CancelTranslationFormProps;
+
   state: CancelTranslationFormState;
 
   constructor() {
@@ -64,9 +65,7 @@ class CancelTranslationForm extends React.Component<*, CancelTranslationFormProp
                 checked={scope === 'global'}
                 title={untranslateAllLabel}
                 value="global"
-                onChange={() => {
-                  return this.updateScope('global');
-                }}
+                onChange={() => this.updateScope('global')}
               >
                 {untranslateAllLabel}
               </Radio>
@@ -76,9 +75,7 @@ class CancelTranslationForm extends React.Component<*, CancelTranslationFormProp
                 checked={scope === 'local'}
                 title={untranslateOneLabel}
                 value="local"
-                onChange={() => {
-                  return this.updateScope('local');
-                }}
+                onChange={() => this.updateScope('local')}
               >
                 {untranslateOneLabel}
               </Radio>

--- a/assembl/static2/js/app/components/debate/common/translations/chooseContentLocaleForm.jsx
+++ b/assembl/static2/js/app/components/debate/common/translations/chooseContentLocaleForm.jsx
@@ -27,6 +27,7 @@ type ChooseContentLocaleFormState = {
 
 class ChooseContentLocaleForm extends React.Component<*, ChooseContentLocaleFormProps, ChooseContentLocaleFormState> {
   props: ChooseContentLocaleFormProps;
+
   state: ChooseContentLocaleFormState;
 
   constructor() {
@@ -67,9 +68,7 @@ class ChooseContentLocaleForm extends React.Component<*, ChooseContentLocaleForm
       language: originalLocaleLabel
     });
     const translateOneLabel = I18n.t('debate.thread.translateOnlyThisMessage');
-    const availableLanguages = allLocales.filter((lang) => {
-      return lang.localeCode !== originalLocale;
-    });
+    const availableLanguages = allLocales.filter(lang => lang.localeCode !== originalLocale);
     return (
       <div className="choose-content-locale-form">
         <Modal.Header closeButton />
@@ -80,9 +79,7 @@ class ChooseContentLocaleForm extends React.Component<*, ChooseContentLocaleForm
                 checked={scope === 'global'}
                 title={translateAllLabel}
                 value="global"
-                onChange={() => {
-                  return this.updateScope('global');
-                }}
+                onChange={() => this.updateScope('global')}
               >
                 {translateAllLabel}
               </Radio>
@@ -92,9 +89,7 @@ class ChooseContentLocaleForm extends React.Component<*, ChooseContentLocaleForm
                 checked={scope === 'local'}
                 title={translateOneLabel}
                 value="local"
-                onChange={() => {
-                  return this.updateScope('local');
-                }}
+                onChange={() => this.updateScope('local')}
               >
                 {translateOneLabel}
               </Radio>
@@ -113,13 +108,11 @@ class ChooseContentLocaleForm extends React.Component<*, ChooseContentLocaleForm
                 value={selectedLocale}
               >
                 <option value="select">{I18n.t('debate.thread.chooseLanguagePh')}</option>
-                {availableLanguages.map((lang) => {
-                  return (
-                    <option key={`locale-${lang.localeCode}`} value={lang.localeCode}>
-                      {lang.label}
-                    </option>
-                  );
-                })}
+                {availableLanguages.map(lang => (
+                  <option key={`locale-${lang.localeCode}`} value={lang.localeCode}>
+                    {lang.label}
+                  </option>
+                ))}
               </FormControl>
             </FormGroup>
           ) : null}

--- a/assembl/static2/js/app/components/debate/common/translations/postTranslate.jsx
+++ b/assembl/static2/js/app/components/debate/common/translations/postTranslate.jsx
@@ -30,7 +30,9 @@ type PostTranslateState = {
 
 class PostTranslate extends React.Component<void, PostTranslateProps, PostTranslateState> {
   props: PostTranslateProps;
+
   state: PostTranslateState;
+
   originalLocaleLabel: '';
 
   constructor() {
@@ -54,9 +56,7 @@ class PostTranslate extends React.Component<void, PostTranslateProps, PostTransl
     // TODO: i'm aware that it is costly to use .find for each post. The improvement
     // I imagine is to use redux to store the locales as a mapping but the main obstacle
     // is to find which component should do the graphql query to update the redux store
-    const originalLocaleInfo = props.data.locales.find((locale) => {
-      return locale.localeCode === props.originalLocale;
-    });
+    const originalLocaleInfo = props.data.locales.find(locale => locale.localeCode === props.originalLocale);
     if (originalLocaleInfo) {
       this.originalLocaleLabel = originalLocaleInfo.label;
     }
@@ -139,23 +139,15 @@ class PostTranslate extends React.Component<void, PostTranslateProps, PostTransl
   }
 }
 
-const mapDispatchToProps = (dispatch, ownProps) => {
-  return {
-    updateById: (value) => {
-      return dispatch(updateContentLocaleById(ownProps.id, value));
-    },
-    updateByOriginalLocale: (value) => {
-      return dispatch(updateContentLocaleByOriginalLocale(ownProps.originalLocale, value));
-    }
-  };
-};
+const mapDispatchToProps = (dispatch, ownProps) => ({
+  updateById: value => dispatch(updateContentLocaleById(ownProps.id, value)),
+  updateByOriginalLocale: value => dispatch(updateContentLocaleByOriginalLocale(ownProps.originalLocale, value))
+});
 
 export default compose(
   graphql(LocalesQuery, {
     // $FlowFixMe (flow, eslint (and even prettier!) are kind of conflicting here)
-    options: () => {
-      return { notifyOnNetworkStatusChange: true };
-    }
+    options: () => ({ notifyOnNetworkStatusChange: true })
   }),
   connect(null, mapDispatchToProps),
   withoutLoadingIndicator()

--- a/assembl/static2/js/app/components/debate/common/whatYouNeedToKnow.jsx
+++ b/assembl/static2/js/app/components/debate/common/whatYouNeedToKnow.jsx
@@ -1,21 +1,19 @@
 import React from 'react';
 import { Translate } from 'react-redux-i18n';
 
-export default ({ synthesisTitle }) => {
-  return (
-    <div className="insert-box wyntk-box">
-      <h3 className="dark-title-4 wyntk-title">
-        <Translate value="debate.whatYouNeedToKnow" />
-      </h3>
-      <div className="box-hyphen" />
-      <div className="wyntk-text-container">
-        <p
-          className="wyntk-text"
-          dangerouslySetInnerHTML={{
-            __html: synthesisTitle // TODO: we need to cleanse synthesisTitle before setting HTML content into the <p> tag
-          }}
-        />
-      </div>
+export default ({ synthesisTitle }) => (
+  <div className="insert-box wyntk-box">
+    <h3 className="dark-title-4 wyntk-title">
+      <Translate value="debate.whatYouNeedToKnow" />
+    </h3>
+    <div className="box-hyphen" />
+    <div className="wyntk-text-container">
+      <p
+        className="wyntk-text"
+        dangerouslySetInnerHTML={{
+          __html: synthesisTitle // TODO: we need to cleanse synthesisTitle before setting HTML content into the <p> tag
+        }}
+      />
     </div>
-  );
-};
+  </div>
+);

--- a/assembl/static2/js/app/components/debate/multiColumns/columnHeader.jsx
+++ b/assembl/static2/js/app/components/debate/multiColumns/columnHeader.jsx
@@ -17,28 +17,26 @@ const ColumnHeader = ({
   title: string,
   ideaId: string,
   refetchIdea: Function
-}) => {
-  return (
-    <div className="column-header">
-      <div
-        style={{
-          backgroundColor: color && `rgba(${hexToRgb(color)},${COLUMN_OPACITY_GAIN})`
-        }}
-      >
-        <div className="start-discussion-container">
-          <div className="start-discussion-icon">
-            <span className="assembl-icon-discussion color" />
-          </div>
-          <div className={'start-discussion start-discussion-multicol'}>
-            <h3 className="dark-title-3 no-margin">{title}</h3>
-          </div>
-          <div className="clear" />
+}) => (
+  <div className="column-header">
+    <div
+      style={{
+        backgroundColor: color && `rgba(${hexToRgb(color)},${COLUMN_OPACITY_GAIN})`
+      }}
+    >
+      <div className="start-discussion-container">
+        <div className="start-discussion-icon">
+          <span className="assembl-icon-discussion color" />
         </div>
-        <TopPostForm ideaId={ideaId} refetchIdea={refetchIdea} ideaOnColumn messageClassifier={classifier} scrollOffset={240} />
+        <div className={'start-discussion start-discussion-multicol'}>
+          <h3 className="dark-title-3 no-margin">{title}</h3>
+        </div>
         <div className="clear" />
       </div>
+      <TopPostForm ideaId={ideaId} refetchIdea={refetchIdea} ideaOnColumn messageClassifier={classifier} scrollOffset={240} />
+      <div className="clear" />
     </div>
-  );
-};
+  </div>
+);
 
 export default ColumnHeader;

--- a/assembl/static2/js/app/components/debate/multiColumns/columnsView.jsx
+++ b/assembl/static2/js/app/components/debate/multiColumns/columnsView.jsx
@@ -10,15 +10,13 @@ class ColumnsView extends React.Component {
   componentDidMount() {
     hashLinkScroll();
   }
-  shouldShowTabs = (columnsCount) => {
-    return columnsCount * MIN_WIDTH_COLUMN > Math.min(this.props.screenWidth, APP_CONTAINER_MAX_WIDTH);
-  };
+
+  shouldShowTabs = columnsCount => columnsCount * MIN_WIDTH_COLUMN > Math.min(this.props.screenWidth, APP_CONTAINER_MAX_WIDTH);
+
   render = () => {
     const { messageColumns: columns, identifier, debateData } = this.props;
     if (!Array.isArray(columns)) return null;
-    const showSynthesis = columns.some((column) => {
-      return !!column.header;
-    });
+    const showSynthesis = columns.some(column => !!column.header);
     return (
       <div className="max-container">
         {this.shouldShowTabs(columns.length) ? (

--- a/assembl/static2/js/app/components/debate/multiColumns/postColumn.jsx
+++ b/assembl/static2/js/app/components/debate/multiColumns/postColumn.jsx
@@ -8,9 +8,7 @@ import { PostFolded } from '../../../components/debate/thread/post';
 import BoxWithHyphen from '../../common/boxWithHyphen';
 import { getIfPhaseCompletedByIdentifier, type Timeline } from '../../../utils/timeline';
 
-const Separator = () => {
-  return <div style={{ height: '25px' }} />;
-};
+const Separator = () => <div style={{ height: '25px' }} />;
 
 const Synthesis = ({
   classifier,
@@ -22,18 +20,16 @@ const Synthesis = ({
   synthesisTitle: string,
   synthesisBody: string,
   hyphenStyle: Object
-}) => {
-  return (
-    <div id={`synthesis-${classifier}`} className="box synthesis background-grey">
-      <BoxWithHyphen
-        additionalContainerClassNames="column-synthesis"
-        subject={synthesisTitle}
-        body={synthesisBody}
-        hyphenStyle={hyphenStyle}
-      />
-    </div>
-  );
-};
+}) => (
+  <div id={`synthesis-${classifier}`} className="box synthesis background-grey">
+    <BoxWithHyphen
+      additionalContainerClassNames="column-synthesis"
+      subject={synthesisTitle}
+      body={synthesisBody}
+      hyphenStyle={hyphenStyle}
+    />
+  </div>
+);
 
 const PostColumn = ({
   color,

--- a/assembl/static2/js/app/components/debate/multiColumns/tabbedColumns.jsx
+++ b/assembl/static2/js/app/components/debate/multiColumns/tabbedColumns.jsx
@@ -24,11 +24,7 @@ export default class TabbedColumns extends React.Component {
     } = this.props;
     const activeKey = this.state && 'activeKey' in this.state ? this.state.activeKey : messageColumns[0].messageClassifier;
     const columnsArray = orderPostsByMessageClassifier(messageColumns, posts);
-    const index = messageColumns.indexOf(
-      messageColumns.find((messageColumn) => {
-        return messageColumn.messageClassifier === activeKey;
-      })
-    );
+    const index = messageColumns.indexOf(messageColumns.find(messageColumn => messageColumn.messageClassifier === activeKey));
     const col = messageColumns[index];
     const synthesisProps = showSynthesis && {
       classifier: activeKey,

--- a/assembl/static2/js/app/components/debate/multiColumns/utils.js
+++ b/assembl/static2/js/app/components/debate/multiColumns/utils.js
@@ -1,12 +1,9 @@
 // @flow
 
-export const orderPostsByMessageClassifier = (messageColumns: IdeaMessageColumns, posts: Array<Post>) => {
-  return messageColumns.reduce((naziLinter, col) => {
+export const orderPostsByMessageClassifier = (messageColumns: IdeaMessageColumns, posts: Array<Post>) =>
+  messageColumns.reduce((naziLinter, col) => {
     const keyName = col.messageClassifier;
     const columnsMap = naziLinter;
-    columnsMap[keyName] = posts.filter((post) => {
-      return post.messageClassifier === keyName;
-    });
+    columnsMap[keyName] = posts.filter(post => post.messageClassifier === keyName);
     return columnsMap;
   }, {});
-};

--- a/assembl/static2/js/app/components/debate/navigation/thumbnails.jsx
+++ b/assembl/static2/js/app/components/debate/navigation/thumbnails.jsx
@@ -16,28 +16,24 @@ class Thumbnails extends React.Component {
         <div className="thumbnails-container">
           <div className="max-container">
             <div className="thumbnails">
-              {thematics.map((thematic, index) => {
-                return (
-                  <div className="thumb-img-container" key={index}>
-                    <Link to={`${get('debate', { slug: slug, phase: identifier })}${get('theme', { themeId: thematic.id })}`}>
-                      <div
-                        className={themeId === thematic.id ? 'thumb-img active' : 'thumb-img'}
-                        style={
-                          thematic.img && thematic.img.externalUrl
-                            ? { backgroundImage: `url(${thematic.img.externalUrl})` }
-                            : null
-                        }
-                      />
-                      <div className="color-box">&nbsp;</div>
-                      <div className="thumb-title">
-                        <div className={themeId === thematic.id ? 'thumb-title-inner active-title' : 'thumb-title-inner'}>
-                          {thematic.title}
-                        </div>
+              {thematics.map((thematic, index) => (
+                <div className="thumb-img-container" key={index}>
+                  <Link to={`${get('debate', { slug: slug, phase: identifier })}${get('theme', { themeId: thematic.id })}`}>
+                    <div
+                      className={themeId === thematic.id ? 'thumb-img active' : 'thumb-img'}
+                      style={
+                        thematic.img && thematic.img.externalUrl ? { backgroundImage: `url(${thematic.img.externalUrl})` } : null
+                      }
+                    />
+                    <div className="color-box">&nbsp;</div>
+                    <div className="thumb-title">
+                      <div className={themeId === thematic.id ? 'thumb-title-inner active-title' : 'thumb-title-inner'}>
+                        {thematic.title}
                       </div>
-                    </Link>
-                  </div>
-                );
-              })}
+                    </div>
+                  </Link>
+                </div>
+              ))}
             </div>
           </div>
         </div>
@@ -46,10 +42,8 @@ class Thumbnails extends React.Component {
   }
 }
 
-const mapStateToProps = (state) => {
-  return {
-    debate: state.debate
-  };
-};
+const mapStateToProps = state => ({
+  debate: state.debate
+});
 
 export default connect(mapStateToProps)(Thumbnails);

--- a/assembl/static2/js/app/components/debate/navigation/timeline.jsx
+++ b/assembl/static2/js/app/components/debate/navigation/timeline.jsx
@@ -11,34 +11,30 @@ class Timeline extends React.Component {
     return (
       <div className="timeline-container">
         {debateData.timeline &&
-          debateData.timeline.map((phase, index) => {
-            return (
-              <TimelineSegment
-                title={phase.title}
-                locale={locale}
-                index={index}
-                key={index}
-                barPercent={getBarPercent(debateData.timeline[index])}
-                isCurrentPhase={isCurrentPhase(debateData.timeline[index])}
-                showNavigation={showNavigation}
-                identifier={identifier}
-                phaseIdentifier={phase.identifier}
-                startDate={phase.start}
-                endDate={phase.end}
-                isStepCompleted={isStepCompleted(phase)}
-              />
-            );
-          })}
+          debateData.timeline.map((phase, index) => (
+            <TimelineSegment
+              title={phase.title}
+              locale={locale}
+              index={index}
+              key={index}
+              barPercent={getBarPercent(debateData.timeline[index])}
+              isCurrentPhase={isCurrentPhase(debateData.timeline[index])}
+              showNavigation={showNavigation}
+              identifier={identifier}
+              phaseIdentifier={phase.identifier}
+              startDate={phase.start}
+              endDate={phase.end}
+              isStepCompleted={isStepCompleted(phase)}
+            />
+          ))}
       </div>
     );
   }
 }
 
-const mapStateToProps = (state) => {
-  return {
-    debate: state.debate,
-    i18n: state.i18n
-  };
-};
+const mapStateToProps = state => ({
+  debate: state.debate,
+  i18n: state.i18n
+});
 
 export default connect(mapStateToProps)(Timeline);

--- a/assembl/static2/js/app/components/debate/navigation/timelineSegment.jsx
+++ b/assembl/static2/js/app/components/debate/navigation/timelineSegment.jsx
@@ -17,9 +17,7 @@ class TimelineSegment extends React.Component {
     const { locale } = this.props.i18n;
     const { phaseIdentifier, title, startDate, endDate } = this.props;
     const { debateData } = this.props.debate;
-    const phase = debateData.timeline.filter((p) => {
-      return p.identifier === phaseIdentifier;
-    });
+    const phase = debateData.timeline.filter(p => p.identifier === phaseIdentifier);
     const isRedirectionToV1 = phase[0].interface_v1;
     const slug = { slug: debateData.slug };
     const params = { slug: debateData.slug, phase: phaseIdentifier };
@@ -59,6 +57,7 @@ class TimelineSegment extends React.Component {
       window.location = get('oldDebate', slug);
     }
   }
+
   render() {
     const { index, barPercent, isCurrentPhase, isStepCompleted, title, locale } = this.props;
     const timelineClass = classNames('timeline-title', {
@@ -68,17 +67,11 @@ class TimelineSegment extends React.Component {
     });
     return (
       <div className="minimized-timeline">
-        {title.entries
-          .filter((entry) => {
-            return locale === entry['@language'];
-          })
-          .map((entry, index2) => {
-            return (
-              <div onClick={this.displayPhase} className={timelineClass} key={index2}>
-                <div className="timeline-link">{entry.value}</div>
-              </div>
-            );
-          })}
+        {title.entries.filter(entry => locale === entry['@language']).map((entry, index2) => (
+          <div onClick={this.displayPhase} className={timelineClass} key={index2}>
+            <div className="timeline-link">{entry.value}</div>
+          </div>
+        ))}
         <div className="timeline-graph">
           <div className={isStepCompleted || isCurrentPhase ? 'timeline-number active' : 'timeline-number not-active'}>
             {isStepCompleted ? <span className="assembl-icon-checked white" /> : <span>{index + 1}</span>}
@@ -97,11 +90,9 @@ class TimelineSegment extends React.Component {
   }
 }
 
-const mapStateToProps = (state) => {
-  return {
-    i18n: state.i18n,
-    debate: state.debate
-  };
-};
+const mapStateToProps = state => ({
+  i18n: state.i18n,
+  debate: state.debate
+});
 
 export default connect(mapStateToProps)(TimelineSegment);

--- a/assembl/static2/js/app/components/debate/survey/navigation.jsx
+++ b/assembl/static2/js/app/components/debate/survey/navigation.jsx
@@ -22,10 +22,12 @@ class Navigation extends React.Component {
       currentQuestionNumber: 0
     };
   }
+
   componentDidMount() {
     window.addEventListener('scroll', this.displayNav);
     window.addEventListener('scroll', this.displayPagination);
   }
+
   componentWillReceiveProps(nextProps) {
     this.setState(
       {
@@ -40,10 +42,12 @@ class Navigation extends React.Component {
       }
     );
   }
+
   componentWillUnmount() {
     window.removeEventListener('scroll', this.displayNav);
     window.removeEventListener('scroll', this.displayPagination);
   }
+
   getQuestionsOffset(questionsLength) {
     const offsetArray = [];
     this.questionsLength = questionsLength;
@@ -56,6 +60,7 @@ class Navigation extends React.Component {
     }
     return offsetArray; // eslint-disable-line
   }
+
   displayNav() {
     const proposals = document.getElementById('proposals');
     if (!proposals) {
@@ -94,6 +99,7 @@ class Navigation extends React.Component {
       });
     }
   }
+
   displayPagination() {
     const navbarHeight = document.getElementById('timeline').clientHeight;
     const questionsOffset = this.getQuestionsOffset(this.state.questionsLength);
@@ -111,6 +117,7 @@ class Navigation extends React.Component {
       currentQuestionNumber: currentQuestionNumber
     });
   }
+
   scrollToQuestion(questionIndex) {
     const navbarHeight = document.getElementById('timeline').clientHeight;
     let target;
@@ -123,6 +130,7 @@ class Navigation extends React.Component {
     window.scrollTo({ top: targetOffset - 80, left: 0, behavior: 'smooth' });
     this.props.scrollToQuestion(false);
   }
+
   render() {
     const barWidth = calculatePercentage(this.state.currentQuestionNumber, this.state.questionsLength);
     return (
@@ -179,10 +187,8 @@ class Navigation extends React.Component {
   }
 }
 
-const mapStateToProps = (state) => {
-  return {
-    debate: state.debate
-  };
-};
+const mapStateToProps = state => ({
+  debate: state.debate
+});
 
 export default withScreenDimensions(connect(mapStateToProps)(Navigation));

--- a/assembl/static2/js/app/components/debate/survey/post.jsx
+++ b/assembl/static2/js/app/components/debate/survey/post.jsx
@@ -49,6 +49,7 @@ class Post extends React.Component {
       inviteUserToLogin();
     }
   };
+
   handleAddSentiment(target, type) {
     const { id, sentimentCounts, mySentiment } = this.props.data.post;
     this.props
@@ -79,6 +80,7 @@ class Post extends React.Component {
         displayAlert('danger', `${error}`);
       });
   }
+
   handleDeleteSentiment() {
     const { id, sentimentCounts, mySentiment } = this.props.data.post;
     this.props
@@ -106,6 +108,7 @@ class Post extends React.Component {
         displayAlert('danger', `${error}`);
       });
   }
+
   render() {
     const { post } = this.props.data;
     const { contentLocale, lang, moreProposals, originalLocale, postIndex, updateLocalContentLocale, screenWidth } = this.props;
@@ -205,13 +208,11 @@ Post.propTypes = {
   deleteSentiment: PropTypes.func.isRequired
 };
 
-const mapStateToProps = (state, { id }) => {
-  return {
-    debate: state.debate,
-    contentLocale: state.contentLocale.getIn([id, 'contentLocale']),
-    lang: state.i18n.locale
-  };
-};
+const mapStateToProps = (state, { id }) => ({
+  debate: state.debate,
+  contentLocale: state.contentLocale.getIn([id, 'contentLocale']),
+  lang: state.i18n.locale
+});
 
 export default compose(
   connect(mapStateToProps),

--- a/assembl/static2/js/app/components/debate/survey/proposals.jsx
+++ b/assembl/static2/js/app/components/debate/survey/proposals.jsx
@@ -8,9 +8,11 @@ class Proposals extends React.Component {
     this.state = { hideProposals: false };
     this.displayProposals = this.displayProposals.bind(this);
   }
+
   displayProposals() {
     this.setState({ hideProposals: !this.state.hideProposals });
   }
+
   render() {
     const { questionIndex, title, posts, moreProposals, refetchTheme } = this.props;
     return (
@@ -26,18 +28,16 @@ class Proposals extends React.Component {
         </h3>
         {posts.length > 0 && (
           <div className={this.state.hideProposals ? 'hidden' : 'shown'}>
-            {posts.map((post, index) => {
-              return (
-                <Post
-                  refetchTheme={refetchTheme}
-                  id={post.node.id}
-                  originalLocale={post.node.originalLocale}
-                  postIndex={index}
-                  moreProposals={moreProposals}
-                  key={post.node.id}
-                />
-              );
-            })}
+            {posts.map((post, index) => (
+              <Post
+                refetchTheme={refetchTheme}
+                id={post.node.id}
+                originalLocale={post.node.originalLocale}
+                postIndex={index}
+                moreProposals={moreProposals}
+                key={post.node.id}
+              />
+            ))}
           </div>
         )}
         {posts.length === 0 && (

--- a/assembl/static2/js/app/components/debate/survey/question.jsx
+++ b/assembl/static2/js/app/components/debate/survey/question.jsx
@@ -21,12 +21,14 @@ class Question extends React.Component {
     this.createPost = this.createPost.bind(this);
     this.redirectToLogin = this.redirectToLogin.bind(this);
   }
+
   componentDidMount() {
     const maxChars = this.txtarea.props.maxLength;
     this.state = {
       remainingChars: maxChars
     };
   }
+
   componentWillReceiveProps() {
     const maxChars = this.txtarea.props.maxLength;
     this.state = {
@@ -35,6 +37,7 @@ class Question extends React.Component {
       remainingChars: maxChars
     };
   }
+
   getRemainingChars(e) {
     const maxChars = this.txtarea.props.maxLength;
     const remainingChars = maxChars - e.currentTarget.value.length;
@@ -42,12 +45,14 @@ class Question extends React.Component {
       remainingChars: remainingChars
     });
   }
+
   getProposalText(e) {
     const txtValue = e.currentTarget.value;
     this.setState({
       postBody: txtValue
     });
   }
+
   displaySubmitButton(e) {
     const nbChars = e.currentTarget.value.length;
     const minAcceptableChars = 10;
@@ -61,6 +66,7 @@ class Question extends React.Component {
       });
     }
   }
+
   createPost() {
     const maxChars = this.txtarea.props.maxLength;
     const { contentLocale, questionId, scrollToQuestion, index, refetchTheme } = this.props;
@@ -81,6 +87,7 @@ class Question extends React.Component {
         displayAlert('danger', error);
       });
   }
+
   redirectToLogin() {
     const isUserConnected = getConnectedUserId();
     const { scrollToQuestion, index } = this.props;
@@ -90,6 +97,7 @@ class Question extends React.Component {
       scrollToQuestion(true, index);
     }
   }
+
   render() {
     const { index, title, screenWidth, screenHeight } = this.props;
     const height = screenHeight - document.getElementById('timeline').clientHeight;
@@ -147,11 +155,9 @@ Question.propTypes = {
   mutate: PropTypes.func.isRequired
 };
 
-const mapStateToProps = (state) => {
-  return {
-    debate: state.debate,
-    contentLocale: state.i18n.locale
-  };
-};
+const mapStateToProps = state => ({
+  debate: state.debate,
+  contentLocale: state.i18n.locale
+});
 
 export default compose(connect(mapStateToProps), graphql(createPostMutation), withScreenDimensions)(Question);

--- a/assembl/static2/js/app/components/debate/thread/answerForm.jsx
+++ b/assembl/static2/js/app/components/debate/thread/answerForm.jsx
@@ -37,6 +37,7 @@ type AnswerFormState = {
 
 class AnswerForm extends React.PureComponent<*, AnswerFormProps, AnswerFormState> {
   props: AnswerFormProps;
+
   state: AnswerFormState;
 
   constructor() {
@@ -46,6 +47,7 @@ class AnswerForm extends React.PureComponent<*, AnswerFormProps, AnswerFormState
       submitting: false
     };
   }
+
   handleCancel = () => {
     const { hideAnswerForm } = this.props;
     this.setState({ body: null }, hideAnswerForm);
@@ -148,12 +150,10 @@ class AnswerForm extends React.PureComponent<*, AnswerFormProps, AnswerFormState
   }
 }
 
-const mapStateToProps = (state) => {
-  return {
-    contentLocale: state.i18n.locale,
-    debateData: state.debate.debateData
-  };
-};
+const mapStateToProps = state => ({
+  contentLocale: state.i18n.locale,
+  debateData: state.debate.debateData
+});
 
 export default compose(
   connect(mapStateToProps),

--- a/assembl/static2/js/app/components/debate/thread/nuggets.jsx
+++ b/assembl/static2/js/app/components/debate/thread/nuggets.jsx
@@ -61,14 +61,12 @@ class Nuggets extends React.Component {
             <span className="assembl-icon-pepite color2" />
           </div>
           <div>
-            {extracts.map((extract) => {
-              return (
-                <div key={extract.id} className="nugget">
-                  <div className="nugget-txt">{extract.body}</div>
-                  <div className="box-hyphen" />
-                </div>
-              );
-            })}
+            {extracts.map(extract => (
+              <div key={extract.id} className="nugget">
+                <div className="nugget-txt">{extract.body}</div>
+                <div className="box-hyphen" />
+              </div>
+            ))}
           </div>
         </div>
       </div>

--- a/assembl/static2/js/app/components/debate/thread/post.jsx
+++ b/assembl/static2/js/app/components/debate/thread/post.jsx
@@ -17,24 +17,17 @@ import Nuggets from './nuggets';
 import hashLinkScroll from '../../../utils/hashLinkScroll';
 import { transformLinksInHtml } from '../../../utils/linkify';
 
-export const PostFolded = ({ nbPosts }) => {
-  return <Translate value="debate.thread.foldedPostLink" count={nbPosts} />;
-};
+export const PostFolded = ({ nbPosts }) => <Translate value="debate.thread.foldedPostLink" count={nbPosts} />;
 
-const getSubjectPrefixString = (fullLevel) => {
-  return (
-    fullLevel && (
-      <span className="subject-prefix">
-        {`Rep. ${fullLevel
-          .split('-')
-          .map((level) => {
-            return `${Number(level) + 1}`;
-          })
-          .join('.')}: `}
-      </span>
-    )
+const getSubjectPrefixString = fullLevel =>
+  fullLevel && (
+    <span className="subject-prefix">
+      {`Rep. ${fullLevel
+        .split('-')
+        .map(level => `${Number(level) + 1}`)
+        .join('.')}: `}
+    </span>
   );
-};
 
 // TODO we need a graphql query to retrieve all languages with native translation, see Python langstrings.LocaleLabel
 // We only have french and english for en, fr, ja for now.
@@ -132,11 +125,11 @@ export class EmptyPost extends React.PureComponent {
     // recompute the tree height after images are loaded
     if (el) {
       const images = el.getElementsByTagName('img');
-      Array.from(images).forEach((img) => {
-        return img.addEventListener('load', () => {
+      Array.from(images).forEach(img =>
+        img.addEventListener('load', () => {
           this.props.measureTreeHeight(400);
-        });
-      });
+        })
+      );
     }
   };
 
@@ -172,9 +165,7 @@ export class EmptyPost extends React.PureComponent {
     const translate = contentLocale !== originalLocale;
     const { body, subject, originalBody, originalSubject } = this.getBodyAndSubject(translate);
 
-    const relatedIdeasTitle = indirectIdeaContentLinks.map((link) => {
-      return link.idea.title;
-    });
+    const relatedIdeasTitle = indirectIdeaContentLinks.map(link => link.idea.title);
 
     const modifiedSubject = (
       <span>
@@ -218,14 +209,7 @@ export class EmptyPost extends React.PureComponent {
       );
     }
 
-    const completeLevelArray = fullLevel
-      ? [
-        rowIndex,
-        ...fullLevel.split('-').map((string) => {
-          return Number(string);
-        })
-      ]
-      : [rowIndex];
+    const completeLevelArray = fullLevel ? [rowIndex, ...fullLevel.split('-').map(string => Number(string))] : [rowIndex];
 
     const answerTextareaRef = (el) => {
       this.answerTextarea = el;
@@ -270,13 +254,11 @@ export class EmptyPost extends React.PureComponent {
                     <Translate value="debate.thread.linkIdea" />
                   </div>
                   <div className="badges">
-                    {relatedIdeasTitle.map((title, index) => {
-                      return (
-                        <span className="badge" key={index}>
-                          {title}
-                        </span>
-                      );
-                    })}
+                    {relatedIdeasTitle.map((title, index) => (
+                      <span className="badge" key={index}>
+                        {title}
+                      </span>
+                    ))}
                   </div>
                 </div>
               ) : null}

--- a/assembl/static2/js/app/components/home/chatbot.jsx
+++ b/assembl/static2/js/app/components/home/chatbot.jsx
@@ -3,27 +3,25 @@ import { Translate } from 'react-redux-i18n';
 import { Link } from 'react-router';
 import { Grid, Row, Col } from 'react-bootstrap';
 
-const Chatbot = ({ chatbot, locale }) => {
-  return (
-    <section className="home-section contact-section">
-      <Grid fluid>
-        <div className="max-container center">
-          <div className="margin-xl">
-            <h1 className="dark-title-1 center">{chatbot.titleEntries[locale]}</h1>
-          </div>
-          <div className="center" style={{ margin: '60px 0' }}>
-            <Row>
-              <Col md={12}>
-                <Link className="button-link button-dark" to={chatbot.link} target="_blank">
-                  <Translate value="home.chatbot" chatbotName={chatbot.name} />
-                </Link>
-              </Col>
-            </Row>
-          </div>
+const Chatbot = ({ chatbot, locale }) => (
+  <section className="home-section contact-section">
+    <Grid fluid>
+      <div className="max-container center">
+        <div className="margin-xl">
+          <h1 className="dark-title-1 center">{chatbot.titleEntries[locale]}</h1>
         </div>
-      </Grid>
-    </section>
-  );
-};
+        <div className="center" style={{ margin: '60px 0' }}>
+          <Row>
+            <Col md={12}>
+              <Link className="button-link button-dark" to={chatbot.link} target="_blank">
+                <Translate value="home.chatbot" chatbotName={chatbot.name} />
+              </Link>
+            </Col>
+          </Row>
+        </div>
+      </div>
+    </Grid>
+  </section>
+);
 
 export default Chatbot;

--- a/assembl/static2/js/app/components/home/header.jsx
+++ b/assembl/static2/js/app/components/home/header.jsx
@@ -14,6 +14,7 @@ class Header extends React.Component {
     super(props);
     this.displayPhase = this.displayPhase.bind(this);
   }
+
   // This redirection should be removed when the phase 2 will be done
   displayPhase() {
     const slug = { slug: getDiscussionSlug() };
@@ -38,6 +39,7 @@ class Header extends React.Component {
       browserHistory.push(get('debate', { ...slug, phase: currentPhaseIdentifier }));
     }
   }
+
   render() {
     const { debateData } = this.props.debate;
     const { locale } = this.props.i18n;
@@ -79,12 +81,10 @@ class Header extends React.Component {
   }
 }
 
-const mapStateToProps = (state) => {
-  return {
-    debate: state.debate,
-    phase: state.phase,
-    i18n: state.i18n
-  };
-};
+const mapStateToProps = state => ({
+  debate: state.debate,
+  phase: state.phase,
+  i18n: state.i18n
+});
 
 export default connect(mapStateToProps)(Header);

--- a/assembl/static2/js/app/components/home/header/statistic.jsx
+++ b/assembl/static2/js/app/components/home/header/statistic.jsx
@@ -13,28 +13,24 @@ type StatisticElementProps = {
   metricNameTranslateKey: string
 };
 
-const StatisticElement = (props: StatisticElementProps) => {
-  return (
-    <div className="stat-container">
-      <div className="stat-box">
-        <div className={`stat-icon assembl-icon-${props.iconName} white`} />
-        <div className="stat">
-          <div className="stat-nb">{props.metricValue}</div>
-          <div className="stat-nb stat-label">
-            <Translate value={props.metricNameTranslateKey} />
-          </div>
+const StatisticElement = (props: StatisticElementProps) => (
+  <div className="stat-container">
+    <div className="stat-box">
+      <div className={`stat-icon assembl-icon-${props.iconName} white`} />
+      <div className="stat">
+        <div className="stat-nb">{props.metricValue}</div>
+        <div className="stat-nb stat-label">
+          <Translate value={props.metricNameTranslateKey} />
         </div>
       </div>
     </div>
-  );
-};
+  </div>
+);
 
 class Statistic extends React.Component {
-  static mapElementsPropsToComponents = (elemsProps) => {
-    return elemsProps.map((elementProps, index) => {
-      return <StatisticElement key={index} {...elementProps} />;
-    });
-  };
+  static mapElementsPropsToComponents = elemsProps =>
+    elemsProps.map((elementProps, index) => <StatisticElement key={index} {...elementProps} />);
+
   render() {
     const { rootIdea, numParticipants, totalSentiments, visitsAnalytics } = this.props.data;
     const elementsProps = [

--- a/assembl/static2/js/app/components/home/objectives.jsx
+++ b/assembl/static2/js/app/components/home/objectives.jsx
@@ -13,6 +13,7 @@ class Objectives extends React.Component {
     super(props);
     this.displayPhase = this.displayPhase.bind(this);
   }
+
   // This redirection should be removed when the phase 2 will be done
   displayPhase() {
     const slug = { slug: getDiscussionSlug() };
@@ -37,6 +38,7 @@ class Objectives extends React.Component {
       browserHistory.push(get('debate', { ...slug, phase: currentPhaseIdentifier }));
     }
   }
+
   render() {
     const { debateData } = this.props.debate;
     const { locale } = this.props.i18n;
@@ -102,12 +104,10 @@ class Objectives extends React.Component {
   }
 }
 
-const mapStateToProps = (state) => {
-  return {
-    debate: state.debate,
-    phase: state.phase,
-    i18n: state.i18n
-  };
-};
+const mapStateToProps = state => ({
+  debate: state.debate,
+  phase: state.phase,
+  i18n: state.i18n
+});
 
 export default connect(mapStateToProps)(Objectives);

--- a/assembl/static2/js/app/components/home/partners.jsx
+++ b/assembl/static2/js/app/components/home/partners.jsx
@@ -19,15 +19,13 @@ class Partners extends React.Component {
             </div>
             <div className="content-section">
               <div className="content-margin">
-                {debateData.partners.map((partner, index) => {
-                  return (
-                    <div className="partner-logo" key={index}>
-                      <Link to={partner.link} target="_blank">
-                        <img src={partner.logo} alt={partner.name} />
-                      </Link>
-                    </div>
-                  );
-                })}
+                {debateData.partners.map((partner, index) => (
+                  <div className="partner-logo" key={index}>
+                    <Link to={partner.link} target="_blank">
+                      <img src={partner.logo} alt={partner.name} />
+                    </Link>
+                  </div>
+                ))}
               </div>
             </div>
           </div>
@@ -37,10 +35,8 @@ class Partners extends React.Component {
   }
 }
 
-const mapStateToProps = (state) => {
-  return {
-    debate: state.debate
-  };
-};
+const mapStateToProps = state => ({
+  debate: state.debate
+});
 
 export default connect(mapStateToProps)(Partners);

--- a/assembl/static2/js/app/components/home/phases.jsx
+++ b/assembl/static2/js/app/components/home/phases.jsx
@@ -21,42 +21,38 @@ class Phases extends React.Component {
             </div>
             <div className="content-section">
               <Row className="no-margin">
-                {debateData.timeline.map((phase, index) => {
-                  return (
-                    <Col
-                      xs={12}
-                      sm={24 / debateData.timeline.length}
-                      md={12 / debateData.timeline.length}
-                      className={isCurrentPhase(debateData.timeline[index]) ? 'no-padding phase' : 'no-padding phase hidden-xs'}
-                      key={index}
-                    >
-                      <Phase
-                        imgUrl={phase.image_url}
-                        startDate={phase.start}
-                        endDate={phase.end}
-                        index={index}
-                        title={phase.title}
-                        description={phase.description}
-                        identifier={phase.identifier}
-                      />
-                    </Col>
-                  );
-                })}
+                {debateData.timeline.map((phase, index) => (
+                  <Col
+                    xs={12}
+                    sm={24 / debateData.timeline.length}
+                    md={12 / debateData.timeline.length}
+                    className={isCurrentPhase(debateData.timeline[index]) ? 'no-padding phase' : 'no-padding phase hidden-xs'}
+                    key={index}
+                  >
+                    <Phase
+                      imgUrl={phase.image_url}
+                      startDate={phase.start}
+                      endDate={phase.end}
+                      index={index}
+                      title={phase.title}
+                      description={phase.description}
+                      identifier={phase.identifier}
+                    />
+                  </Col>
+                ))}
               </Row>
               <Row className="no-margin">
-                {debateData.timeline.map((phase, index) => {
-                  return (
-                    <Col
-                      xs={12 / debateData.timeline.length}
-                      sm={12 / debateData.timeline.length}
-                      md={12 / debateData.timeline.length}
-                      className={'no-padding bar'}
-                      key={index}
-                    >
-                      <Timeline index={index} />
-                    </Col>
-                  );
-                })}
+                {debateData.timeline.map((phase, index) => (
+                  <Col
+                    xs={12 / debateData.timeline.length}
+                    sm={12 / debateData.timeline.length}
+                    md={12 / debateData.timeline.length}
+                    className={'no-padding bar'}
+                    key={index}
+                  >
+                    <Timeline index={index} />
+                  </Col>
+                ))}
               </Row>
             </div>
           </div>
@@ -66,10 +62,8 @@ class Phases extends React.Component {
   }
 }
 
-const mapStateToProps = (state) => {
-  return {
-    debate: state.debate
-  };
-};
+const mapStateToProps = state => ({
+  debate: state.debate
+});
 
 export default connect(mapStateToProps)(Phases);

--- a/assembl/static2/js/app/components/home/phases/phase.jsx
+++ b/assembl/static2/js/app/components/home/phases/phase.jsx
@@ -11,12 +11,11 @@ class Phase extends React.Component {
     super(props);
     this.displayPhase = this.displayPhase.bind(this);
   }
+
   displayPhase() {
     const { identifier, startDate, endDate, title } = this.props;
     const { debateData } = this.props.debate;
-    const phase = debateData.timeline.filter((p) => {
-      return p.identifier === identifier;
-    });
+    const phase = debateData.timeline.filter(p => p.identifier === identifier);
     const isRedirectionToV1 = phase[0].interface_v1;
     const { locale } = this.props.i18n;
     const slug = { slug: debateData.slug };
@@ -57,6 +56,7 @@ class Phase extends React.Component {
       window.location = get('oldDebate', slug);
     }
   }
+
   render() {
     const { locale } = this.props.i18n;
     const { imgUrl, startDate, title, description, index } = this.props;
@@ -68,17 +68,15 @@ class Phase extends React.Component {
           <h1 className="light-title-1">{stepNumber}</h1>
           {title && (
             <h3 className="light-title-3">
-              {title.entries.map((entry, index2) => {
-                return <span key={index2}>{locale === entry['@language'] ? entry.value : ''}</span>;
-              })}
+              {title.entries.map((entry, index2) => <span key={index2}>{locale === entry['@language'] ? entry.value : ''}</span>)}
             </h3>
           )}
           <h4 className="light-title-4">{startDate && <Localize value={startDate} dateFormat="date.format2" />}</h4>
           {description && (
             <div className="description-box">
-              {description.entries.map((entry, index3) => {
-                return <span key={index3}>{locale === entry['@language'] ? entry.value : ''}</span>;
-              })}
+              {description.entries.map((entry, index3) => (
+                <span key={index3}>{locale === entry['@language'] ? entry.value : ''}</span>
+              ))}
             </div>
           )}
         </div>
@@ -90,11 +88,9 @@ class Phase extends React.Component {
   }
 }
 
-const mapStateToProps = (state) => {
-  return {
-    i18n: state.i18n,
-    debate: state.debate
-  };
-};
+const mapStateToProps = state => ({
+  i18n: state.i18n,
+  debate: state.debate
+});
 
 export default connect(mapStateToProps)(Phase);

--- a/assembl/static2/js/app/components/home/phases/timeline.jsx
+++ b/assembl/static2/js/app/components/home/phases/timeline.jsx
@@ -33,10 +33,8 @@ class Timeline extends React.Component {
   }
 }
 
-const mapStateToProps = (state) => {
-  return {
-    debate: state.debate
-  };
-};
+const mapStateToProps = state => ({
+  debate: state.debate
+});
 
 export default connect(mapStateToProps)(Timeline);

--- a/assembl/static2/js/app/components/home/synthesis.jsx
+++ b/assembl/static2/js/app/components/home/synthesis.jsx
@@ -35,18 +35,14 @@ class SynthesisContainer extends React.Component {
   }
 }
 
-const mapStateToProps = (state) => {
-  return {
-    synthesis: state.synthesis
-  };
-};
+const mapStateToProps = state => ({
+  synthesis: state.synthesis
+});
 
-const mapDispatchToProps = (dispatch) => {
-  return {
-    fetchSynthesis: (discussionId) => {
-      dispatch(fetchSynthesis(discussionId));
-    }
-  };
-};
+const mapDispatchToProps = dispatch => ({
+  fetchSynthesis: (discussionId) => {
+    dispatch(fetchSynthesis(discussionId));
+  }
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(SynthesisContainer);

--- a/assembl/static2/js/app/components/home/themes.jsx
+++ b/assembl/static2/js/app/components/home/themes.jsx
@@ -31,30 +31,28 @@ class Themes extends React.Component {
                 </div>
                 <div className="content-section">
                   <Row className="no-margin">
-                    {ideas.latestIdeas.map((idea, index) => {
-                      return (
-                        <Col
-                          xs={12}
-                          sm={24 / ideas.latestIdeas.length}
-                          md={12 / ideas.latestIdeas.length}
-                          className="theme no-padding"
-                          key={index}
-                        >
-                          <ThematicPreview
-                            imgUrl={idea.img ? idea.img.externalUrl : ''}
-                            numPosts={idea.nbPosts}
-                            numContributors={idea.nbContributors}
-                            link={
-                              connectedUserId
-                                ? `${get('oldDebate', slug)}/idea/local:Idea/${idea.id}`
-                                : `${getContextual('login', slug)}?next=${get('home', slug)}`
-                            }
-                            title={idea.title}
-                            description={<p dangerouslySetInnerHTML={{ __html: idea.definition }} />}
-                          />
-                        </Col>
-                      );
-                    })}
+                    {ideas.latestIdeas.map((idea, index) => (
+                      <Col
+                        xs={12}
+                        sm={24 / ideas.latestIdeas.length}
+                        md={12 / ideas.latestIdeas.length}
+                        className="theme no-padding"
+                        key={index}
+                      >
+                        <ThematicPreview
+                          imgUrl={idea.img ? idea.img.externalUrl : ''}
+                          numPosts={idea.nbPosts}
+                          numContributors={idea.nbContributors}
+                          link={
+                            connectedUserId
+                              ? `${get('oldDebate', slug)}/idea/local:Idea/${idea.id}`
+                              : `${getContextual('login', slug)}?next=${get('home', slug)}`
+                          }
+                          title={idea.title}
+                          description={<p dangerouslySetInnerHTML={{ __html: idea.definition }} />}
+                        />
+                      </Col>
+                    ))}
                   </Row>
                 </div>
               </div>
@@ -65,11 +63,9 @@ class Themes extends React.Component {
   }
 }
 
-const mapStateToProps = (state) => {
-  return {
-    debate: state.debate,
-    ideas: state.ideas
-  };
-};
+const mapStateToProps = state => ({
+  debate: state.debate,
+  ideas: state.ideas
+});
 
 export default connect(mapStateToProps)(Themes);

--- a/assembl/static2/js/app/components/home/themes/topIdea.jsx
+++ b/assembl/static2/js/app/components/home/themes/topIdea.jsx
@@ -16,18 +16,14 @@ class TopIdea extends React.Component {
         <h2 className="dark-title-2 center">
           <Translate value={translateKey} />
         </h2>
-        {topIdeas.map((idea, index) => {
-          return <IdeaLink key={index} idea={idea} />;
-        })}
+        {topIdeas.map((idea, index) => <IdeaLink key={index} idea={idea} />)}
       </div>
     );
   }
 }
 
-const mapStateToProps = (state) => {
-  return {
-    ideas: state.ideas
-  };
-};
+const mapStateToProps = state => ({
+  ideas: state.ideas
+});
 
 export default connect(mapStateToProps)(TopIdea);

--- a/assembl/static2/js/app/components/home/twitter.jsx
+++ b/assembl/static2/js/app/components/home/twitter.jsx
@@ -35,10 +35,8 @@ class Twitter extends React.Component {
   }
 }
 
-const mapStateToProps = (state) => {
-  return {
-    debate: state.debate
-  };
-};
+const mapStateToProps = state => ({
+  debate: state.debate
+});
 
 export default connect(mapStateToProps)(Twitter);

--- a/assembl/static2/js/app/components/home/video.jsx
+++ b/assembl/static2/js/app/components/home/video.jsx
@@ -10,6 +10,7 @@ class Video extends React.Component {
       isTextHigher: false
     };
   }
+
   componentWillReceiveProps() {
     const { debateData } = this.props.debate;
     const videoTxt = document.getElementById('video-txt');
@@ -20,6 +21,7 @@ class Video extends React.Component {
       if (textHeight > videoHeight + 5) this.setState({ isTextHigher: true });
     }
   }
+
   render() {
     const { debateData } = this.props.debate;
     const { locale } = this.props.i18n;
@@ -60,11 +62,9 @@ class Video extends React.Component {
   }
 }
 
-const mapStateToProps = (state) => {
-  return {
-    debate: state.debate,
-    i18n: state.i18n
-  };
-};
+const mapStateToProps = state => ({
+  debate: state.debate,
+  i18n: state.i18n
+});
 
 export default connect(mapStateToProps)(Video);

--- a/assembl/static2/js/app/components/login/assemblLogin.jsx
+++ b/assembl/static2/js/app/components/login/assemblLogin.jsx
@@ -57,10 +57,8 @@ class AsLogin extends React.Component {
   }
 }
 
-const mapStateToProps = (state) => {
-  return {
-    debate: state.debate
-  };
-};
+const mapStateToProps = state => ({
+  debate: state.debate
+});
 
 export default connect(mapStateToProps)(AsLogin);

--- a/assembl/static2/js/app/components/login/sendPwdForm.jsx
+++ b/assembl/static2/js/app/components/login/sendPwdForm.jsx
@@ -14,6 +14,7 @@ class SendPwdForm extends React.Component {
     this.submitHandler = this.submitHandler.bind(this);
     this.handleInput = this.handleInput.bind(this);
   }
+
   componentWillReceiveProps(nextProps) {
     const { auth } = nextProps;
     const resp = auth.passwordChangeRequest;
@@ -28,13 +29,16 @@ class SendPwdForm extends React.Component {
       displayAlert('danger', msg, true);
     }
   }
+
   handleInput(e) {
     inputHandler(this, e);
   }
+
   submitHandler(e) {
     e.preventDefault();
     this.props.sendRequest(this.state.identifier, getDiscussionSlug());
   }
+
   render() {
     return (
       <div className="login-view">
@@ -70,18 +74,12 @@ class SendPwdForm extends React.Component {
   }
 }
 
-const mapStateToProps = (state) => {
-  return {
-    auth: state.auth
-  };
-};
+const mapStateToProps = state => ({
+  auth: state.auth
+});
 
-const mapDispatchToProps = (dispatch) => {
-  return {
-    sendRequest: (id, discussionSlug) => {
-      return dispatch(requestPasswordChangeAction(id, discussionSlug));
-    }
-  };
-};
+const mapDispatchToProps = dispatch => ({
+  sendRequest: (id, discussionSlug) => dispatch(requestPasswordChangeAction(id, discussionSlug))
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(SendPwdForm);

--- a/assembl/static2/js/app/components/login/signupForm.jsx
+++ b/assembl/static2/js/app/components/login/signupForm.jsx
@@ -115,18 +115,14 @@ class SignupForm extends React.Component {
   }
 }
 
-const mapStateToProps = (state) => {
-  return {
-    auth: state.auth
-  };
-};
+const mapStateToProps = state => ({
+  auth: state.auth
+});
 
-const mapDispatchToProps = (dispatch) => {
-  return {
-    signUp: (payload) => {
-      dispatch(signupAction(payload));
-    }
-  };
-};
+const mapDispatchToProps = dispatch => ({
+  signUp: (payload) => {
+    dispatch(signupAction(payload));
+  }
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(SignupForm);

--- a/assembl/static2/js/app/components/login/socialMediaLogin.jsx
+++ b/assembl/static2/js/app/components/login/socialMediaLogin.jsx
@@ -3,20 +3,18 @@ import { form } from 'react-bootstrap';
 import { Translate } from 'react-redux-i18n';
 import { get } from '../../utils/routeMap';
 
-const convertNameToCssClass = (name) => {
-  return name
+const convertNameToCssClass = name =>
+  name
     .toLowerCase()
     .split(/\s+/)
     .filter(Boolean)
     .join('_');
-};
 
-const reverseString = (s) => {
-  return s
+const reverseString = s =>
+  s
     .split('')
     .reverse()
     .join('');
-};
 
 export class SocialMedia extends React.Component {
   render() {
@@ -42,9 +40,9 @@ export class SocialMedia extends React.Component {
                 <form id={reverseString(provider.name)} method="get" action={provider.login}>
                   {next ? <input type="hidden" name="next" value={`${next}`} /> : null}
                   {provider.extra &&
-                    Object.keys(provider.extra).map((k) => {
-                      return <input key={provider.name + k} type="hidden" name={k} value={provider.extra[k]} />;
-                    })}
+                    Object.keys(provider.extra).map(k => (
+                      <input key={provider.name + k} type="hidden" name={k} value={provider.extra[k]} />
+                    ))}
                   <button className={`btn btn-block btn-social btn-${providerName}`} type="submit">
                     <i className={`assembl-icon-${providerName}`} />
                     {provider.name}

--- a/assembl/static2/js/app/components/navbar/BurgerNavbar.jsx
+++ b/assembl/static2/js/app/components/navbar/BurgerNavbar.jsx
@@ -11,25 +11,28 @@ import UserMenu from './UserMenu';
 
 export default class BurgerNavbar extends React.PureComponent {
   unlisten: () => void;
+
   state: {
     shouldDisplayMenu: boolean
   };
+
   componentWillMount() {
     this.setState({ shouldDisplayMenu: false });
     this.unlisten = browserHistory.listen(() => {
       this.setState({ shouldDisplayMenu: false });
     });
   }
+
   componentWillUnmount() {
     this.unlisten();
   }
+
   toggleMenu = () => {
-    this.setState((prevState) => {
-      return {
-        shouldDisplayMenu: !prevState.shouldDisplayMenu
-      };
-    });
+    this.setState(prevState => ({
+      shouldDisplayMenu: !prevState.shouldDisplayMenu
+    }));
   };
+
   render() {
     const { state, props, toggleMenu } = this;
     const { elements, slug, logoSrc, connectedUserId, currentPhaseIdentifier, helpUrl, location, logoLink } = props;

--- a/assembl/static2/js/app/components/navbar/FlatNavbar.jsx
+++ b/assembl/static2/js/app/components/navbar/FlatNavbar.jsx
@@ -7,10 +7,8 @@ import NavigationMenu from './navigationMenu';
 import LanguageMenu from './languageMenu';
 import UserMenu from './UserMenu';
 
-const refWidthUpdate = (setWidth) => {
-  return (ref) => {
-    if (ref) setWidth(ref.getBoundingClientRect().width);
-  };
+const refWidthUpdate = setWidth => (ref) => {
+  if (ref) setWidth(ref.getBoundingClientRect().width);
 };
 
 export default class FlatNavbar extends React.PureComponent {
@@ -18,14 +16,17 @@ export default class FlatNavbar extends React.PureComponent {
     leftWidth: number,
     rightWidth: number
   };
+
   static defaultProps = {
     style: {}
   };
+
   updateWidth = () => {
     const { leftWidth = 0, rightWidth = 0 } = this.state;
     const margin = 50;
     this.props.setWidth(leftWidth + rightWidth + margin);
   };
+
   render = () => {
     const { elements, slug, logoSrc, connectedUserId, currentPhaseIdentifier, helpUrl, location, style, logoLink } = this.props;
     return (

--- a/assembl/static2/js/app/components/navbar/UserMenu.jsx
+++ b/assembl/static2/js/app/components/navbar/UserMenu.jsx
@@ -13,23 +13,21 @@ type Props = {
   helpUrl: string
 };
 
-const UserMenu = ({ location, currentPhaseIdentifier, helpUrl }: Props) => {
-  return (
-    <div className="navbar-icons">
-      {currentPhaseIdentifier !== 'survey' && (
-        <div id="search">
-          <Search />
-        </div>
+const UserMenu = ({ location, currentPhaseIdentifier, helpUrl }: Props) => (
+  <div className="navbar-icons">
+    {currentPhaseIdentifier !== 'survey' && (
+      <div id="search">
+        <Search />
+      </div>
+    )}
+    {getConnectedUserId() &&
+      helpUrl && (
+        <Link to={helpUrl} target="_blank">
+          <span className="assembl-icon-faq grey" />
+        </Link>
       )}
-      {getConnectedUserId() &&
-        helpUrl && (
-          <Link to={helpUrl} target="_blank">
-            <span className="assembl-icon-faq grey" />
-          </Link>
-        )}
-      <Avatar location={location} />
-    </div>
-  );
-};
+    <Avatar location={location} />
+  </div>
+);
 
 export default UserMenu;

--- a/assembl/static2/js/app/components/navbar/languageMenu.jsx
+++ b/assembl/static2/js/app/components/navbar/languageMenu.jsx
@@ -15,6 +15,7 @@ class LanguageMenu extends React.Component {
     availableLocales: Array<string>,
     preferencesMapByLocale: { [string]: { nativeName: string, name: string, locale: string } }
   };
+
   static defaultProps = {
     className: ''
   };
@@ -76,18 +77,16 @@ class LanguageMenu extends React.Component {
             <MenuItem key={i18n.locale} className="active">
               {this.getLocaleLabel(i18n.locale)}
             </MenuItem>
-            {this.state.availableLocales.map((availableLocale) => {
-              return (
-                <MenuItem
-                  onClick={() => {
-                    this.doChangeLanguage(availableLocale);
-                  }}
-                  key={availableLocale}
-                >
-                  {this.getLocaleLabel(availableLocale)}
-                </MenuItem>
-              );
-            })}
+            {this.state.availableLocales.map(availableLocale => (
+              <MenuItem
+                onClick={() => {
+                  this.doChangeLanguage(availableLocale);
+                }}
+                key={availableLocale}
+              >
+                {this.getLocaleLabel(availableLocale)}
+              </MenuItem>
+            ))}
           </NavDropdown>
         </ul>
       );
@@ -96,33 +95,27 @@ class LanguageMenu extends React.Component {
   }
 }
 
-const mapStateToProps = (state) => {
-  return {
-    i18n: state.i18n
-  };
-};
+const mapStateToProps = state => ({
+  i18n: state.i18n
+});
 
-const mapDispatchToProps = (dispatch) => {
-  return {
-    changeLanguage: (locale) => {
-      dispatch(setLocale(locale));
-    },
-    addLanguageToStore: (locale) => {
-      dispatch(addLanguagePreference(locale));
-    }
-  };
-};
+const mapDispatchToProps = dispatch => ({
+  changeLanguage: (locale) => {
+    dispatch(setLocale(locale));
+  },
+  addLanguageToStore: (locale) => {
+    dispatch(addLanguagePreference(locale));
+  }
+});
 
 export default compose(
   connect(mapStateToProps, mapDispatchToProps),
   graphql(getDiscussionPreferenceLanguage, {
-    options: (props) => {
-      return {
-        variables: {
-          inLocale: props.i18n.locale
-        }
-      };
-    }
+    options: props => ({
+      variables: {
+        inLocale: props.i18n.locale
+      }
+    })
   }),
   withLoadingIndicator()
 )(LanguageMenu);

--- a/assembl/static2/js/app/components/navbar/navbar.jsx
+++ b/assembl/static2/js/app/components/navbar/navbar.jsx
@@ -35,23 +35,14 @@ const filterSection = ({ sectionType }, { hasResourcesCenter, hasSyntheses }) =>
   }
 };
 
-const sectionFilter = (options = {}) => {
-  return (section) => {
-    return filterSection(section, options);
-  };
-};
+const sectionFilter = (options = {}) => section => filterSection(section, options);
 
-const sectionKey = ({ sectionType, id }) => {
-  return sectionType === 'CUSTOM' ? `${sectionType}-${id}` : sectionType;
-};
+const sectionKey = ({ sectionType, id }) => (sectionType === 'CUSTOM' ? `${sectionType}-${id}` : sectionType);
 
-const sectionSlug = (sectionType) => {
-  return snakeToCamel(sectionType === 'HOMEPAGE' ? 'HOME' : sectionType);
-};
+const sectionSlug = sectionType => snakeToCamel(sectionType === 'HOMEPAGE' ? 'HOME' : sectionType);
 
-const sectionURL = ({ sectionType, url }, options) => {
-  return sectionType === 'CUSTOM' ? url : url || `${get(sectionSlug(sectionType), options)}`;
-};
+const sectionURL = ({ sectionType, url }, options) =>
+  (sectionType === 'CUSTOM' ? url : url || `${get(sectionSlug(sectionType), options)}`);
 
 const SectionLink = ({ section, options }) => {
   const { title, url, sectionType } = section;
@@ -67,20 +58,18 @@ const SectionLink = ({ section, options }) => {
 };
 SectionLink.displayName = 'SectionLink';
 
-const createDisplayModal = ({ debate, i18n }) => {
-  return () => {
-    const slug = { slug: getDiscussionSlug() };
-    const { timeline } = debate.debateData;
-    const { locale } = i18n;
-    const currentPhaseIdentifier = getCurrentPhaseIdentifier(timeline);
-    const phaseName = getPhaseName(timeline, currentPhaseIdentifier, locale).toLowerCase();
-    const body = <Translate value="redirectToV1" phaseName={phaseName} />;
-    const button = { link: get('oldDebate', slug), label: I18n.t('home.accessButton'), internalLink: false };
-    displayModal(null, body, true, null, button, true);
-    setTimeout(() => {
-      window.location = get('oldDebate', slug);
-    }, 6000);
-  };
+const createDisplayModal = ({ debate, i18n }) => () => {
+  const slug = { slug: getDiscussionSlug() };
+  const { timeline } = debate.debateData;
+  const { locale } = i18n;
+  const currentPhaseIdentifier = getCurrentPhaseIdentifier(timeline);
+  const phaseName = getPhaseName(timeline, currentPhaseIdentifier, locale).toLowerCase();
+  const body = <Translate value="redirectToV1" phaseName={phaseName} />;
+  const button = { link: get('oldDebate', slug), label: I18n.t('home.accessButton'), internalLink: false };
+  displayModal(null, body, true, null, button, true);
+  setTimeout(() => {
+    window.location = get('oldDebate', slug);
+  }, 6000);
 };
 
 const mapDebateSectionToElement = (debateSection, options) => {
@@ -119,13 +108,12 @@ type Section = {
   title: string
 };
 
-export const mapSectionToElement = (section: Section, options: MapSectionOptions) => {
-  return section.sectionType === 'DEBATE' ? (
+export const mapSectionToElement = (section: Section, options: MapSectionOptions) =>
+  (section.sectionType === 'DEBATE' ? (
     mapDebateSectionToElement(section, options)
   ) : (
     <SectionLink key={sectionKey(section)} section={section} options={options} />
-  );
-};
+  ));
 
 const phaseContext = (timeline, phase) => {
   const isSeveralPhases = isSeveralIdentifiers(timeline);
@@ -142,9 +130,11 @@ export class AssemblNavbar extends React.PureComponent {
   state: {
     flatWidth: number
   };
+
   setFlatWidth = (newWidth: number) => {
     this.setState({ flatWidth: newWidth });
   };
+
   render = () => {
     const { screenWidth, debate, data, location, phase, i18n } = this.props;
     const sections = (data && data.sections) || [];
@@ -153,9 +143,7 @@ export class AssemblNavbar extends React.PureComponent {
     const flatWidth = (this.state && this.state.flatWidth) || 0;
     const maxAppWidth = Math.min(APP_CONTAINER_MAX_WIDTH, screenWidth) - APP_CONTAINER_PADDING * 2;
     const screenTooSmall = flatWidth > maxAppWidth;
-    const filteredSections = sections.filter(sectionFilter(data)).sort((a, b) => {
-      return a.order - b.order;
-    });
+    const filteredSections = sections.filter(sectionFilter(data)).sort((a, b) => a.order - b.order);
     const mapOptions = {
       slug: slug,
       phase: getCurrentPhaseIdentifier(timeline),
@@ -168,11 +156,7 @@ export class AssemblNavbar extends React.PureComponent {
       logoSrc: logo,
       helpUrl: helpUrl,
       location: location,
-      logoLink:
-        sections.length > 0 &&
-        sections.find((section) => {
-          return section && section.sectionType === 'HOMEPAGE';
-        }).url
+      logoLink: sections.length > 0 && sections.find(section => section && section.sectionType === 'HOMEPAGE').url
     };
     return (
       <div className="background-light">
@@ -192,13 +176,11 @@ export class AssemblNavbar extends React.PureComponent {
 }
 
 export default compose(
-  connect((state) => {
-    return {
-      debate: state.debate,
-      phase: state.phase,
-      i18n: state.i18n
-    };
-  }),
+  connect(state => ({
+    debate: state.debate,
+    phase: state.phase,
+    i18n: state.i18n
+  })),
   graphql(SectionsQuery),
   withScreenWidth
 )(AssemblNavbar);

--- a/assembl/static2/js/app/components/resourcesCenter/index.jsx
+++ b/assembl/static2/js/app/components/resourcesCenter/index.jsx
@@ -22,20 +22,18 @@ type ResourcesCenterProps = {
   headerBackgroundUrl: string
 };
 
-const ResourcesCenter = ({ resources, headerBackgroundUrl, headerTitle }: ResourcesCenterProps) => {
-  return (
-    <div className="resources-center">
-      <Header title={headerTitle} imgUrl={headerBackgroundUrl} />
-      <section>
-        {resources.map((resource, index) => {
-          const { title, text, embedCode, image, doc } = resource;
-          return (
-            <ResourceBlock title={title} text={text} embedCode={embedCode} image={image} doc={doc} index={index} key={index} />
-          );
-        })}
-      </section>
-    </div>
-  );
-};
+const ResourcesCenter = ({ resources, headerBackgroundUrl, headerTitle }: ResourcesCenterProps) => (
+  <div className="resources-center">
+    <Header title={headerTitle} imgUrl={headerBackgroundUrl} />
+    <section>
+      {resources.map((resource, index) => {
+        const { title, text, embedCode, image, doc } = resource;
+        return (
+          <ResourceBlock title={title} text={text} embedCode={embedCode} image={image} doc={doc} index={index} key={index} />
+        );
+      })}
+    </section>
+  </div>
+);
 
 export default ResourcesCenter;

--- a/assembl/static2/js/app/components/search.jsx
+++ b/assembl/static2/js/app/components/search.jsx
@@ -47,9 +47,7 @@ const FRAGMENT_SIZE = 400;
 const elasticsearchLangIndexesElement = document.getElementById('elasticsearchLangIndexes');
 const elasticsearchLangIndexes = elasticsearchLangIndexesElement ? elasticsearchLangIndexesElement.value.split(' ') : [];
 
-const truncateText = (text) => {
-  return truncate(text, { length: FRAGMENT_SIZE, separator: ' ', omission: ' [...]' });
-};
+const truncateText = text => truncate(text, { length: FRAGMENT_SIZE, separator: ' ', omission: ' [...]' });
 
 const highlightedTextOrTruncatedText = (hit, field) => {
   let text = get(hit, `highlight.${field}`);
@@ -77,9 +75,7 @@ if (typeof __resourceQuery !== 'undefined' && __resourceQuery) {
   // const querystring = require('querystring');
   // const params = querystring.parse(__resourceQuery.slice(1));
   // if (params.v === '1') {
-  Link = (props) => {
-    return <a href={props.to} dangerouslySetInnerHTML={props.dangerouslySetInnerHTML} />;
-  };
+  Link = props => <a href={props.to} dangerouslySetInnerHTML={props.dangerouslySetInnerHTML} />;
   getUrl = (hit) => {
     const id = hit._source.id;
     switch (hit._type) {
@@ -97,9 +93,7 @@ if (typeof __resourceQuery !== 'undefined' && __resourceQuery) {
   // }
 } else {
   // Link = require('react-router').Link; // eslint-disable-line
-  Link = (props) => {
-    return <a href={props.to} dangerouslySetInnerHTML={props.dangerouslySetInnerHTML} />;
-  };
+  Link = props => <a href={props.to} dangerouslySetInnerHTML={props.dangerouslySetInnerHTML} />;
   getUrl = (hit) => {
     const id = hit._source.id;
     let ideaBase64id;
@@ -145,9 +139,7 @@ const TYPE_TO_ICON = {
   synthesis: 'synthesis'
 };
 
-const ImageType = (props) => {
-  return <span className={`${props.className} assembl-icon-${TYPE_TO_ICON[props.type]}`} />;
-};
+const ImageType = props => <span className={`${props.className} assembl-icon-${TYPE_TO_ICON[props.type]}`} />;
 
 const getFieldAnyLang = (source, prop, locale) => {
   let result;
@@ -226,9 +218,7 @@ const DumbPostHit = (props) => {
   );
 };
 
-const PostHit = connect((state) => {
-  return { locale: getLocale(state) };
-})(DumbPostHit);
+const PostHit = connect(state => ({ locale: getLocale(state) }))(DumbPostHit);
 
 const DumbSynthesisHit = (props) => {
   const locale = props.locale;
@@ -264,9 +254,7 @@ const DumbSynthesisHit = (props) => {
   );
 };
 
-const SynthesisHit = connect((state) => {
-  return { locale: getLocale(state) };
-})(DumbSynthesisHit);
+const SynthesisHit = connect(state => ({ locale: getLocale(state) }))(DumbSynthesisHit);
 
 const UserHit = (props) => {
   const source = props.result._source;
@@ -347,9 +335,7 @@ const DumbIdeaHit = (props) => {
   );
 };
 
-const IdeaHit = connect((state) => {
-  return { locale: getLocale(state) };
-})(DumbIdeaHit);
+const IdeaHit = connect(state => ({ locale: getLocale(state) }))(DumbIdeaHit);
 
 const HitItem = (props) => {
   switch (props.result._type) {
@@ -365,9 +351,7 @@ const HitItem = (props) => {
   }
 };
 
-const NoPanel = (props) => {
-  return <div>{props.children}</div>;
-};
+const NoPanel = props => <div>{props.children}</div>;
 
 const calcQueryFields = () => {
   const base = [
@@ -459,9 +443,7 @@ export class SearchComponent extends React.Component {
       return modifiedQuery;
     });
     const translate = I18n.t.bind(I18n);
-    this.searchkit.translateFunction = (key) => {
-      return translate(`search.${key}`);
-    };
+    this.searchkit.translateFunction = key => translate(`search.${key}`);
     this.state = { show: false, queryString: null };
   }
 
@@ -678,13 +660,11 @@ export class SearchComponent extends React.Component {
   }
 }
 
-const mapStateToProps = (state) => {
-  return {
-    isExpert: connectedUserIsExpert(),
-    connectedUserId: getConnectedUserId(state),
-    discussionId: getDebateId(state)
-  };
-};
+const mapStateToProps = state => ({
+  isExpert: connectedUserIsExpert(),
+  connectedUserId: getConnectedUserId(state),
+  discussionId: getDebateId(state)
+});
 
 const ConnectedSearch = connect(mapStateToProps)(SearchComponent);
 export default ConnectedSearch;

--- a/assembl/static2/js/app/components/search/SortingSelector.jsx
+++ b/assembl/static2/js/app/components/search/SortingSelector.jsx
@@ -19,9 +19,7 @@ class FilteredSortingSelector extends SortingSelector {
       setItems: this.setItems.bind(this),
       toggleItem: this.toggleItem.bind(this),
       disabled: disabled,
-      urlBuilder: (item) => {
-        return this.accessor.urlWithState(item.key);
-      },
+      urlBuilder: item => this.accessor.urlWithState(item.key),
       translate: this.translate
     });
   }

--- a/assembl/static2/js/app/components/svg/disagree.jsx
+++ b/assembl/static2/js/app/components/svg/disagree.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 
 class Disagree extends React.Component {
   props: { size: number };
+
   render() {
     const { size } = this.props;
     return (

--- a/assembl/static2/js/app/components/svg/dontUnderstand.jsx
+++ b/assembl/static2/js/app/components/svg/dontUnderstand.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 
 class DontUnderstand extends React.Component {
   props: { size: number };
+
   render() {
     const { size } = this.props;
     return (

--- a/assembl/static2/js/app/components/svg/doughnut.jsx
+++ b/assembl/static2/js/app/components/svg/doughnut.jsx
@@ -23,19 +23,16 @@ const describeArc = (x, y, radius, startAngle, endAngle) => {
   return d;
 };
 
-const getColor = (element) => {
-  return 'color' in element ? element.color : 'lightgrey';
-};
+const getColor = element => ('color' in element ? element.color : 'lightgrey');
 
-const simpleCircle = (cx, cy, r, element) => {
-  return 'Tooltip' in element ? (
+const simpleCircle = (cx, cy, r, element) =>
+  ('Tooltip' in element ? (
     <OverlayTrigger overlay={element.Tooltip} placement="bottom">
       <circle className="circle" cx={cx} cy={cy} r={r} stroke={getColor(element)} />
     </OverlayTrigger>
   ) : (
     <circle className="circle" cx={cx} cy={cy} r={r} stroke={getColor(element)} />
-  );
-};
+  ));
 
 const placementFromAngle = (angle) => {
   const topQuadrantStart = 360 - 45;
@@ -76,12 +73,8 @@ const doughnutConstants = {
 };
 
 const Doughnut = ({ elements }) => {
-  const filteredElements = elements.filter(({ count }) => {
-    return count > 0;
-  });
-  const totalCount = filteredElements.reduce((total, element) => {
-    return total + element.count;
-  }, 0);
+  const filteredElements = elements.filter(({ count }) => count > 0);
+  const totalCount = filteredElements.reduce((total, element) => total + element.count, 0);
   const { cx, cy, r } = doughnutConstants;
   const viewBox = `0 0 ${cx * 2} ${cy * 2}`;
   return totalCount === 0 ? (

--- a/assembl/static2/js/app/components/svg/gauge.jsx
+++ b/assembl/static2/js/app/components/svg/gauge.jsx
@@ -12,11 +12,9 @@ export default ({ rectCounts, color }) => {
   }
   return (
     <svg width="25" height="58">
-      {rectArray.map((hexa, index) => {
-        return (
-          <rect rx="1" height="3" width="15" y={(index + 1) * 5} x="5" strokeWidth="1.5" stroke={hexa} fill={hexa} key={index} />
-        );
-      })}
+      {rectArray.map((hexa, index) => (
+        <rect rx="1" height="3" width="15" y={(index + 1) * 5} x="5" strokeWidth="1.5" stroke={hexa} fill={hexa} key={index} />
+      ))}
     </svg>
   );
 };

--- a/assembl/static2/js/app/components/svg/like.jsx
+++ b/assembl/static2/js/app/components/svg/like.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 
 class Like extends React.Component {
   props: { size: number };
+
   render() {
     const { size } = this.props;
     return (

--- a/assembl/static2/js/app/components/synthesis/IdeaSynthesis.jsx
+++ b/assembl/static2/js/app/components/synthesis/IdeaSynthesis.jsx
@@ -27,23 +27,19 @@ export type SynthesisIdea = {
   }
 };
 
-const SynthesisBody = ({ level, hasSiblings, value, stats }) => {
-  return (
-    <div className="synthesis-body" style={{ columnCount: !hasSiblings && level > 2 ? 2 : 'auto' }}>
-      <p dangerouslySetInnerHTML={{ __html: value }} />
-      {stats}
-    </div>
-  );
-};
+const SynthesisBody = ({ level, hasSiblings, value, stats }) => (
+  <div className="synthesis-body" style={{ columnCount: !hasSiblings && level > 2 ? 2 : 'auto' }}>
+    <p dangerouslySetInnerHTML={{ __html: value }} />
+    {stats}
+  </div>
+);
 
-const LinkToIdea = ({ href }) => {
-  return (
-    <Link className="idea-link" to={href}>
-      {'> '}
-      <Translate value="synthesis.seeConversation" />
-    </Link>
-  );
-};
+const LinkToIdea = ({ href }) => (
+  <Link className="idea-link" to={href}>
+    {'> '}
+    <Translate value="synthesis.seeConversation" />
+  </Link>
+);
 
 const SynthesisStats = ({ numContributors, numPosts, ideaLink, posts }) => {
   const sentimentCounts = getSentimentsCount(posts);

--- a/assembl/static2/js/app/components/synthesis/IdeaSynthesisTree.jsx
+++ b/assembl/static2/js/app/components/synthesis/IdeaSynthesisTree.jsx
@@ -23,22 +23,20 @@ const IdeaSynthesisTree = (props: {
   const newParents = parents.slice();
   newParents.push(index);
   const level = parents.length + 1;
-  const tree = roots.map((idea, subIndex) => {
-    return (
-      <Row key={idea.id}>
-        <Col sm={level === 3 && hasSiblings ? 6 : 12} xs={12}>
-          <IdeaSynthesisTree
-            hasSiblings={rootsHasSiblings}
-            rootIdea={idea}
-            index={subIndex + 1}
-            parents={newParents}
-            subIdeas={getChildren(idea, descendants)}
-            slug={slug}
-          />
-        </Col>
-      </Row>
-    );
-  });
+  const tree = roots.map((idea, subIndex) => (
+    <Row key={idea.id}>
+      <Col sm={level === 3 && hasSiblings ? 6 : 12} xs={12}>
+        <IdeaSynthesisTree
+          hasSiblings={rootsHasSiblings}
+          rootIdea={idea}
+          index={subIndex + 1}
+          parents={newParents}
+          subIdeas={getChildren(idea, descendants)}
+          slug={slug}
+        />
+      </Col>
+    </Row>
+  ));
   return (
     <Section displayIndex title={rootIdea.title} index={index} parents={parents} className="idea-synthesis-section">
       <IdeaSynthesis hasSiblings={hasSiblings} level={level} idea={rootIdea} slug={slug} />

--- a/assembl/static2/js/app/main.jsx
+++ b/assembl/static2/js/app/main.jsx
@@ -12,6 +12,7 @@ type Debate = { debateData: { timeline: Timeline } };
 
 class Main extends React.Component {
   state: { identifier: string, location: string };
+
   constructor(props: {
     debate: Debate,
     params: { phase: string },
@@ -28,6 +29,7 @@ class Main extends React.Component {
       location: this.props.location.pathname
     };
   }
+
   componentWillMount() {
     const { debateData } = this.props.debate;
     const currentPhaseIdentifier = getCurrentPhaseIdentifier(debateData.timeline);
@@ -36,13 +38,12 @@ class Main extends React.Component {
       // timeline is not configured
       isRedirectionToV1 = true;
     } else {
-      const currentPhase = debateData.timeline.filter((phase) => {
-        return phase.identifier === currentPhaseIdentifier;
-      });
+      const currentPhase = debateData.timeline.filter(phase => phase.identifier === currentPhaseIdentifier);
       isRedirectionToV1 = currentPhase[0] && currentPhase[0].interface_v1;
     }
     this.props.addRedirectionToV1(isRedirectionToV1);
   }
+
   componentWillReceiveProps(nextProps) {
     const location = nextProps.location.pathname;
     const { debateData } = this.props.debate;
@@ -55,13 +56,14 @@ class Main extends React.Component {
 
     window.scrollTo({ top: 0, left: 0, behavior: 'smooth' });
   }
+
   render() {
     const that = this;
-    const children = React.Children.map(this.props.children, (child) => {
-      return React.cloneElement(child, {
+    const children = React.Children.map(this.props.children, child =>
+      React.cloneElement(child, {
         identifier: that.state.identifier
-      });
-    });
+      })
+    );
     return (
       <div className="main">
         <Navbar location={this.state.location} />
@@ -72,18 +74,14 @@ class Main extends React.Component {
   }
 }
 
-const mapStateToProps = (state: { debate: Debate }) => {
-  return {
-    debate: state.debate
-  };
-};
+const mapStateToProps = (state: { debate: Debate }) => ({
+  debate: state.debate
+});
 
-const mapDispatchToProps = (dispatch) => {
-  return {
-    addRedirectionToV1: (discussionId: string) => {
-      dispatch(addRedirectionToV1(discussionId));
-    }
-  };
-};
+const mapDispatchToProps = dispatch => ({
+  addRedirectionToV1: (discussionId: string) => {
+    dispatch(addRedirectionToV1(discussionId));
+  }
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(Main);

--- a/assembl/static2/js/app/pages/administration.jsx
+++ b/assembl/static2/js/app/pages/administration.jsx
@@ -97,12 +97,10 @@ class Administration extends React.Component {
 
   putResourcesInStore(resources) {
     const filteredResources = filter(ResourcesQuery, { resources: resources });
-    const resourcesForStore = filteredResources.resources.map((resource) => {
-      return {
-        ...resource,
-        textEntries: resource.textEntries ? convertEntriesToRawContentState(resource.textEntries) : null
-      };
-    });
+    const resourcesForStore = filteredResources.resources.map(resource => ({
+      ...resource,
+      textEntries: resource.textEntries ? convertEntriesToRawContentState(resource.textEntries) : null
+    }));
     this.props.updateResources(resourcesForStore);
   }
 
@@ -113,9 +111,7 @@ class Administration extends React.Component {
 
   putSectionsInStore(sections) {
     const filteredSections = filter(SectionsQuery, {
-      sections: sections.filter((section) => {
-        return section.sectionType !== 'ADMINISTRATION';
-      })
+      sections: sections.filter(section => section.sectionType !== 'ADMINISTRATION')
     });
     this.props.updateSections(filteredSections.sections);
   }
@@ -147,11 +143,11 @@ class Administration extends React.Component {
     } = this.props;
     const { phase } = params;
     const { timeline } = this.props.debate.debateData;
-    const childrenWithProps = React.Children.map(children, (child) => {
-      return React.cloneElement(child, {
+    const childrenWithProps = React.Children.map(children, child =>
+      React.cloneElement(child, {
         toggleLanguageMenu: this.toggleLanguageMenu
-      });
-    });
+      })
+    );
 
     return (
       <div className="administration">
@@ -202,65 +198,51 @@ class Administration extends React.Component {
   }
 }
 
-const mapStateToProps = (state) => {
-  return {
-    debate: state.debate,
-    i18n: state.i18n
-  };
-};
+const mapStateToProps = state => ({
+  debate: state.debate,
+  i18n: state.i18n
+});
 
-const mapDispatchToProps = (dispatch) => {
-  return {
-    updateResources: (resources) => {
-      return dispatch(updateResources(resources));
-    },
-    updateSections: (sections) => {
-      return dispatch(updateSections(sections));
-    },
-    updateThematics: (thematics) => {
-      return dispatch(updateThematics(thematics));
-    },
-    updateResourcesCenterPage: ({ titleEntries, headerImage }) => {
-      dispatch(updateResourcesCenterPage(titleEntries, headerImage));
-    },
-    updateLegalNoticeAndTerms: (legalNoticeAndTerms) => {
-      return dispatch(updateLegalNoticeAndTerms(legalNoticeAndTerms));
-    }
-  };
-};
+const mapDispatchToProps = dispatch => ({
+  updateResources: resources => dispatch(updateResources(resources)),
+  updateSections: sections => dispatch(updateSections(sections)),
+  updateThematics: thematics => dispatch(updateThematics(thematics)),
+  updateResourcesCenterPage: ({ titleEntries, headerImage }) => {
+    dispatch(updateResourcesCenterPage(titleEntries, headerImage));
+  },
+  updateLegalNoticeAndTerms: legalNoticeAndTerms => dispatch(updateLegalNoticeAndTerms(legalNoticeAndTerms))
+});
 
-const mergeLoadingAndHasErrors = (WrappedComponent) => {
-  return (props) => {
-    const {
-      data,
-      resourcesHasErrors,
-      resourcesCenterHasErrors,
-      resourcesLoading,
-      resourcesCenterLoading,
-      sectionsHasErrors,
-      sectionsLoading,
-      tabsConditionsLoading,
-      tabsConditionsHasErrors,
-      legalNoticeAndTermsLoading,
-      legalNoticeAndTermsHasErrors
-    } = props;
-    const hasErrors =
-      resourcesHasErrors ||
-      resourcesCenterHasErrors ||
-      tabsConditionsHasErrors ||
-      legalNoticeAndTermsHasErrors ||
-      sectionsHasErrors ||
-      (data && data.error);
-    const loading =
-      resourcesLoading ||
-      resourcesCenterLoading ||
-      tabsConditionsLoading ||
-      legalNoticeAndTermsLoading ||
-      sectionsLoading ||
-      (data && data.loading);
+const mergeLoadingAndHasErrors = WrappedComponent => (props) => {
+  const {
+    data,
+    resourcesHasErrors,
+    resourcesCenterHasErrors,
+    resourcesLoading,
+    resourcesCenterLoading,
+    sectionsHasErrors,
+    sectionsLoading,
+    tabsConditionsLoading,
+    tabsConditionsHasErrors,
+    legalNoticeAndTermsLoading,
+    legalNoticeAndTermsHasErrors
+  } = props;
+  const hasErrors =
+    resourcesHasErrors ||
+    resourcesCenterHasErrors ||
+    tabsConditionsHasErrors ||
+    legalNoticeAndTermsHasErrors ||
+    sectionsHasErrors ||
+    (data && data.error);
+  const loading =
+    resourcesLoading ||
+    resourcesCenterLoading ||
+    tabsConditionsLoading ||
+    legalNoticeAndTermsLoading ||
+    sectionsLoading ||
+    (data && data.loading);
 
-    return <WrappedComponent {...props} hasErrors={hasErrors} loading={loading} />;
-  };
+  return <WrappedComponent {...props} hasErrors={hasErrors} loading={loading} />;
 };
 
 export default compose(
@@ -269,11 +251,9 @@ export default compose(
     options: { variables: { identifier: 'survey' } }
   }),
   graphql(TabsConditionQuery, {
-    options: ({ i18n }) => {
-      return {
-        variables: { lang: i18n.locale }
-      };
-    },
+    options: ({ i18n }) => ({
+      variables: { lang: i18n.locale }
+    }),
     // pass refetchTabsConditions to re-render navigation menu if there is a change in resources
     props: ({ data }) => {
       if (data.loading) {

--- a/assembl/static2/js/app/pages/debate.jsx
+++ b/assembl/static2/js/app/pages/debate.jsx
@@ -19,28 +19,32 @@ class Debate extends React.Component {
     this.hideThumbnails = this.hideThumbnails.bind(this);
     this.displayThumbnails = this.displayThumbnails.bind(this);
   }
+
   showThumbnails() {
     this.setState({ isThumbnailsHidden: false });
   }
+
   hideThumbnails() {
     setTimeout(() => {
       this.setState({ isThumbnailsHidden: true });
     }, 400);
   }
+
   displayThumbnails() {
     this.setState({ isThumbnailsHidden: !this.state.isThumbnailsHidden });
   }
+
   render() {
     const { loading, thematics } = this.props.data;
     const { identifier } = this.props;
     const isParentRoute = !this.props.params.themeId || false;
     const themeId = this.props.params.themeId || null;
-    const children = React.Children.map(this.props.children, (child) => {
-      return React.cloneElement(child, {
+    const children = React.Children.map(this.props.children, child =>
+      React.cloneElement(child, {
         id: themeId,
         identifier: identifier
-      });
-    });
+      })
+    );
     return (
       <div className="debate">
         {loading && isParentRoute && <Loader color="black" />}
@@ -85,10 +89,8 @@ Debate.propTypes = {
 
 const DebateWithData = graphql(DebateThematicsQuery)(Debate);
 
-const mapStateToProps = (state) => {
-  return {
-    lang: state.i18n.locale
-  };
-};
+const mapStateToProps = state => ({
+  lang: state.i18n.locale
+});
 
 export default connect(mapStateToProps)(DebateWithData);

--- a/assembl/static2/js/app/pages/debateThread.jsx
+++ b/assembl/static2/js/app/pages/debateThread.jsx
@@ -14,12 +14,12 @@ const DebateThread = ({ identifier, data, params, children, slug }) => {
   const { loading, ideas, rootIdea } = data;
   const isParentRoute = !params.themeId || false;
   const themeId = params.themeId || null;
-  const childrenElm = React.Children.map(children, (child) => {
-    return React.cloneElement(child, {
+  const childrenElm = React.Children.map(children, child =>
+    React.cloneElement(child, {
       id: themeId,
       identifier: identifier
-    });
-  });
+    })
+  );
   return (
     <div className="debate">
       {loading && isParentRoute && <Loader color="black" />}
@@ -54,11 +54,9 @@ DebateThread.propTypes = {
   }).isRequired
 };
 
-const mapStateToProps = (state) => {
-  return {
-    lang: state.i18n.locale,
-    slug: state.debate.debateData.slug
-  };
-};
+const mapStateToProps = state => ({
+  lang: state.i18n.locale,
+  slug: state.debate.debateData.slug
+});
 
 export default compose(connect(mapStateToProps), graphql(AllIdeasQuery))(DebateThread);

--- a/assembl/static2/js/app/pages/discussionAdmin.jsx
+++ b/assembl/static2/js/app/pages/discussionAdmin.jsx
@@ -18,10 +18,8 @@ const DiscussionAdmin = (props) => {
   );
 };
 
-const mapStateToProps = (state) => {
-  return {
-    selectedLocale: state.admin.selectedLocale
-  };
-};
+const mapStateToProps = state => ({
+  selectedLocale: state.admin.selectedLocale
+});
 
 export default connect(mapStateToProps)(DiscussionAdmin);

--- a/assembl/static2/js/app/pages/home.jsx
+++ b/assembl/static2/js/app/pages/home.jsx
@@ -50,11 +50,9 @@ class Home extends React.Component {
   }
 }
 
-const mapStateToProps = (state) => {
-  return {
-    debate: state.debate,
-    i18n: state.i18n
-  };
-};
+const mapStateToProps = state => ({
+  debate: state.debate,
+  i18n: state.i18n
+});
 
 export default connect(mapStateToProps)(Home);

--- a/assembl/static2/js/app/pages/idea.jsx
+++ b/assembl/static2/js/app/pages/idea.jsx
@@ -30,15 +30,14 @@ export const transformPosts = (edges, messageColumns, additionnalProps = {}) => 
     items.push(p);
   });
 
-  const getChildren = (id) => {
-    return (postsByParent[id] || []).map((post) => {
+  const getChildren = id =>
+    (postsByParent[id] || []).map((post) => {
       const newPost = post;
       // We modify the object in place, we are sure it's already a copy from
       // the forEach edges above.
       newPost.children = getChildren(post.id);
       return newPost;
     });
-  };
 
   // postsByParent.null is the list of top posts
   return (postsByParent.null || []).map((p) => {
@@ -48,13 +47,11 @@ export const transformPosts = (edges, messageColumns, additionnalProps = {}) => 
   });
 };
 
-const noRowsRenderer = () => {
-  return (
-    <div className="center">
-      <Translate value="debate.thread.noPostsInThread" />
-    </div>
-  );
-};
+const noRowsRenderer = () => (
+  <div className="center">
+    <Translate value="debate.thread.noPostsInThread" />
+  </div>
+);
 
 class Idea extends React.Component {
   constructor(props) {
@@ -104,9 +101,7 @@ class Idea extends React.Component {
         post = allPosts[post.parentId];
       }
       const topPostId = post.id;
-      const index = topPosts.findIndex((value) => {
-        return value.id === topPostId;
-      });
+      const index = topPosts.findIndex(value => value.id === topPostId);
       if (index > -1) {
         return index;
       }
@@ -193,22 +188,16 @@ class Idea extends React.Component {
   }
 }
 
-const mapStateToProps = (state) => {
-  return {
-    contentLocaleMapping: state.contentLocale,
-    debateData: state.debate.debateData,
-    defaultContentLocaleMapping: state.defaultContentLocaleMapping,
-    lang: state.i18n.locale
-  };
-};
+const mapStateToProps = state => ({
+  contentLocaleMapping: state.contentLocale,
+  debateData: state.debate.debateData,
+  defaultContentLocaleMapping: state.defaultContentLocaleMapping,
+  lang: state.i18n.locale
+});
 
-const mapDispatchToProps = (dispatch) => {
-  return {
-    updateContentLocaleMapping: (info) => {
-      return dispatch(updateContentLocale(info));
-    }
-  };
-};
+const mapDispatchToProps = dispatch => ({
+  updateContentLocaleMapping: info => dispatch(updateContentLocale(info))
+});
 
 export default compose(
   connect(mapStateToProps, mapDispatchToProps),

--- a/assembl/static2/js/app/pages/joinDiscussion.jsx
+++ b/assembl/static2/js/app/pages/joinDiscussion.jsx
@@ -1,5 +1,3 @@
 import React from 'react';
 
-export const Join = () => {
-  return <div>Join the discussion</div>;
-};
+export const Join = () => <div>Join the discussion</div>;

--- a/assembl/static2/js/app/pages/legalNotice.jsx
+++ b/assembl/static2/js/app/pages/legalNotice.jsx
@@ -9,11 +9,9 @@ import withLoadingIndicator from '../components/common/withLoadingIndicator';
 import LegalNoticeAndTerms from '../graphql/LegalNoticeAndTerms.graphql';
 import type { RootReducer } from '../reducers/rootReducer';
 
-export const mapStateToProps: RootReducer => LegalNoticeAndTermsQueryVariables = (state) => {
-  return {
-    lang: state.i18n.locale
-  };
-};
+export const mapStateToProps: RootReducer => LegalNoticeAndTermsQueryVariables = state => ({
+  lang: state.i18n.locale
+});
 
 type Response = {
   text?: string,

--- a/assembl/static2/js/app/pages/profile.jsx
+++ b/assembl/static2/js/app/pages/profile.jsx
@@ -33,6 +33,7 @@ type ProfileSate = {
 
 class Profile extends React.PureComponent<*, ProfileProps, ProfileSate> {
   props: ProfileProps;
+
   state: ProfileSate;
 
   constructor(props) {
@@ -44,6 +45,7 @@ class Profile extends React.PureComponent<*, ProfileProps, ProfileSate> {
       email: email
     };
   }
+
   componentWillMount() {
     const { connectedUserId, slug } = this.props;
     const { userId } = this.props.params;
@@ -54,15 +56,19 @@ class Profile extends React.PureComponent<*, ProfileProps, ProfileSate> {
       browserHistory.push(get('home', { slug: slug }));
     }
   }
+
   handleUsernameChange = (e) => {
     this.setState({ username: e.target.value });
   };
+
   handleFullnameChange = (e) => {
     this.setState({ name: e.target.value });
   };
+
   handleEmailChange = (e) => {
     this.setState({ email: e.target.value });
   };
+
   handleSaveClick = () => {
     const { updateUser, id } = this.props;
     const { name, username } = this.state;
@@ -79,10 +85,12 @@ class Profile extends React.PureComponent<*, ProfileProps, ProfileSate> {
         displayAlert('danger', error);
       });
   };
+
   handlePasswordClick = () => {
     const { slug } = this.props;
     browserHistory.push(get('ctxRequestPasswordChange', { slug: slug }));
   };
+
   render() {
     const { username, name, email } = this.state;
     const fullNameLabel = I18n.t('profile.fullname');

--- a/assembl/static2/js/app/pages/requestPasswordChange.jsx
+++ b/assembl/static2/js/app/pages/requestPasswordChange.jsx
@@ -25,10 +25,8 @@ class RequestPasswordChange extends React.Component {
   }
 }
 
-const mapStateToProps = (state) => {
-  return {
-    auth: state.auth
-  };
-};
+const mapStateToProps = state => ({
+  auth: state.auth
+});
 
 export default connect(mapStateToProps)(RequestPasswordChange);

--- a/assembl/static2/js/app/pages/resourcesCenter.jsx
+++ b/assembl/static2/js/app/pages/resourcesCenter.jsx
@@ -7,16 +7,14 @@ import ResourcesCenterPageQuery from '../graphql/ResourcesCenterPage.graphql';
 import withLoadingIndicator from '../components/common/withLoadingIndicator';
 import ResourcesCenter from '../components/resourcesCenter';
 
-const ResourcesCenterContainer = ({ data, resourcesCenterHeaderUrl, resourcesCenterTitle }) => {
-  return <ResourcesCenter {...data} headerBackgroundUrl={resourcesCenterHeaderUrl} headerTitle={resourcesCenterTitle} />;
-};
+const ResourcesCenterContainer = ({ data, resourcesCenterHeaderUrl, resourcesCenterTitle }) => (
+  <ResourcesCenter {...data} headerBackgroundUrl={resourcesCenterHeaderUrl} headerTitle={resourcesCenterTitle} />
+);
 
-const mapStateToProps = (state) => {
-  return {
-    debate: state.debate,
-    lang: state.i18n.locale
-  };
-};
+const mapStateToProps = state => ({
+  debate: state.debate,
+  lang: state.i18n.locale
+});
 
 export default compose(
   connect(mapStateToProps),

--- a/assembl/static2/js/app/pages/resourcesCenterAdmin.jsx
+++ b/assembl/static2/js/app/pages/resourcesCenterAdmin.jsx
@@ -6,20 +6,16 @@ import SectionTitle from '../components/administration/sectionTitle';
 import PageForm from '../components/administration/resourcesCenter/pageForm';
 import ManageResourcesForm from '../components/administration/resourcesCenter/manageResourcesForm';
 
-const ResourcesCenterAdmin = ({ selectedLocale }) => {
-  return (
-    <div className="resources-center-admin admin-box">
-      <SectionTitle title={I18n.t('administration.resourcesCenter.title')} annotation={I18n.t('administration.annotation')} />
-      <PageForm selectedLocale={selectedLocale} />
-      <ManageResourcesForm selectedLocale={selectedLocale} />
-    </div>
-  );
-};
+const ResourcesCenterAdmin = ({ selectedLocale }) => (
+  <div className="resources-center-admin admin-box">
+    <SectionTitle title={I18n.t('administration.resourcesCenter.title')} annotation={I18n.t('administration.annotation')} />
+    <PageForm selectedLocale={selectedLocale} />
+    <ManageResourcesForm selectedLocale={selectedLocale} />
+  </div>
+);
 
-const mapStateToProps = (state) => {
-  return {
-    selectedLocale: state.admin.selectedLocale
-  };
-};
+const mapStateToProps = state => ({
+  selectedLocale: state.admin.selectedLocale
+});
 
 export default connect(mapStateToProps)(ResourcesCenterAdmin);

--- a/assembl/static2/js/app/pages/signup.jsx
+++ b/assembl/static2/js/app/pages/signup.jsx
@@ -25,10 +25,8 @@ class Signup extends React.Component {
   }
 }
 
-const mapStateToProps = (state) => {
-  return {
-    auth: state.auth
-  };
-};
+const mapStateToProps = state => ({
+  auth: state.auth
+});
 
 export default connect(mapStateToProps)(Signup);

--- a/assembl/static2/js/app/pages/survey.jsx
+++ b/assembl/static2/js/app/pages/survey.jsx
@@ -60,7 +60,9 @@ type SurveyState = {
 
 class Survey extends React.Component<*, SurveyProps, SurveyState> {
   props: SurveyProps;
+
   state: SurveyState;
+
   unlisten: Function;
 
   constructor(props) {
@@ -148,18 +150,16 @@ class Survey extends React.Component<*, SurveyProps, SurveyState> {
           <Media {...media} />
           <div className="questions">
             {questions &&
-              questions.map((question, index) => {
-                return (
-                  <Question
-                    title={question.title}
-                    index={index + 1}
-                    key={index}
-                    questionId={question.id}
-                    scrollToQuestion={this.scrollToQuestion}
-                    refetchTheme={refetchThematic}
-                  />
-                );
-              })}
+              questions.map((question, index) => (
+                <Question
+                  title={question.title}
+                  index={index + 1}
+                  key={index}
+                  questionId={question.id}
+                  scrollToQuestion={this.scrollToQuestion}
+                  refetchTheme={refetchThematic}
+                />
+              ))}
           </div>
           {questions && (
             <Navigation
@@ -181,18 +181,16 @@ class Survey extends React.Component<*, SurveyProps, SurveyState> {
                   </div>
                   <div className="center">
                     {questions &&
-                      questions.map((question, index) => {
-                        return (
-                          <Proposals
-                            title={question.title}
-                            posts={question.posts.edges}
-                            moreProposals={this.state.moreProposals}
-                            questionIndex={index + 1}
-                            key={index}
-                            refetchTheme={refetchThematic}
-                          />
-                        );
-                      })}
+                      questions.map((question, index) => (
+                        <Proposals
+                          title={question.title}
+                          posts={question.posts.edges}
+                          moreProposals={this.state.moreProposals}
+                          questionIndex={index + 1}
+                          key={index}
+                          refetchTheme={refetchThematic}
+                        />
+                      ))}
                     {!this.state.moreProposals &&
                       this.getIfProposals(questions) && (
                         <Button className="button-submit button-dark" onClick={this.showMoreProposals}>
@@ -211,21 +209,15 @@ class Survey extends React.Component<*, SurveyProps, SurveyState> {
   }
 }
 
-const mapStateToProps = (state) => {
-  return {
-    debate: state.debate,
-    defaultContentLocaleMapping: state.defaultContentLocaleMapping,
-    lang: state.i18n.locale
-  };
-};
+const mapStateToProps = state => ({
+  debate: state.debate,
+  defaultContentLocaleMapping: state.defaultContentLocaleMapping,
+  lang: state.i18n.locale
+});
 
-const mapDispatchToProps = (dispatch) => {
-  return {
-    updateContentLocaleMapping: (data) => {
-      return dispatch(updateContentLocale(data));
-    }
-  };
-};
+const mapDispatchToProps = dispatch => ({
+  updateContentLocaleMapping: data => dispatch(updateContentLocale(data))
+});
 
 export default compose(
   connect(mapStateToProps, mapDispatchToProps),

--- a/assembl/static2/js/app/pages/syntheses.jsx
+++ b/assembl/static2/js/app/pages/syntheses.jsx
@@ -22,6 +22,7 @@ type SynthesesProps = {
 
 export class DumbSyntheses extends React.Component<void, SynthesesProps, void> {
   props: SynthesesProps;
+
   componentDidMount() {
     const { syntheses, slug } = this.props;
     if (syntheses.length === 1) {
@@ -29,6 +30,7 @@ export class DumbSyntheses extends React.Component<void, SynthesesProps, void> {
       browserHistory.push(`${get('synthesis', { synthesisId: firstSynthesis.post.id, slug: slug })}`);
     }
   }
+
   render() {
     const { syntheses, slug, hasSyntheses } = this.props;
     return (
@@ -42,20 +44,18 @@ export class DumbSyntheses extends React.Component<void, SynthesesProps, void> {
             data={syntheses}
             classNameGenerator={CLASS_NAME_GENERATOR.default}
             itemClassName="theme"
-            CardItem={(itemData) => {
-              return (
-                <Card imgUrl={itemData.img ? itemData.img.externalUrl : ''} className="synthesis-preview">
-                  <Link className="content-box" to={`${get('synthesis', { synthesisId: itemData.post.id, slug: slug })}`}>
-                    <div className="title-container center">
-                      <h3 className="light-title-3">{itemData.subject}</h3>
-                      <h4 className="light-title-4">
-                        <Localize value={itemData.creationDate} dateFormat="date.format2" />
-                      </h4>
-                    </div>
-                  </Link>
-                </Card>
-              );
-            }}
+            CardItem={itemData => (
+              <Card imgUrl={itemData.img ? itemData.img.externalUrl : ''} className="synthesis-preview">
+                <Link className="content-box" to={`${get('synthesis', { synthesisId: itemData.post.id, slug: slug })}`}>
+                  <div className="title-container center">
+                    <h3 className="light-title-3">{itemData.subject}</h3>
+                    <h4 className="light-title-4">
+                      <Localize value={itemData.creationDate} dateFormat="date.format2" />
+                    </h4>
+                  </div>
+                </Link>
+              </Card>
+            )}
           />
         )}
       </Section>
@@ -63,12 +63,10 @@ export class DumbSyntheses extends React.Component<void, SynthesesProps, void> {
   }
 }
 
-const mapStateToProps = (state) => {
-  return {
-    lang: state.i18n.locale,
-    slug: state.debate.debateData.slug
-  };
-};
+const mapStateToProps = state => ({
+  lang: state.i18n.locale,
+  slug: state.debate.debateData.slug
+});
 
 export default compose(
   connect(mapStateToProps),

--- a/assembl/static2/js/app/pages/synthesis.jsx
+++ b/assembl/static2/js/app/pages/synthesis.jsx
@@ -48,19 +48,17 @@ export class DumbSynthesis extends React.Component<void, SynthesisProps, void> {
           )}
           <Row className="background-grey synthesis-tree">
             <Col mdOffset={3} md={7} smOffset={1} sm={10}>
-              {roots.map((rootIdea, index) => {
-                return (
-                  <IdeaSynthesisTree
-                    hasSiblings={hasSiblings}
-                    key={rootIdea.id}
-                    rootIdea={rootIdea}
-                    index={index + 1}
-                    parents={[]}
-                    subIdeas={getChildren(rootIdea, descendants)}
-                    slug={routeParams.slug}
-                  />
-                );
-              })}
+              {roots.map((rootIdea, index) => (
+                <IdeaSynthesisTree
+                  hasSiblings={hasSiblings}
+                  key={rootIdea.id}
+                  rootIdea={rootIdea}
+                  index={index + 1}
+                  parents={[]}
+                  subIdeas={getChildren(rootIdea, descendants)}
+                  slug={routeParams.slug}
+                />
+              ))}
             </Col>
           </Row>
           {conclusion && (
@@ -78,20 +76,16 @@ export class DumbSynthesis extends React.Component<void, SynthesisProps, void> {
   }
 }
 
-const mapStateToProps = (state) => {
-  return {
-    lang: state.i18n.locale
-  };
-};
+const mapStateToProps = state => ({
+  lang: state.i18n.locale
+});
 
 export default compose(
   connect(mapStateToProps),
   graphql(SynthesisQuery, {
-    options: (props) => {
-      return {
-        variables: { id: props.params.synthesisId, lang: props.lang }
-      };
-    },
+    options: props => ({
+      variables: { id: props.params.synthesisId, lang: props.lang }
+    }),
     props: ({ data }) => {
       if (data.loading) {
         return { loading: true };

--- a/assembl/static2/js/app/reducers/adminReducer/adminSections.js
+++ b/assembl/static2/js/app/reducers/adminReducer/adminSections.js
@@ -45,14 +45,8 @@ export const sectionsInOrder: SectionsInOrderReducer = (state = List(), action) 
     return state.delete(idx);
   }
   case UPDATE_SECTIONS: {
-    const sections = action.sections.sort((a, b) => {
-      return a.order - b.order;
-    });
-    return List(
-      sections.map((s) => {
-        return s.id;
-      })
-    );
+    const sections = action.sections.sort((a, b) => a.order - b.order);
+    return List(sections.map(s => s.id));
   }
   case MOVE_UP_SECTION: {
     const idx = state.indexOf(action.id);

--- a/assembl/static2/js/app/reducers/adminReducer/index.js
+++ b/assembl/static2/js/app/reducers/adminReducer/index.js
@@ -29,11 +29,7 @@ export const thematicsInOrder: ThematicsInOrderReducer = (state = List(), action
   case 'CREATE_NEW_THEMATIC':
     return state.push(action.id);
   case 'UPDATE_THEMATICS': {
-    return List(
-      action.thematics.map((t) => {
-        return t.id;
-      })
-    );
+    return List(action.thematics.map(t => t.id));
   }
   default:
     return state;
@@ -48,9 +44,7 @@ export const thematicsById: ThematicsByIdReducer = (state = Map(), action) => {
     const newQuestion = fromJS({
       titleEntries: [{ localeCode: action.locale, value: '' }]
     });
-    return state.updateIn([action.id, 'questions'], (questions) => {
-      return questions.push(newQuestion);
-    });
+    return state.updateIn([action.id, 'questions'], questions => questions.push(newQuestion));
   }
   case 'CREATE_NEW_THEMATIC': {
     const emptyThematic = Map({
@@ -68,14 +62,10 @@ export const thematicsById: ThematicsByIdReducer = (state = Map(), action) => {
   case 'DELETE_THEMATIC':
     return state.setIn([action.id, 'toDelete'], true);
   case 'REMOVE_QUESTION':
-    return state.updateIn([action.thematicId, 'questions'], (questions) => {
-      return questions.remove(action.index);
-    });
+    return state.updateIn([action.thematicId, 'questions'], questions => questions.remove(action.index));
   case 'UPDATE_QUESTION_TITLE':
     return state.updateIn([action.thematicId, 'questions', action.index, 'titleEntries'], (titleEntries) => {
-      const titleEntryIndex = titleEntries.findIndex((entry) => {
-        return entry.get('localeCode') === action.locale;
-      });
+      const titleEntryIndex = titleEntries.findIndex(entry => entry.get('localeCode') === action.locale);
 
       if (titleEntryIndex === -1) {
         return titleEntries.push(Map({ localeCode: action.locale, value: action.value }));
@@ -166,9 +156,7 @@ export const thematicsHaveChanged: ThematicsHaveChangedReducer = (state = false,
 };
 
 const hasLocale = (l: string, arr: Array<string>): boolean => {
-  const i = arr.findIndex((a) => {
-    return a === l;
-  });
+  const i = arr.findIndex(a => a === l);
   return i >= 0;
 };
 
@@ -184,9 +172,7 @@ export const languagePreferences: LanguagePreferencesReducer = (state = List(), 
     return state;
   case 'REMOVE_LANGUAGE_PREFERENCE':
     if (hasLocale(action.locale, state)) {
-      const i = state.findIndex((a) => {
-        return a === action.locale;
-      });
+      const i = state.findIndex(a => a === action.locale);
       return state.delete(i);
     }
     return state;

--- a/assembl/static2/js/app/reducers/adminReducer/resourcesCenter.js
+++ b/assembl/static2/js/app/reducers/adminReducer/resourcesCenter.js
@@ -78,11 +78,7 @@ export const resourcesInOrder = (state: List<number> = List(), action: ReduxActi
   case CREATE_RESOURCE:
     return state.push(action.id);
   case UPDATE_RESOURCES:
-    return List(
-      action.resources.map((r) => {
-        return r.id;
-      })
-    );
+    return List(action.resources.map(r => r.id));
   default:
     return state;
   }

--- a/assembl/static2/js/app/reducers/contextReducer.js
+++ b/assembl/static2/js/app/reducers/contextReducer.js
@@ -19,18 +19,10 @@ const ContextReducer = (state = initialState, action) => {
 
 export default ContextReducer;
 
-export const getConnectedUserId = (state) => {
-  return state.context.connectedUserId;
-};
+export const getConnectedUserId = state => state.context.connectedUserId;
 
-export const getDebateId = (state) => {
-  return state.context.debateId;
-};
+export const getDebateId = state => state.context.debateId;
 
-export const getLocale = (state) => {
-  return state.i18n.locale;
-};
+export const getLocale = state => state.i18n.locale;
 
-export const getConnectedUserName = (state) => {
-  return state.context.connectedUserName;
-};
+export const getConnectedUserName = state => state.context.connectedUserName;

--- a/assembl/static2/js/app/reducers/screenDimensionsReducers.js
+++ b/assembl/static2/js/app/reducers/screenDimensionsReducers.js
@@ -1,12 +1,10 @@
-const singleReducer = (type, key, initialState) => {
-  return (state = initialState, action) => {
-    switch (action.type) {
-    case type:
-      if (key in action) return action[key]; // eslint-disable-line no-fallthrough
-    default:
-      return state;
-    }
-  };
+const singleReducer = (type, key, initialState) => (state = initialState, action) => {
+  switch (action.type) {
+  case type:
+    if (key in action) return action[key]; // eslint-disable-line no-fallthrough
+  default:
+    return state;
+  }
 };
 
 export const screenWidth = singleReducer('UPDATE_SCREEN_DIMENSIONS', 'newWidth', 0);

--- a/assembl/static2/js/app/root.jsx
+++ b/assembl/static2/js/app/root.jsx
@@ -6,21 +6,19 @@ import { modalManager, alertManager } from './utils/utilityManager';
   Parent class of all of Assembl. All high level components that require
   to exist in every context should be placed here. Eg. Alert, Modal, etc.
 */
-export default ({ children }) => {
-  return (
-    <div>
-      <Modal
-        ref={(modalComponent) => {
-          modalManager.setComponent(modalComponent);
-        }}
-      />
-      <Alert
-        isBase
-        ref={(alertComponent) => {
-          alertManager.setComponent(alertComponent);
-        }}
-      />
-      <div className="root-child">{children}</div>
-    </div>
-  );
-};
+export default ({ children }) => (
+  <div>
+    <Modal
+      ref={(modalComponent) => {
+        modalManager.setComponent(modalComponent);
+      }}
+    />
+    <Alert
+      isBase
+      ref={(alertComponent) => {
+        alertManager.setComponent(alertComponent);
+      }}
+    />
+    <div className="root-child">{children}</div>
+  </div>
+);

--- a/assembl/static2/js/app/searchv1.jsx
+++ b/assembl/static2/js/app/searchv1.jsx
@@ -38,6 +38,7 @@ class SearchApp extends React.Component {
     super(props);
     this.state = { isExpert: false };
   }
+
   componentWillMount() {
     const discussionId = getDiscussionId();
     const connectedUserId = getConnectedUserId();

--- a/assembl/static2/js/app/services/partnersService.js
+++ b/assembl/static2/js/app/services/partnersService.js
@@ -2,7 +2,5 @@ import { xmlHttpRequest } from '../utils/httpRequestHandler';
 
 export const getPartners = (debateId) => {
   const fetchUrl = `/data/Discussion/${debateId}/partner_organizations`;
-  return xmlHttpRequest({ method: 'GET', url: fetchUrl }).then((partners) => {
-    return partners;
-  });
+  return xmlHttpRequest({ method: 'GET', url: fetchUrl }).then(partners => partners);
 };

--- a/assembl/static2/js/app/services/synthesisService.js
+++ b/assembl/static2/js/app/services/synthesisService.js
@@ -25,7 +25,5 @@ export const buildSynthesis = (synthesis) => {
 
 export const getSynthesis = (debateId) => {
   const fetchUrl = `/api/v1/discussion/${debateId}/explicit_subgraphs/synthesis`;
-  return xmlHttpRequest({ method: 'GET', url: fetchUrl }).then((synthesis) => {
-    return buildSynthesis(synthesis);
-  });
+  return xmlHttpRequest({ method: 'GET', url: fetchUrl }).then(synthesis => buildSynthesis(synthesis));
 };

--- a/assembl/static2/js/app/utils/draftjs.js
+++ b/assembl/static2/js/app/utils/draftjs.js
@@ -31,9 +31,7 @@ export function createEmptyRawContentState(): RawContentState {
   return convertToRaw(ContentState.createFromText(''));
 }
 
-export const textToRawContentState = (text: string): RawContentState => {
-  return convertToRaw(ContentState.createFromText(text));
-};
+export const textToRawContentState = (text: string): RawContentState => convertToRaw(ContentState.createFromText(text));
 
 export function convertToRawContentState(value: string): RawContentState {
   return convertToRaw(customConvertFromHTML(value));
@@ -41,28 +39,20 @@ export function convertToRawContentState(value: string): RawContentState {
 
 export function convertEntries(converter: Function): Function {
   return function (entries: Array<Entry>): Array<Entry> {
-    return entries.map((entry) => {
-      return {
-        ...entry,
-        value: converter(entry.value)
-      };
-    });
+    return entries.map(entry => ({
+      ...entry,
+      value: converter(entry.value)
+    }));
   };
 }
 
 export const convertEntriesToRawContentState = convertEntries(convertToRawContentState);
-export const convertRawContentStateToHTML = (cs: RawContentState): string => {
-  return customConvertToHTML(convertFromRaw(cs));
-};
+export const convertRawContentStateToHTML = (cs: RawContentState): string => customConvertToHTML(convertFromRaw(cs));
 export const convertEntriesToHTML = convertEntries(convertRawContentStateToHTML);
 
 export function rawContentStateIsEmpty(rawContentState: RawContentState): boolean {
   const contentState = convertFromRaw(rawContentState);
-  const containAtomicBlock = (blockMap) => {
-    return blockMap.some((b) => {
-      return b.type === 'atomic';
-    });
-  };
+  const containAtomicBlock = blockMap => blockMap.some(b => b.type === 'atomic');
   if (contentState.getPlainText().length === 0 && !containAtomicBlock(contentState.getBlockMap())) {
     return true;
   }

--- a/assembl/static2/js/app/utils/globalFunctions.js
+++ b/assembl/static2/js/app/utils/globalFunctions.js
@@ -12,13 +12,9 @@ const getScriptText = (id: string) => {
   return text;
 };
 
-export const getDiscussionId = () => {
-  return getInputValue('discussion-id');
-};
+export const getDiscussionId = () => getInputValue('discussion-id');
 
-export const getDiscussionSlug = () => {
-  return getInputValue('discussion-slug');
-};
+export const getDiscussionSlug = () => getInputValue('discussion-slug');
 
 // cache userId to avoid accessing the dom at each permission check
 let userId;
@@ -29,9 +25,7 @@ export const getConnectedUserId = () => {
   return userId;
 };
 
-export const getConnectedUserName = () => {
-  return getInputValue('user-displayname');
-};
+export const getConnectedUserName = () => getInputValue('user-displayname');
 
 // cache permissions to avoid accessing the dom at each permission check
 let permissions;
@@ -74,35 +68,26 @@ export function getSortedArrayByKey<KeyType>(arr: Array<{ [KeyType]: number }>, 
   return arr;
 }
 
-export const isDateExpired = (date1: number, date2: number) => {
-  return date1 > date2;
-};
+export const isDateExpired = (date1: number, date2: number) => date1 > date2;
 
 export const getNumberOfDays = (date1: number, date2: number) => {
   const days = (date1 - date2) / (1000 * 60 * 60 * 24);
   return Math.round(days);
 };
 
-export const calculatePercentage = (value1: number, value2: number) => {
-  return Math.round(value1 * 100 / value2 * 100) / 100;
-};
+export const calculatePercentage = (value1: number, value2: number) => Math.round(value1 * 100 / value2 * 100) / 100;
 
 /*
   Handrolled instead of using lodash
   Because lodash/capitalize lowercases everything else
 */
-export const capitalize = (s: string) => {
-  return s.charAt(0).toUpperCase() + s.slice(1);
-};
+export const capitalize = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
 
-export const getDocumentScrollTop = () => {
-  return (
-    window.pageYOffset ||
-    (document.documentElement && document.documentElement.scrollTop) ||
-    (document.body && document.body.scrollTop) ||
-    0
-  );
-};
+export const getDocumentScrollTop = () =>
+  window.pageYOffset ||
+  (document.documentElement && document.documentElement.scrollTop) ||
+  (document.body && document.body.scrollTop) ||
+  0;
 
 export const getDomElementOffset = (el: HTMLElement) => {
   const rect = el.getBoundingClientRect();
@@ -141,13 +126,12 @@ export const createEvent = (
 /*
   Get basename from a unix or windows path
 */
-export const getBasename = (path: string) => {
-  return path
+export const getBasename = (path: string) =>
+  path
     .split('\\')
     .pop()
     .split('/')
     .pop();
-};
 
 export const hashLinkScroll = () => {
   const { hash } = window.location;
@@ -178,29 +162,13 @@ export const hexToRgb = (c: string) => {
 };
 
 export const isMobile = {
-  android: () => {
-    return navigator.userAgent.match(/Android/i);
-  },
-  blackberry: () => {
-    return navigator.userAgent.match(/BlackBerry/i);
-  },
-  ios: () => {
-    return navigator.userAgent.match(/iPhone|iPad|iPod/i);
-  },
-  opera: () => {
-    return navigator.userAgent.match(/Opera Mini/i);
-  },
-  windows: () => {
-    return navigator.userAgent.match(/IEMobile/i);
-  },
-  any: () => {
-    return isMobile.android() || isMobile.blackberry() || isMobile.ios() || isMobile.opera() || isMobile.windows();
-  }
+  android: () => navigator.userAgent.match(/Android/i),
+  blackberry: () => navigator.userAgent.match(/BlackBerry/i),
+  ios: () => navigator.userAgent.match(/iPhone|iPad|iPod/i),
+  opera: () => navigator.userAgent.match(/Opera Mini/i),
+  windows: () => navigator.userAgent.match(/IEMobile/i),
+  any: () => isMobile.android() || isMobile.blackberry() || isMobile.ios() || isMobile.opera() || isMobile.windows()
 };
 
 // works for SCREAMING_SNAKE_CASE, snake_case or cRazY_SNAKE_case
-export const snakeToCamel = (string: string) => {
-  return string.toLowerCase().replace(/_[a-z]/g, (match) => {
-    return match[1].toUpperCase();
-  });
-};
+export const snakeToCamel = (string: string) => string.toLowerCase().replace(/_[a-z]/g, match => match[1].toUpperCase());

--- a/assembl/static2/js/app/utils/httpRequestHandler.js
+++ b/assembl/static2/js/app/utils/httpRequestHandler.js
@@ -1,22 +1,18 @@
-const convertToURLEncodedString = (obj) => {
-  return Object.keys(obj)
-    .map((k) => {
-      return `${encodeURIComponent(k)}=${encodeURIComponent(obj[k])}`;
-    })
+const convertToURLEncodedString = obj =>
+  Object.keys(obj)
+    .map(k => `${encodeURIComponent(k)}=${encodeURIComponent(obj[k])}`)
     .join('&');
-};
-const getResponseContentType = (xhr) => {
+const getResponseContentType = xhr =>
   // eslint-disable-line no-unused-vars
-  return xhr.getResponseHeader('Content-Type').split(';')[0];
-};
+  xhr.getResponseHeader('Content-Type').split(';')[0];
 /*
   A global async method that returns a Promisified ajax call
   @params payload [Object] The object that will be sent
   @params isJson [Boolean] Pass a flag if the object is JSON. Default is form header.
   @retuns [Promise]
 */
-export const xmlHttpRequest = (obj) => {
-  return new Promise((resolve, reject) => {
+export const xmlHttpRequest = obj =>
+  new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest();
     const url = obj.url;
     let payload = obj.payload;
@@ -60,23 +56,13 @@ export const xmlHttpRequest = (obj) => {
         reject(resp);
       }
     };
-    xhr.onerror = () => {
+    xhr.onerror = () =>
       // Network level failure
-      return reject(xhr.statusText || xhr.responseText);
-    };
+      reject(xhr.statusText || xhr.responseText);
     xhr.send(payload);
   });
-};
 
-export const fetchContentType = (url) => {
-  return fetch(url, {
+export const fetchContentType = url =>
+  fetch(url, {
     method: 'HEAD'
-  }).then(
-    (response) => {
-      return response.headers.get('Content-Type');
-    },
-    () => {
-      return null;
-    }
-  );
-};
+  }).then(response => response.headers.get('Content-Type'), () => null);

--- a/assembl/static2/js/app/utils/i18n.js
+++ b/assembl/static2/js/app/utils/i18n.js
@@ -24,9 +24,7 @@ const myHandleMissingTranslation = function (key, replacements) {
 };
 I18n.setHandleMissingTranslation(myHandleMissingTranslation);
 
-export const getTranslations = () => {
-  return Translations;
-};
+export const getTranslations = () => Translations;
 
 export const getLocale = (browserLanguage) => {
   let locale;
@@ -71,18 +69,14 @@ export const getAvailableLocales = (locale, translations) => {
     @returns {function} Updater function (see immutable-js) that updates the value of the
     entry with given locale by the given value
 */
-export const updateInLangstringEntries = (locale, value) => {
-  return (entries) => {
-    const entryIndex = entries.findIndex((entry) => {
-      return entry.get('localeCode') === locale;
-    });
+export const updateInLangstringEntries = (locale, value) => (entries) => {
+  const entryIndex = entries.findIndex(entry => entry.get('localeCode') === locale);
 
-    if (entryIndex === -1) {
-      return entries.push(Map({ localeCode: locale, value: value }));
-    }
+  if (entryIndex === -1) {
+    return entries.push(Map({ localeCode: locale, value: value }));
+  }
 
-    return entries.setIn([entryIndex, 'value'], value);
-  };
+  return entries.setIn([entryIndex, 'value'], value);
 };
 
 export const getEntryValueForLocale = (entries, locale, defaultValue = null) => {
@@ -90,9 +84,7 @@ export const getEntryValueForLocale = (entries, locale, defaultValue = null) => 
     return defaultValue;
   }
 
-  const entry = entries.find((e) => {
-    return e.get('localeCode') === locale;
-  });
+  const entry = entries.find(e => e.get('localeCode') === locale);
 
   return entry ? entry.get('value') : defaultValue;
 };

--- a/assembl/static2/js/app/utils/linkify.js
+++ b/assembl/static2/js/app/utils/linkify.js
@@ -36,9 +36,7 @@ export function transformLinksInHtml(html: string): string {
       return null;
     })
     // remove null values
-    .filter((link: LinkToReplace | null) => {
-      return link;
-    });
+    .filter((link: LinkToReplace | null) => link);
 
   let transformedHtml = html;
   linksToReplace.forEach((linkToReplace: LinkToReplace) => {

--- a/assembl/static2/js/app/utils/literalStringParser.js
+++ b/assembl/static2/js/app/utils/literalStringParser.js
@@ -9,9 +9,7 @@
 /* eslint no-useless-escape: off, no-new-func: off */
 
 function get(path, obj, fb = `$\{${path}}`) {
-  return path.split('.').reduce((res, key) => {
-    return res[key] || fb;
-  }, obj);
+  return path.split('.').reduce((res, key) => res[key] || fb, obj);
 }
 
 function parse(template, map, fallback) {

--- a/assembl/static2/js/app/utils/routeMap.js
+++ b/assembl/static2/js/app/utils/routeMap.js
@@ -12,9 +12,7 @@ const convertToContextualName = (name) => {
   const workingName = capitalize(name);
   return base + workingName;
 };
-const maybePrependSlash = (pre, s) => {
-  return pre ? `/${s}` : s;
-};
+const maybePrependSlash = (pre, s) => (pre ? `/${s}` : s);
 export const get = (name, args) => {
   const newArgs = args || {};
   const pre = 'preSlash' in newArgs ? newArgs.preSlash : true;
@@ -28,9 +26,7 @@ export const get = (name, args) => {
   const a = parse(literal, newArgs);
   return a;
 };
-const basePath = () => {
-  return `${window.location.protocol}//${window.location.host}`;
-};
+const basePath = () => `${window.location.protocol}//${window.location.host}`;
 export const getFullPath = (name, args) => {
   const rel = get(name, { ...args, preSlash: false });
   return urljoin(basePath(), rel);
@@ -48,9 +44,7 @@ export const routeForRouter = (name, isCtx, args) => {
   }
   return get(name, newArgs);
 };
-export const getCurrentView = () => {
-  return window.location.pathname;
-};
+export const getCurrentView = () => window.location.pathname;
 /* Not use for the moment, but maybe later
 
 const slug = getDiscussionSlug();

--- a/assembl/static2/js/app/utils/section.js
+++ b/assembl/static2/js/app/utils/section.js
@@ -8,14 +8,10 @@ const LEN_CHARS = CHARS.length;
 
 const LEN_NUMERIC = 2;
 
-const defaultGenerator = (indexes: Array<number>): string => {
-  return indexes.join(SEPARATOR) + SEPARATOR;
-};
+const defaultGenerator = (indexes: Array<number>): string => indexes.join(SEPARATOR) + SEPARATOR;
 
 const alphanumeric = (indexes: Array<number>): string => {
-  const alphanumericIndexes = indexes.map((i, level) => {
-    return level < LEN_NUMERIC ? level : CHARS[i % LEN_CHARS - 1];
-  });
+  const alphanumericIndexes = indexes.map((i, level) => (level < LEN_NUMERIC ? level : CHARS[i % LEN_CHARS - 1]));
   return alphanumericIndexes.join(SEPARATOR) + SEPARATOR;
 };
 
@@ -35,9 +31,7 @@ const alphanumericOr = (indexes: Array<number>): string => {
   const isAlpha = indexes.length > LEN_NUMERIC;
   if (isAlpha) {
     const indexesToDesplay = indexes.slice(LEN_NUMERIC);
-    const alphanumericIndexes = indexesToDesplay.map((i) => {
-      return CHARS[i % LEN_CHARS - 1];
-    });
+    const alphanumericIndexes = indexesToDesplay.map(i => CHARS[i % LEN_CHARS - 1]);
     return alphanumericIndexes.join(SEPARATOR) + SEPARATOR;
   }
   return indexes.join(SEPARATOR) + SEPARATOR;

--- a/assembl/static2/js/app/utils/tree.js
+++ b/assembl/static2/js/app/utils/tree.js
@@ -17,9 +17,7 @@ type TreeType<T> = {
  * @returns {Array<T>} Returns the direct child nodes of the root.
  */
 export function getChildren<T: NodeType>(rootNode: T, nodes: Array<T>): Array<T> {
-  return nodes.filter((node) => {
-    return node.ancestors.includes(rootNode.id);
-  });
+  return nodes.filter(node => node.ancestors.includes(rootNode.id));
 }
 
 /**
@@ -28,20 +26,10 @@ export function getChildren<T: NodeType>(rootNode: T, nodes: Array<T>): Array<T>
  * @returns {{roots: Array<T>, descendants: Array<T>}} Returns the partial tree composed of all the root nodes and their children.
  */
 export function getPartialTree<T: NodeType>(nodes: Array<T>): TreeType<T> {
-  let ids = nodes.map((node) => {
-    return node.id;
-  });
-  const roots = nodes.filter((node) => {
-    return node.ancestors.every((a) => {
-      return !ids.includes(a);
-    });
-  });
-  ids = roots.map((node) => {
-    return node.id;
-  });
-  const descendants = nodes.filter((node) => {
-    return !ids.includes(node.id);
-  });
+  let ids = nodes.map(node => node.id);
+  const roots = nodes.filter(node => node.ancestors.every(a => !ids.includes(a)));
+  ids = roots.map(node => node.id);
+  const descendants = nodes.filter(node => !ids.includes(node.id));
   return {
     roots: roots,
     descendants: descendants

--- a/assembl/static2/js/app/utils/utilityManager.jsx
+++ b/assembl/static2/js/app/utils/utilityManager.jsx
@@ -96,13 +96,11 @@ export const inviteUserToLogin = () => {
 };
 
 /* if user is not connected, ask for login, else, execute given action */
-export const promptForLoginOr = (action) => {
-  return () => {
-    const isUserConnected = getConnectedUserId(); // TO DO put isUserConnected in the store
-    if (!isUserConnected) {
-      inviteUserToLogin();
-    } else {
-      action();
-    }
-  };
+export const promptForLoginOr = action => () => {
+  const isUserConnected = getConnectedUserId(); // TO DO put isUserConnected in the store
+  if (!isUserConnected) {
+    inviteUserToLogin();
+  } else {
+    action();
+  }
 };

--- a/assembl/static2/scripts/translations2messages.js
+++ b/assembl/static2/scripts/translations2messages.js
@@ -17,9 +17,7 @@ const nestedObjects2nestedMessages = (objOrString, fullkey = '') => {
   });
 };
 
-const nestedObjects2messages = (objOrString, fullkey = '') => {
-  return flattenDeep(nestedObjects2nestedMessages(objOrString, fullkey));
-};
+const nestedObjects2messages = (objOrString, fullkey = '') => flattenDeep(nestedObjects2nestedMessages(objOrString, fullkey));
 
 const messages = flattenDeep(nestedObjects2messages(englishTranslations));
 

--- a/assembl/static2/tests/unit/components/common/cardList.spec.jsx
+++ b/assembl/static2/tests/unit/components/common/cardList.spec.jsx
@@ -13,9 +13,7 @@ describe('CardList component', () => {
           data={data}
           classNameGenerator={CLASS_NAME_GENERATOR.default}
           itemClassName="classFoo"
-          CardItem={(itemData) => {
-            return <div>{itemData.title}</div>;
-          }}
+          CardItem={itemData => <div>{itemData.title}</div>}
         />
       )
       .toJSON();

--- a/assembl/static2/tests/unit/components/common/richTextEditor/atomicBlockRenderer.spec.jsx
+++ b/assembl/static2/tests/unit/components/common/richTextEditor/atomicBlockRenderer.spec.jsx
@@ -31,9 +31,7 @@ describe('AtomicBlockRenderer component', () => {
       }
     };
     const fakeBlock = {
-      getEntityAt: (offset) => {
-        return offset.toString(); // fake entity key
-      }
+      getEntityAt: offset => offset.toString() // fake entity key
     };
 
     const props = {

--- a/assembl/static2/tests/unit/components/common/richTextEditor/index.spec.jsx
+++ b/assembl/static2/tests/unit/components/common/richTextEditor/index.spec.jsx
@@ -7,9 +7,7 @@ import RichTextEditor from '../../../../../js/app/components/common/richTextEdit
 describe('RichTextEditor component', () => {
   it.skip('should render a rich text editor', () => {
     const rawContentState = convertToRaw(ContentState.createFromText('foobar'));
-    const updateEditorStateSpy = jest.fn((newState) => {
-      return newState;
-    });
+    const updateEditorStateSpy = jest.fn(newState => newState);
     const props = {
       rawContentState: rawContentState,
       maxLength: 2000,

--- a/assembl/static2/tests/unit/utils/globalFunctions.spec.js
+++ b/assembl/static2/tests/unit/utils/globalFunctions.spec.js
@@ -76,9 +76,7 @@ describe('hexToRgb function', () => {
   it('should return a color\'s RGB components from the hexadecimal code', () => {
     const colors = [{ hexa: '#40A497' }, { hexa: '#A44072' }, { hexa: '#4051A4' }, { hexa: '#FDEC00' }];
     const expectedResult = [{ rgb: '64,164,151' }, { rgb: '164,64,114' }, { rgb: '64,81,164' }, { rgb: '253,236,0' }];
-    const result = colors.map((color) => {
-      return { rgb: hexToRgb(color.hexa) };
-    });
+    const result = colors.map(color => ({ rgb: hexToRgb(color.hexa) }));
     expect(result).toEqual(expectedResult);
   });
 });

--- a/assembl/static2/tests/unit/utils/i18n.spec.js
+++ b/assembl/static2/tests/unit/utils/i18n.spec.js
@@ -5,9 +5,7 @@ describe('i18n util module', () => {
     it('should return the browser language', () => {
       const testedLocales = ['fr-FR', 'de-DE', 'de-AT', 'en-US', 'fr-fr', 'de-de', 'de-at', 'en-us', 'fr', 'de', 'ar', 'be'];
       const expectedResult = ['fr', 'en', 'en', 'en', 'fr', 'en', 'en', 'en', 'fr', 'en', 'en', 'en'];
-      const result = testedLocales.map((testedLocale) => {
-        return getLocale(testedLocale);
-      });
+      const result = testedLocales.map(testedLocale => getLocale(testedLocale));
       expect(result).toEqual(expectedResult);
     });
   });

--- a/assembl/static2/tests/unit/utils/tree.spec.js
+++ b/assembl/static2/tests/unit/utils/tree.spec.js
@@ -19,9 +19,7 @@ describe('Tree', () => {
       expect(roots.length).toEqual(1);
       expect(roots[0].id).toEqual('foo');
       expect(descendants.length).toEqual(2);
-      const ids = descendants.map((c) => {
-        return c.id;
-      });
+      const ids = descendants.map(c => c.id);
       const expected = ['bar', 'tar'];
       expect(ids).toEqual(expect.arrayContaining(expected));
     });

--- a/assembl/static2/yarn.lock
+++ b/assembl/static2/yarn.lock
@@ -138,9 +138,18 @@ ajv@^4.9.1:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
-ajv@^5.0.0, ajv@^5.1.0, ajv@^5.1.5, ajv@^5.2.0, ajv@^5.2.3, ajv@^5.3.0:
+ajv@^5.0.0, ajv@^5.1.0, ajv@^5.1.5:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.0.tgz#eb2840746e9dc48bd5e063a36e3fd400c5eab5a9"
+  dependencies:
+    co "^4.6.0"
+    fast-deep-equal "^1.0.0"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.3.0"
+
+ajv@^5.2.3, ajv@^5.3.0:
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.1.tgz#b38bb8876d9e86bee994956a04e721e88b248eb2"
   dependencies:
     co "^4.6.0"
     fast-deep-equal "^1.0.0"
@@ -187,7 +196,7 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
-ansi-styles@^3.0.0, ansi-styles@^3.1.0:
+ansi-styles@^3.0.0, ansi-styles@^3.1.0, ansi-styles@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
   dependencies:
@@ -442,7 +451,7 @@ babel-code-frame@^6.11.0, babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
-babel-core@^6.0.0, babel-core@^6.26.0:
+babel-core@6.26.0, babel-core@^6.0.0, babel-core@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.0.tgz#af32f78b31a6fcef119c87b0fd8d9753f03a0bb8"
   dependencies:
@@ -1345,8 +1354,8 @@ camelcase-keys@^2.0.0:
     map-obj "^1.0.0"
 
 camelcase-keys@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-4.1.0.tgz#214d348cc5457f39316a2c31cc3e37246325e73f"
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-4.2.0.tgz#a2aa5fb1af688758259c32c141426d78923b9b77"
   dependencies:
     camelcase "^4.1.0"
     map-obj "^2.0.0"
@@ -1400,9 +1409,9 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
-chalk@2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.1.0.tgz#ac5becf14fa21b99c6c92ca7a7d7cfd5b17e743e"
+chalk@2.3.0, chalk@^2.0.0, chalk@^2.1.0, chalk@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
   dependencies:
     ansi-styles "^3.1.0"
     escape-string-regexp "^1.0.5"
@@ -1417,14 +1426,6 @@ chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
     has-ansi "^2.0.0"
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
-
-chalk@^2.0.0, chalk@^2.1.0, chalk@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
-  dependencies:
-    ansi-styles "^3.1.0"
-    escape-string-regexp "^1.0.5"
-    supports-color "^4.0.0"
 
 chalk@^2.0.1:
   version "2.0.1"
@@ -1605,10 +1606,10 @@ commander@^2.9.0, commander@~2.12.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.12.2.tgz#0f5946c427ed9ec0d91a46bb9def53e54650e555"
 
 common-tags@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.4.0.tgz#1187be4f3d4cf0c0427d43f74eef1f73501614c0"
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.5.1.tgz#e2e39931a013cd02253defeed89a1ad615a27f07"
   dependencies:
-    babel-runtime "^6.18.0"
+    babel-runtime "^6.26.0"
 
 commondir@^1.0.1:
   version "1.0.1"
@@ -2444,51 +2445,9 @@ eslint-scope@^3.7.1:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint@^4.5.0:
-  version "4.6.1"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.6.1.tgz#ddc7fc7fd70bf93205b0b3449bb16a1e9e7d4950"
-  dependencies:
-    ajv "^5.2.0"
-    babel-code-frame "^6.22.0"
-    chalk "^2.1.0"
-    concat-stream "^1.6.0"
-    cross-spawn "^5.1.0"
-    debug "^2.6.8"
-    doctrine "^2.0.0"
-    eslint-scope "^3.7.1"
-    espree "^3.5.0"
-    esquery "^1.0.0"
-    estraverse "^4.2.0"
-    esutils "^2.0.2"
-    file-entry-cache "^2.0.0"
-    functional-red-black-tree "^1.0.1"
-    glob "^7.1.2"
-    globals "^9.17.0"
-    ignore "^3.3.3"
-    imurmurhash "^0.1.4"
-    inquirer "^3.0.6"
-    is-resolvable "^1.0.0"
-    js-yaml "^3.9.1"
-    json-stable-stringify "^1.0.1"
-    levn "^0.3.0"
-    lodash "^4.17.4"
-    minimatch "^3.0.2"
-    mkdirp "^0.5.1"
-    natural-compare "^1.4.0"
-    optionator "^0.8.2"
-    path-is-inside "^1.0.2"
-    pluralize "^4.0.0"
-    progress "^2.0.0"
-    require-uncached "^1.0.3"
-    semver "^5.3.0"
-    strip-ansi "^4.0.0"
-    strip-json-comments "~2.0.1"
-    table "^4.0.1"
-    text-table "~0.2.0"
-
-eslint@^4.6.1:
-  version "4.12.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.12.0.tgz#a7ce78eba8cc8f2443acfbbc870cc31a65135884"
+eslint@^4.5.0, eslint@^4.6.1:
+  version "4.12.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.12.1.tgz#5ec1973822b4a066b353770c3c6d69a2a188e880"
   dependencies:
     ajv "^5.3.0"
     babel-code-frame "^6.22.0"
@@ -2528,7 +2487,7 @@ eslint@^4.6.1:
     table "^4.0.1"
     text-table "~0.2.0"
 
-espree@^3.5.0, espree@^3.5.2:
+espree@^3.5.2:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.2.tgz#756ada8b979e9dcfcdb30aad8d1a9304a905e1ca"
   dependencies:
@@ -3110,7 +3069,7 @@ globals@^11.0.1:
   version "11.0.1"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.0.1.tgz#12a87bb010e5154396acc535e1e43fc753b0e5e8"
 
-globals@^9.17.0, globals@^9.18.0:
+globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
 
@@ -3464,11 +3423,7 @@ iferr@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
 
-ignore@^3.2.7:
-  version "3.3.5"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.5.tgz#c4e715455f6073a8d7e5dae72d2fc9d71663dba6"
-
-ignore@^3.3.3:
+ignore@^3.2.7, ignore@^3.3.3:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.7.tgz#612289bfb3c220e186a58118618d5be8c1bab021"
 
@@ -3703,8 +3658,8 @@ is-path-in-cwd@^1.0.0:
     is-path-inside "^1.0.0"
 
 is-path-inside@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.0.tgz#fc06e5a1683fbda13de667aff717bbc10a48f37f"
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.1.tgz#8ef5b7de50437a3fdca6b4e865ef7aa55cb48036"
   dependencies:
     path-is-inside "^1.0.1"
 
@@ -4470,9 +4425,9 @@ make-dir@^1.0.0:
   dependencies:
     pify "^3.0.0"
 
-make-plural@~3.0.6:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/make-plural/-/make-plural-3.0.6.tgz#2033a03bac290b8f3bb91258f65b9df7e8b01ca7"
+make-plural@^4.0.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/make-plural/-/make-plural-4.1.1.tgz#5658ce9d337487077daed221854c8cef9dd75749"
   optionalDependencies:
     minimist "^1.2.0"
 
@@ -4545,19 +4500,19 @@ merge@^1.1.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
 
-messageformat-parser@^1.0.0:
+messageformat-parser@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/messageformat-parser/-/messageformat-parser-1.1.0.tgz#13ba2250a76bbde8e0fca0dbb3475f95c594a90a"
 
 messageformat@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/messageformat/-/messageformat-1.0.2.tgz#908f4691f29ff28dae35c45436a24cff93402388"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/messageformat/-/messageformat-1.1.0.tgz#706c26f901e8219b3aa5308f8b5eaa3781d23a7a"
   dependencies:
     glob "~7.0.6"
-    make-plural "~3.0.6"
-    messageformat-parser "^1.0.0"
+    make-plural "^4.0.1"
+    messageformat-parser "^1.1.0"
     nopt "~3.0.6"
-    reserved-words "^0.1.1"
+    reserved-words "^0.1.2"
 
 methods@~1.1.2:
   version "1.1.2"
@@ -5201,10 +5156,6 @@ platform@^1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.4.tgz#6f0fb17edaaa48f21442b3a975c063130f1c3ebd"
 
-pluralize@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-4.0.0.tgz#59b708c1c0190a2f692f1c7618c446b052fd1762"
-
 pluralize@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
@@ -5518,14 +5469,14 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
 prettier-eslint-cli@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/prettier-eslint-cli/-/prettier-eslint-cli-4.4.0.tgz#3ceca9d5a207f4dde90a40545f317d6e13a3f932"
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/prettier-eslint-cli/-/prettier-eslint-cli-4.4.2.tgz#c72f5a3333a1022357474c36762d219378285a6a"
   dependencies:
     arrify "^1.0.1"
     babel-runtime "^6.23.0"
     boolify "^1.0.0"
     camelcase-keys "^4.1.0"
-    chalk "2.1.0"
+    chalk "2.3.0"
     common-tags "^1.4.0"
     eslint "^4.5.0"
     find-up "^2.1.0"
@@ -5538,12 +5489,13 @@ prettier-eslint-cli@^4.4.0:
     messageformat "^1.0.2"
     prettier-eslint "^8.0.0"
     rxjs "^5.3.0"
-    yargs "8.0.2"
+    yargs "10.0.3"
 
 prettier-eslint@^8.0.0, prettier-eslint@^8.2.2:
-  version "8.2.2"
-  resolved "https://registry.yarnpkg.com/prettier-eslint/-/prettier-eslint-8.2.2.tgz#b03c8794f844e863036163061ae14c2049bcff1a"
+  version "8.2.5"
+  resolved "https://registry.yarnpkg.com/prettier-eslint/-/prettier-eslint-8.2.5.tgz#1eb41c23159a6770f9e4191ecae8b0447a0a1867"
   dependencies:
+    babel-core "6.26.0"
     common-tags "^1.4.0"
     dlv "^1.1.0"
     eslint "^4.5.0"
@@ -5551,14 +5503,14 @@ prettier-eslint@^8.0.0, prettier-eslint@^8.2.2:
     lodash.merge "^4.6.0"
     loglevel-colored-level-prefix "^1.0.0"
     prettier "^1.7.1"
-    pretty-format "^20.0.3"
+    pretty-format "^21.2.1"
     require-relative "^0.8.7"
     typescript "^2.5.1"
     typescript-eslint-parser "^8.0.0"
 
 prettier@^1.7.1, prettier@^1.8.2:
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.8.2.tgz#bff83e7fd573933c607875e5ba3abbdffb96aeb8"
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.9.1.tgz#41638a0d47c1efbd1b7d5a742aaa5548eab86d70"
 
 pretty-format@^20.0.3:
   version "20.0.3"
@@ -5566,6 +5518,13 @@ pretty-format@^20.0.3:
   dependencies:
     ansi-regex "^2.1.1"
     ansi-styles "^3.0.0"
+
+pretty-format@^21.2.1:
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-21.2.1.tgz#ae5407f3cf21066cd011aa1ba5fce7b6a2eddb36"
+  dependencies:
+    ansi-regex "^3.0.0"
+    ansi-styles "^3.2.0"
 
 private@^0.1.6, private@^0.1.7, private@~0.1.5:
   version "0.1.8"
@@ -6341,7 +6300,7 @@ reselect@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/reselect/-/reselect-3.0.1.tgz#efdaa98ea7451324d092b2b2163a6a1d7a9a2147"
 
-reserved-words@^0.1.1:
+reserved-words@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/reserved-words/-/reserved-words-0.1.2.tgz#00a0940f98cd501aeaaac316411d9adc52b31ab1"
 
@@ -6426,10 +6385,10 @@ rx-lite@*, rx-lite@^4.0.8:
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
 
 rxjs@^5.3.0:
-  version "5.4.3"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.4.3.tgz#0758cddee6033d68e0fd53676f0f3596ce3d483f"
+  version "5.5.5"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.5.tgz#e164f11d38eaf29f56f08c3447f74ff02dd84e97"
   dependencies:
-    symbol-observable "^1.0.1"
+    symbol-observable "1.0.1"
 
 safe-buffer@5.1.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
@@ -7003,7 +6962,11 @@ svgo@^0.7.0:
     sax "~1.2.1"
     whet.extend "~0.9.9"
 
-symbol-observable@^1.0.1, symbol-observable@^1.0.2, symbol-observable@^1.0.3:
+symbol-observable@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
+
+symbol-observable@^1.0.2, symbol-observable@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
 
@@ -7187,8 +7150,8 @@ typescript-eslint-parser@^8.0.0:
     semver "5.4.1"
 
 typescript@^2.5.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.1.tgz#ef39cdea27abac0b500242d6726ab90e0c846631"
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.2.tgz#3c5b6fd7f6de0914269027f03c0946758f7673a4"
 
 ua-parser-js@^0.7.9:
   version "0.7.17"
@@ -7609,23 +7572,28 @@ yargs-parser@^7.0.0:
   dependencies:
     camelcase "^4.1.0"
 
-yargs@8.0.2, yargs@^8.0.2:
-  version "8.0.2"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-8.0.2.tgz#6299a9055b1cefc969ff7e79c1d918dceb22c360"
+yargs-parser@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-8.0.0.tgz#21d476330e5a82279a4b881345bf066102e219c6"
   dependencies:
     camelcase "^4.1.0"
+
+yargs@10.0.3:
+  version "10.0.3"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-10.0.3.tgz#6542debd9080ad517ec5048fb454efe9e4d4aaae"
+  dependencies:
     cliui "^3.2.0"
     decamelize "^1.1.1"
+    find-up "^2.1.0"
     get-caller-file "^1.0.1"
     os-locale "^2.0.0"
-    read-pkg-up "^2.0.0"
     require-directory "^2.1.1"
     require-main-filename "^1.0.1"
     set-blocking "^2.0.0"
     string-width "^2.0.0"
     which-module "^2.0.0"
     y18n "^3.2.1"
-    yargs-parser "^7.0.0"
+    yargs-parser "^8.0.0"
 
 yargs@^6.6.0:
   version "6.6.0"
@@ -7662,6 +7630,24 @@ yargs@^7.0.0, yargs@^7.0.2:
     which-module "^1.0.0"
     y18n "^3.2.1"
     yargs-parser "^5.0.0"
+
+yargs@^8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-8.0.2.tgz#6299a9055b1cefc969ff7e79c1d918dceb22c360"
+  dependencies:
+    camelcase "^4.1.0"
+    cliui "^3.2.0"
+    decamelize "^1.1.1"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    read-pkg-up "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^7.0.0"
 
 yargs@~3.10.0:
   version "3.10.0"


### PR DESCRIPTION
To discuss. Changed arrow-body-style rule to `["error", "as-needed", { "requireReturnForObjectLiteral": true }]`, see https://eslint.org/docs/rules/arrow-body-style

Latest commit was done with:
```
npm run eslint:fix
npm run format
edit static2/js/app/components/debate/multiColumns/utils.js with atom to add a line break after the first `=>`
```

This PR probably needs to be rebased once all other branches are merged.
```
git reset --hard HEAD^
git rebase develop
# reformat all files, see above
git add -A
git commit -m"reformat all files with new arrow-body-style rule config"
```