### PR TITLE
Revert 1044 posts in column with published synthesis are editable

### DIFF
--- a/assembl/alembic/versions/c3f8bc9c75d5_column_synthesis_post.py
+++ b/assembl/alembic/versions/c3f8bc9c75d5_column_synthesis_post.py
@@ -9,7 +9,7 @@ Create Date: 2017-12-12 09:50:52.192838
 
 # revision identifiers, used by Alembic.
 revision = 'c3f8bc9c75d5'
-down_revision = 'c5754a7cb6be'
+down_revision = '8ed4db9d977f'
 
 from alembic import context, op
 import sqlalchemy as sa

--- a/assembl/static2/js/app/components/common/tree.jsx
+++ b/assembl/static2/js/app/components/common/tree.jsx
@@ -94,8 +94,7 @@ class Child extends React.PureComponent {
       nuggetsManager,
       listRef,
       cache,
-      identifier,
-      innerComponentProps
+      identifier
     } = this.props;
     const cssClasses = () => {
       let cls = `level level-${level}`;
@@ -119,8 +118,7 @@ class Child extends React.PureComponent {
     const forwardProps = {
       contentLocale: contentLocale,
       ...this.props,
-      numChildren: numChildren,
-      ...innerComponentProps
+      numChildren: numChildren
     };
     delete forwardProps.children;
     return (
@@ -148,7 +146,6 @@ class Child extends React.PureComponent {
                 listRef={listRef}
                 cache={cache}
                 identifier={identifier}
-                innerComponentProps={innerComponentProps}
               />
             );
           })
@@ -239,8 +236,7 @@ class Tree extends React.Component {
       InnerComponent, // component that will be rendered in the child
       InnerComponentFolded, // component that will be used to render the children when folded
       SeparatorComponent, // separator component between first level children
-      identifier,
-      innerComponentProps
+      identifier
     } = this.props;
 
     const childData = data[index];
@@ -261,7 +257,6 @@ class Tree extends React.Component {
             listRef={this.listRef}
             cache={this.cache}
             identifier={identifier}
-            innerComponentProps={innerComponentProps}
           />
         </div>
       </CellMeasurer>
@@ -317,8 +312,7 @@ class Tree extends React.Component {
 }
 
 Tree.defaultProps = {
-  InnerComponentFolded: () => null,
-  innerComponentProps: {}
+  InnerComponentFolded: () => null
 };
 
 export default Tree;

--- a/assembl/static2/js/app/components/debate/common/post/index.jsx
+++ b/assembl/static2/js/app/components/debate/common/post/index.jsx
@@ -55,7 +55,6 @@ type State = {
 };
 
 type DefaultProps = {
-  editable: boolean,
   multiColumns: boolean
 };
 
@@ -69,7 +68,6 @@ export class DumbPost extends React.PureComponent<DefaultProps, Props, State> {
   state: State;
 
   static defaultProps = {
-    editable: true,
     multiColumns: false
   };
 

--- a/assembl/static2/js/app/components/debate/common/post/postView.jsx
+++ b/assembl/static2/js/app/components/debate/common/post/postView.jsx
@@ -81,7 +81,6 @@ class PostView extends React.PureComponent<void, Props, State> {
       lang,
       ideaId,
       refetchIdea,
-      editable,
       // creationDate is retrieved by IdeaWithPosts query, not PostQuery
       creationDate,
       fullLevel,
@@ -152,11 +151,9 @@ class PostView extends React.PureComponent<void, Props, State> {
                 </div>
               )}
             </div>
-
             <div className="post-right">
               <PostActions
                 creatorUserId={creator.userId}
-                editable={editable}
                 postId={id}
                 handleEditClick={handleEditClick}
                 sentimentCounts={sentimentCounts}

--- a/assembl/static2/js/app/components/debate/common/postActions.jsx
+++ b/assembl/static2/js/app/components/debate/common/postActions.jsx
@@ -84,7 +84,7 @@ class PostActions extends React.Component<DefaultProps, Props, void> {
     let overflowMenu = null;
     const tooltipPlacement = screenWidth >= MEDIUM_SCREEN_WIDTH ? 'left' : 'top';
     const isPhaseCompleted = getIfPhaseCompletedByIdentifier(debateData.timeline, identifier);
-    if (editable && (userCanDeleteThisMessage || userCanEditThisMessage)) {
+    if (userCanDeleteThisMessage || userCanEditThisMessage) {
       overflowMenu = (
         <div className="overflow-action">
           <OverlayTrigger

--- a/assembl/static2/js/app/components/debate/multiColumns/multiColumns.jsx
+++ b/assembl/static2/js/app/components/debate/multiColumns/multiColumns.jsx
@@ -22,6 +22,7 @@ const MultiColumns = ({
   debateData
 }) => {
   const columnsArray = orderPostsByMessageClassifier(messageColumns, posts);
+  const isPhaseCompleted = getIfPhaseCompletedByIdentifier(debateData.timeline, identifier);
   return (
     <div className="multi-column-container">
       {Object.keys(columnsArray).map((classifier, index) => {
@@ -38,12 +39,9 @@ const MultiColumns = ({
           synthesisBody: get(col, 'columnSynthesis.body', I18n.t('multiColumns.synthesis.noSynthesisYet')),
           hyphenStyle: { borderTopColor: col.color }
         };
-        const isPhaseCompleted = getIfPhaseCompletedByIdentifier(debateData.timeline, identifier);
-        const canEditPosts = !isPhaseCompleted && !get(col, 'columnSynthesis.body');
         return (
           <PostColumn
             key={classifier}
-            canEditPosts={canEditPosts}
             synthesisProps={synthesisProps}
             width={width}
             contentLocaleMapping={contentLocaleMapping}
@@ -58,6 +56,7 @@ const MultiColumns = ({
             refetchIdea={refetchIdea}
             identifier={identifier}
             debateData={debateData}
+            withColumnHeader={!isPhaseCompleted}
           />
         );
       })}

--- a/assembl/static2/js/app/components/debate/multiColumns/postColumn.jsx
+++ b/assembl/static2/js/app/components/debate/multiColumns/postColumn.jsx
@@ -24,27 +24,28 @@ type Props = {
   refetchIdea: Function,
   synthesisProps: ColumnSynthesisProps,
   title: string,
-  width: number
+  width: number,
+  withColumnHeader: boolean
 };
 
 const PostColumn = ({
-  canEditPosts,
-  color,
   classifier,
-  title,
-  synthesisProps,
-  width,
-  data,
+  color,
   contentLocaleMapping,
-  lang,
-  initialRowIndex,
-  noRowsRenderer,
+  data,
   ideaId,
+  identifier,
+  initialRowIndex,
+  lang,
+  noRowsRenderer,
   refetchIdea,
-  identifier
+  synthesisProps,
+  title,
+  width,
+  withColumnHeader
 }: Props) => (
   <div className="column-view" style={{ width: width }}>
-    {canEditPosts && (
+    {withColumnHeader && (
       <ColumnHeader color={color} classifier={classifier} title={title} ideaId={ideaId} refetchIdea={refetchIdea} />
     )}
     {synthesisProps && <ColumnSynthesis {...synthesisProps} />}
@@ -60,7 +61,6 @@ const PostColumn = ({
           InnerComponentFolded={FoldedPost}
           SeparatorComponent={Separator}
           identifier={identifier}
-          innerComponentProps={{ editable: canEditPosts }}
         />
       ) : (
         noRowsRenderer()

--- a/assembl/static2/tests/unit/components/debate/common/post/__snapshots__/postView.spec.jsx.snap
+++ b/assembl/static2/tests/unit/components/debate/common/post/__snapshots__/postView.spec.jsx.snap
@@ -176,7 +176,6 @@ exports[`PostView component should render a post in view mode 1`] = `
               "translationEnabled": true,
             }
           }
-          editable={true}
           handleEditClick={[Function]}
           identifier="thread"
           mySentiment="like"


### PR DESCRIPTION
Revert changes that made that we can't add/edit posts that are in a column which synthesis has been published (see comment on DEVAS-1044)