### PR TITLE
EDF - Home video no autoplay

### DIFF
--- a/assembl/static2/css/components/video.scss
+++ b/assembl/static2/css/components/video.scss
@@ -6,6 +6,7 @@
   padding-top: 30px;
   position: relative;
 
+  video,
   iframe,
   object,
   embed {

--- a/assembl/static2/js/app/components/common/media.jsx
+++ b/assembl/static2/js/app/components/common/media.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { I18n } from 'react-redux-i18n';
 import { Grid, Col, Button, Image, ResponsiveEmbed } from 'react-bootstrap';
+import { EDFHacks } from '../home/video';
 
 import { displayModal } from '../../utils/utilityManager';
 
@@ -34,11 +35,16 @@ class Media extends React.Component {
 
   static Content = ({ content }) => {
     const isLocal = content[0] === '/';
+    const isVideoFile = EDFHacks.srcIsVideoFile(content);
     const component = isLocal ? (
       <Image responsive src={content} />
     ) : (
       <ResponsiveEmbed a16by9>
-        <iframe title="media" src={content} />
+        {isVideoFile ? (
+          <video src={content} controls preload="none" /> // eslint-disable-line jsx-a11y/media-has-caption
+        ) : (
+          <iframe title="media" src={content} />
+        )}
       </ResponsiveEmbed>
     );
     return (

--- a/assembl/static2/js/app/components/home/video.jsx
+++ b/assembl/static2/js/app/components/home/video.jsx
@@ -82,6 +82,8 @@ class Video extends React.Component {
     const videoUrl = get(debateData, 'video.videoUrl', '');
     const posterUrl = get(debateData, 'video.posterUrl', '');
     const isVideoFile = EDFHacks.srcIsVideoFile(videoUrl);
+    const posterProps = {};
+    if (posterUrl) posterProps.poster = posterUrl;
     return (
       <section className="home-section video-section">
         <Grid fluid>
@@ -106,7 +108,7 @@ class Video extends React.Component {
                     <Col xs={12} md={6} className={this.state.isTextHigher ? 'col-bottom' : ''}>
                       <div className="video-container" id="video-vid">
                         {isVideoFile ? (
-                          <video src={videoUrl} controls preload="none" poster={posterUrl} style={{ width: '100%' }} /> // eslint-disable-line jsx-a11y/media-has-caption
+                          <video src={videoUrl} controls preload="none" style={{ width: '100%' }} {...posterProps} /> // eslint-disable-line jsx-a11y/media-has-caption
                         ) : (
                           <iframe src={debateData.video.videoUrl} frameBorder="0" width="560" height="315" title="video" />
                         )}

--- a/assembl/static2/js/app/components/home/video.jsx
+++ b/assembl/static2/js/app/components/home/video.jsx
@@ -2,6 +2,60 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { Translate } from 'react-redux-i18n';
 import { Grid, Row, Col } from 'react-bootstrap';
+import get from 'lodash/get';
+
+// https://en.wikipedia.org/wiki/Video_file_format
+const videoExtensions = [
+  'webm',
+  'mkv',
+  'flv',
+  'vob',
+  'ogv',
+  'ogg',
+  'drc',
+  'gif',
+  'gifv',
+  'mng',
+  'avi',
+  'mov',
+  'qt',
+  'wmv',
+  'yuv',
+  'rm',
+  'rmvb',
+  'asf',
+  'amv',
+  'mp4',
+  'm4p',
+  'm4v',
+  'mpg',
+  'mp2',
+  'mpeg',
+  'mpe',
+  'mpv',
+  'mpg',
+  'mpeg',
+  'm2v',
+  'm4v',
+  'svi',
+  '3gp',
+  '3g2',
+  'mxf',
+  'roq',
+  'nsv',
+  'f4v',
+  'f4p',
+  'f4a',
+  'f4b'
+];
+
+const EDFHacks = {
+  srcIsVideoFile: (src) => {
+    const components = src.split('.');
+    const extension = components[components.length - 1];
+    return videoExtensions.indexOf(extension) > -1;
+  }
+};
 
 class Video extends React.Component {
   constructor(props) {
@@ -25,6 +79,9 @@ class Video extends React.Component {
   render() {
     const { debateData } = this.props.debate;
     const { locale } = this.props.i18n;
+    const videoUrl = get(debateData, 'video.videoUrl', '');
+    const posterUrl = get(debateData, 'video.posterUrl', '');
+    const isVideoFile = EDFHacks.srcIsVideoFile(videoUrl);
     return (
       <section className="home-section video-section">
         <Grid fluid>
@@ -45,10 +102,14 @@ class Video extends React.Component {
                       </div>
                     </Col>
                   )}
-                  {debateData.video.videoUrl && (
+                  {videoUrl && (
                     <Col xs={12} md={6} className={this.state.isTextHigher ? 'col-bottom' : ''}>
                       <div className="video-container" id="video-vid">
-                        <iframe src={debateData.video.videoUrl} frameBorder="0" width="560" height="315" title="video" />
+                        {isVideoFile ? (
+                          <video src={videoUrl} controls preload="none" poster={posterUrl} style={{ width: '100%' }} /> // eslint-disable-line jsx-a11y/media-has-caption
+                        ) : (
+                          <iframe src={debateData.video.videoUrl} frameBorder="0" width="560" height="315" title="video" />
+                        )}
                       </div>
                     </Col>
                   )}

--- a/assembl/static2/js/app/components/home/video.jsx
+++ b/assembl/static2/js/app/components/home/video.jsx
@@ -49,7 +49,7 @@ const videoExtensions = [
   'f4b'
 ];
 
-const EDFHacks = {
+export const EDFHacks = {
   srcIsVideoFile: (src) => {
     const components = src.split('.');
     const extension = components[components.length - 1];

--- a/assembl/static2/js/app/components/home/video.jsx
+++ b/assembl/static2/js/app/components/home/video.jsx
@@ -108,7 +108,7 @@ class Video extends React.Component {
                     <Col xs={12} md={6} className={this.state.isTextHigher ? 'col-bottom' : ''}>
                       <div className="video-container" id="video-vid">
                         {isVideoFile ? (
-                          <video src={videoUrl} controls preload="none" style={{ width: '100%' }} {...posterProps} /> // eslint-disable-line jsx-a11y/media-has-caption
+                          <video src={videoUrl} controls preload="none" {...posterProps} /> // eslint-disable-line jsx-a11y/media-has-caption
                         ) : (
                           <iframe src={debateData.video.videoUrl} frameBorder="0" width="560" height="315" title="video" />
                         )}


### PR DESCRIPTION
You need to add a `video.posterUrl` value in the extra_json
for edf it would be:
`"posterUrl": "https://edf-content.cdn.mediactive-network.net/images/poster-player-EDF.png"`