### PR TITLE
Fix i18n in admin

### DIFF
--- a/assembl/static2/js/app/actions/adminActions/index.js
+++ b/assembl/static2/js/app/actions/adminActions/index.js
@@ -1,6 +1,6 @@
-export const updateSelectedLocale = newLocale => ({
+export const updateEditLocale = newLocale => ({
   newLocale: newLocale,
-  type: 'UPDATE_SELECTED_LOCALE'
+  type: 'UPDATE_EDIT_LOCALE'
 });
 
 export const updateThematics = thematics => ({

--- a/assembl/static2/js/app/components/administration/discussion/languageSection.jsx
+++ b/assembl/static2/js/app/components/administration/discussion/languageSection.jsx
@@ -46,10 +46,10 @@ class LanguageSection extends React.Component {
 
     // Manage toggling of checkbox states from the store
     const totalLocaleList = List(Object.keys(this.state.localeState));
-    const currentSelectedLocaleList = totalLocaleList.filter(locale => this.state.localeState[locale].selected).sort();
+    const currentEditLocaleList = totalLocaleList.filter(locale => this.state.localeState[locale].selected).sort();
     const newLocalePreferences = nextProps.discussionLanguagePreferences.sort();
     // Only update the state if there is a change in language preferences
-    if (!currentSelectedLocaleList.equals(newLocalePreferences)) {
+    if (!currentEditLocaleList.equals(newLocalePreferences)) {
       const newState = { ...this.state.localeState };
       Object.entries(newState).forEach(([locale, state]) => {
         const selectedState = state;

--- a/assembl/static2/js/app/components/administration/discussion/legalNoticeAndTermsForm.jsx
+++ b/assembl/static2/js/app/components/administration/discussion/legalNoticeAndTermsForm.jsx
@@ -11,16 +11,16 @@ import type { RootReducer } from '../../../reducers/rootReducer';
 import { getEntryValueForLocale } from '../../../utils/i18n';
 
 type LegalNoticeAndTermsFormProps = {
-  locale: string,
   legalNotice: string,
+  selectedLocale: string,
   termsAndConditions: string,
   updateLegalNotice: Function,
   updateTermsAndConditions: Function
 };
 
 export const DumbLegalNoticeAndTermsForm = ({
-  locale,
   legalNotice,
+  selectedLocale,
   termsAndConditions,
   updateLegalNotice,
   updateTermsAndConditions
@@ -34,7 +34,7 @@ export const DumbLegalNoticeAndTermsForm = ({
         <Row>
           <div className="form-container">
             <FormControlWithLabel
-              key={`tac-${locale}-${termsAndConditions}`}
+              key={`tac-${selectedLocale}-${termsAndConditions}`}
               label={`${tacLabel}*`}
               onChange={updateTermsAndConditions}
               required
@@ -43,7 +43,7 @@ export const DumbLegalNoticeAndTermsForm = ({
             />
             <div className="separator" />
             <FormControlWithLabel
-              key={`legal-notice-${locale}-${legalNotice}`}
+              key={`legal-notice-${selectedLocale}-${legalNotice}`}
               label={`${legalNoticeLabel}*`}
               onChange={updateLegalNotice}
               required
@@ -57,19 +57,19 @@ export const DumbLegalNoticeAndTermsForm = ({
   );
 };
 
-const mapStateToProps = (state: RootReducer, { locale }: LegalNoticeAndTermsFormProps) => {
+const mapStateToProps = (state: RootReducer, { selectedLocale }: LegalNoticeAndTermsFormProps) => {
   const legalNoticeAndTerms = state.admin.legalNoticeAndTerms;
-  const legalNotice = getEntryValueForLocale(legalNoticeAndTerms.get('legalNoticeEntries'), locale);
-  const termsAndConditions = getEntryValueForLocale(legalNoticeAndTerms.get('termsAndConditionsEntries'), locale);
+  const legalNotice = getEntryValueForLocale(legalNoticeAndTerms.get('legalNoticeEntries'), selectedLocale);
+  const termsAndConditions = getEntryValueForLocale(legalNoticeAndTerms.get('termsAndConditionsEntries'), selectedLocale);
   return {
     legalNotice: legalNotice ? legalNotice.toJS() : '',
     termsAndConditions: termsAndConditions ? termsAndConditions.toJS() : ''
   };
 };
 
-const mapDispatchToProps = (dispatch: Function, { locale }: LegalNoticeAndTermsFormProps) => ({
-  updateLegalNotice: (value: string) => dispatch(actions.updateLegalNoticeEntry(locale, value)),
-  updateTermsAndConditions: (value: string) => dispatch(actions.updateTermsAndConditionsEntry(locale, value))
+const mapDispatchToProps = (dispatch: Function, { selectedLocale }: LegalNoticeAndTermsFormProps) => ({
+  updateLegalNotice: (value: string) => dispatch(actions.updateLegalNoticeEntry(selectedLocale, value)),
+  updateTermsAndConditions: (value: string) => dispatch(actions.updateTermsAndConditionsEntry(selectedLocale, value))
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(DumbLegalNoticeAndTermsForm);

--- a/assembl/static2/js/app/components/administration/discussion/legalNoticeAndTermsForm.jsx
+++ b/assembl/static2/js/app/components/administration/discussion/legalNoticeAndTermsForm.jsx
@@ -12,7 +12,7 @@ import { getEntryValueForLocale } from '../../../utils/i18n';
 
 type LegalNoticeAndTermsFormProps = {
   legalNotice: string,
-  selectedLocale: string,
+  editLocale: string,
   termsAndConditions: string,
   updateLegalNotice: Function,
   updateTermsAndConditions: Function
@@ -20,7 +20,7 @@ type LegalNoticeAndTermsFormProps = {
 
 export const DumbLegalNoticeAndTermsForm = ({
   legalNotice,
-  selectedLocale,
+  editLocale,
   termsAndConditions,
   updateLegalNotice,
   updateTermsAndConditions
@@ -34,7 +34,7 @@ export const DumbLegalNoticeAndTermsForm = ({
         <Row>
           <div className="form-container">
             <FormControlWithLabel
-              key={`tac-${selectedLocale}-${termsAndConditions}`}
+              key={`tac-${editLocale}-${termsAndConditions}`}
               label={`${tacLabel}*`}
               onChange={updateTermsAndConditions}
               required
@@ -43,7 +43,7 @@ export const DumbLegalNoticeAndTermsForm = ({
             />
             <div className="separator" />
             <FormControlWithLabel
-              key={`legal-notice-${selectedLocale}-${legalNotice}`}
+              key={`legal-notice-${editLocale}-${legalNotice}`}
               label={`${legalNoticeLabel}*`}
               onChange={updateLegalNotice}
               required
@@ -57,19 +57,19 @@ export const DumbLegalNoticeAndTermsForm = ({
   );
 };
 
-const mapStateToProps = (state: RootReducer, { selectedLocale }: LegalNoticeAndTermsFormProps) => {
+const mapStateToProps = (state: RootReducer, { editLocale }: LegalNoticeAndTermsFormProps) => {
   const legalNoticeAndTerms = state.admin.legalNoticeAndTerms;
-  const legalNotice = getEntryValueForLocale(legalNoticeAndTerms.get('legalNoticeEntries'), selectedLocale);
-  const termsAndConditions = getEntryValueForLocale(legalNoticeAndTerms.get('termsAndConditionsEntries'), selectedLocale);
+  const legalNotice = getEntryValueForLocale(legalNoticeAndTerms.get('legalNoticeEntries'), editLocale);
+  const termsAndConditions = getEntryValueForLocale(legalNoticeAndTerms.get('termsAndConditionsEntries'), editLocale);
   return {
     legalNotice: legalNotice ? legalNotice.toJS() : '',
     termsAndConditions: termsAndConditions ? termsAndConditions.toJS() : ''
   };
 };
 
-const mapDispatchToProps = (dispatch: Function, { selectedLocale }: LegalNoticeAndTermsFormProps) => ({
-  updateLegalNotice: (value: string) => dispatch(actions.updateLegalNoticeEntry(selectedLocale, value)),
-  updateTermsAndConditions: (value: string) => dispatch(actions.updateTermsAndConditionsEntry(selectedLocale, value))
+const mapDispatchToProps = (dispatch: Function, { editLocale }: LegalNoticeAndTermsFormProps) => ({
+  updateLegalNotice: (value: string) => dispatch(actions.updateLegalNoticeEntry(editLocale, value)),
+  updateTermsAndConditions: (value: string) => dispatch(actions.updateTermsAndConditionsEntry(editLocale, value))
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(DumbLegalNoticeAndTermsForm);

--- a/assembl/static2/js/app/components/administration/discussion/manageSectionsForm.jsx
+++ b/assembl/static2/js/app/components/administration/discussion/manageSectionsForm.jsx
@@ -12,17 +12,17 @@ import * as actions from '../../../actions/adminActions/adminSections';
 
 type ManageSectionFormProps = {
   sections: List<string>,
-  selectedLocale: string,
+  editLocale: string,
   createSection: Function
 };
 
-const DumbManageSectionsForm = ({ sections, selectedLocale, createSection }: ManageSectionFormProps) => (
+const DumbManageSectionsForm = ({ sections, editLocale, createSection }: ManageSectionFormProps) => (
   <div className="admin-box">
     <SectionTitle title={I18n.t('administration.sections.sectionsTitle')} annotation={I18n.t('administration.annotation')} />
     <div className="admin-content">
       <form>
         {sections.map((id, index) => (
-          <EditSectionForm key={id} id={id} index={index} locale={selectedLocale} nbSections={sections.size} />
+          <EditSectionForm key={id} id={id} index={index} locale={editLocale} nbSections={sections.size} />
         ))}
         <OverlayTrigger placement="top" overlay={addSectionTooltip}>
           <div onClick={() => createSection(sections.size)} className="plus margin-l">
@@ -37,7 +37,7 @@ const DumbManageSectionsForm = ({ sections, selectedLocale, createSection }: Man
 const mapStateToProps = (state) => {
   const { sectionsInOrder } = state.admin.sections;
   return {
-    selectedLocale: state.admin.selectedLocale,
+    editLocale: state.admin.editLocale,
     sections: sectionsInOrder
   };
 };

--- a/assembl/static2/js/app/components/administration/languageMenu.jsx
+++ b/assembl/static2/js/app/components/administration/languageMenu.jsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { OverlayTrigger } from 'react-bootstrap';
 
 import { languageTooltip } from '../common/tooltips';
-import { updateSelectedLocale } from '../../actions/adminActions';
+import { updateEditLocale } from '../../actions/adminActions';
 import En from '../svg/flags/en';
 import Fr from '../svg/flags/fr';
 import Ja from '../svg/flags/ja';
@@ -28,7 +28,7 @@ const Flag = ({ locale }) => {
   }
 };
 
-const LanguageMenu = ({ changeLocale, selectedLocale, discussionPreferences, visibility }) => {
+const LanguageMenu = ({ changeLocale, editLocale, discussionPreferences, visibility }) => {
   if (visibility) {
     return (
       <div className="relative">
@@ -39,7 +39,7 @@ const LanguageMenu = ({ changeLocale, selectedLocale, discussionPreferences, vis
                 <div
                   onClick={() => changeLocale(key)}
                   id={key}
-                  className={selectedLocale === key ? 'flag-container active' : 'flag-container'}
+                  className={editLocale === key ? 'flag-container active' : 'flag-container'}
                   key={index}
                 >
                   <Flag locale={key} />
@@ -57,13 +57,13 @@ const LanguageMenu = ({ changeLocale, selectedLocale, discussionPreferences, vis
 
 const mapStateToProps = state => ({
   translations: state.i18n.translations,
-  selectedLocale: state.admin.selectedLocale,
+  editLocale: state.admin.editLocale,
   discussionPreferences: state.admin.discussionLanguagePreferences
 });
 
 const mapDispatchToProps = dispatch => ({
   changeLocale: (newLocale) => {
-    dispatch(updateSelectedLocale(newLocale));
+    dispatch(updateEditLocale(newLocale));
   }
 });
 

--- a/assembl/static2/js/app/components/administration/resourcesCenter/manageResourcesForm.jsx
+++ b/assembl/static2/js/app/components/administration/resourcesCenter/manageResourcesForm.jsx
@@ -6,9 +6,9 @@ import * as actions from '../../../actions/adminActions/resourcesCenter';
 import { createResourceTooltip } from '../../common/tooltips';
 import EditResourceForm from './editResourceForm';
 
-const ManageResourcesForm = ({ createResource, resources, selectedLocale }) => (
+const ManageResourcesForm = ({ createResource, resources, editLocale }) => (
   <div>
-    {resources.map(id => <EditResourceForm key={id} id={id} locale={selectedLocale} />)}
+    {resources.map(id => <EditResourceForm key={id} id={id} locale={editLocale} />)}
     <OverlayTrigger placement="top" overlay={createResourceTooltip}>
       <div onClick={() => createResource(resources.size + 1)} className="plus margin-l">
         +

--- a/assembl/static2/js/app/components/administration/resourcesCenter/pageForm.jsx
+++ b/assembl/static2/js/app/components/administration/resourcesCenter/pageForm.jsx
@@ -14,7 +14,7 @@ type PageFormProps = {
   handlePageTitleChange: Function,
   headerMimeType: string,
   headerUrl: File | string,
-  selectedLocale: string,
+  editLocale: string,
   title: string
 };
 
@@ -23,14 +23,14 @@ const DumbPageForm = ({
   handlePageTitleChange,
   headerMimeType,
   headerUrl,
-  selectedLocale,
+  editLocale,
   title
 }: PageFormProps) => {
   const titleLabel = I18n.t('administration.resourcesCenter.pageTitleLabel');
   const headerImageFieldName = 'header-image';
   return (
     <div>
-      <FormControlWithLabel key={selectedLocale} label={titleLabel} onChange={handlePageTitleChange} type="text" value={title} />
+      <FormControlWithLabel key={editLocale} label={titleLabel} onChange={handlePageTitleChange} type="text" value={title} />
       <FormGroup>
         <label htmlFor={headerImageFieldName}>
           <Translate value="administration.resourcesCenter.headerImageLabel" />
@@ -47,19 +47,19 @@ const DumbPageForm = ({
   );
 };
 
-const mapStateToProps = (state, { selectedLocale }) => {
+const mapStateToProps = (state, { editLocale }) => {
   const page = state.admin.resourcesCenter.page;
   return {
-    title: getEntryValueForLocale(page.get('titleEntries'), selectedLocale, ''),
+    title: getEntryValueForLocale(page.get('titleEntries'), editLocale, ''),
     headerFilename: page.getIn(['headerImage', 'title']),
     headerMimeType: page.getIn(['headerImage', 'mimeType']),
     headerUrl: page.getIn(['headerImage', 'externalUrl'])
   };
 };
 
-const mapDispatchToProps = (dispatch, { selectedLocale }) => ({
+const mapDispatchToProps = (dispatch, { editLocale }) => ({
   handleHeaderImageChange: value => dispatch(updateResourcesCenterHeaderImage(value)),
-  handlePageTitleChange: e => dispatch(updateResourcesCenterPageTitle(selectedLocale, e.target.value))
+  handlePageTitleChange: e => dispatch(updateResourcesCenterPageTitle(editLocale, e.target.value))
 });
 
 export { DumbPageForm };

--- a/assembl/static2/js/app/components/administration/saveButton.jsx
+++ b/assembl/static2/js/app/components/administration/saveButton.jsx
@@ -6,7 +6,7 @@ import { Translate, I18n } from 'react-redux-i18n';
 
 import { displayAlert } from '../../utils/utilityManager';
 import { convertEntriesToHTML } from '../../utils/draftjs';
-import { languagePreferencesHasChanged, updateSelectedLocale } from '../../actions/adminActions';
+import { languagePreferencesHasChanged, updateEditLocale } from '../../actions/adminActions';
 import createThematicMutation from '../../graphql/mutations/createThematic.graphql';
 import deleteThematicMutation from '../../graphql/mutations/deleteThematic.graphql';
 import updateThematicMutation from '../../graphql/mutations/updateThematic.graphql';
@@ -357,7 +357,7 @@ const mapDispatchToProps = dispatch => ({
     dispatch(languagePreferencesHasChanged(false));
   },
   changeLocale: (newLocale) => {
-    dispatch(updateSelectedLocale(newLocale));
+    dispatch(updateEditLocale(newLocale));
   }
 });
 

--- a/assembl/static2/js/app/components/administration/survey/mediaForm.jsx
+++ b/assembl/static2/js/app/components/administration/survey/mediaForm.jsx
@@ -44,7 +44,7 @@ class MediaForm extends React.Component {
       descriptionSide,
       hasMedia,
       htmlCode,
-      selectedLocale,
+      editLocale,
       title,
       toggle,
       updateDescriptionTop,
@@ -53,7 +53,7 @@ class MediaForm extends React.Component {
       updateTitle,
       updateHtmlCode
     } = this.props;
-    const upperCaseLocale = selectedLocale.toUpperCase();
+    const upperCaseLocale = editLocale.toUpperCase();
     const titlePh = `${I18n.t('administration.ph.title')} ${upperCaseLocale}`;
     const quotePh = `${I18n.t('administration.ph.quote')} ${upperCaseLocale}`;
     const descriptionTopPh = `${I18n.t('administration.ph.descriptionTop')} ${upperCaseLocale}`;
@@ -141,7 +141,7 @@ class MediaForm extends React.Component {
   }
 }
 
-export const mapStateToProps = ({ admin: { thematicsById } }, { thematicId, selectedLocale }) => {
+export const mapStateToProps = ({ admin: { thematicsById } }, { thematicId, editLocale }) => {
   const media = thematicsById.getIn([thematicId, 'video']);
   const hasMedia = media && media !== null;
   let descriptionTop;
@@ -150,11 +150,11 @@ export const mapStateToProps = ({ admin: { thematicsById } }, { thematicId, sele
   let htmlCode = '';
   let title = '';
   if (hasMedia) {
-    descriptionTop = getEntryValueForLocale(media.get('descriptionEntriesTop'), selectedLocale);
-    descriptionBottom = getEntryValueForLocale(media.get('descriptionEntriesBottom'), selectedLocale);
-    descriptionSide = getEntryValueForLocale(media.get('descriptionEntriesSide'), selectedLocale);
+    descriptionTop = getEntryValueForLocale(media.get('descriptionEntriesTop'), editLocale);
+    descriptionBottom = getEntryValueForLocale(media.get('descriptionEntriesBottom'), editLocale);
+    descriptionSide = getEntryValueForLocale(media.get('descriptionEntriesSide'), editLocale);
     htmlCode = media.get('htmlCode', '');
-    title = getEntryValueForLocale(media.get('titleEntries'), selectedLocale, '');
+    title = getEntryValueForLocale(media.get('titleEntries'), editLocale, '');
   }
   return {
     descriptionTop: descriptionTop ? descriptionTop.toJS() : null,
@@ -166,13 +166,13 @@ export const mapStateToProps = ({ admin: { thematicsById } }, { thematicId, sele
   };
 };
 
-export const mapDispatchToProps = (dispatch, { selectedLocale, thematicId }) => ({
+export const mapDispatchToProps = (dispatch, { editLocale, thematicId }) => ({
   toggle: () => dispatch(toggleVideo(thematicId)),
   updateHtmlCode: value => dispatch(updateVideoHtmlCode(thematicId, value)),
-  updateDescriptionTop: value => dispatch(updateVideoDescriptionTop(thematicId, selectedLocale, value)),
-  updateDescriptionBottom: value => dispatch(updateVideoDescriptionBottom(thematicId, selectedLocale, value)),
-  updateDescriptionSide: value => dispatch(updateVideoDescriptionSide(thematicId, selectedLocale, value)),
-  updateTitle: value => dispatch(updateVideoTitle(thematicId, selectedLocale, value))
+  updateDescriptionTop: value => dispatch(updateVideoDescriptionTop(thematicId, editLocale, value)),
+  updateDescriptionBottom: value => dispatch(updateVideoDescriptionBottom(thematicId, editLocale, value)),
+  updateDescriptionSide: value => dispatch(updateVideoDescriptionSide(thematicId, editLocale, value)),
+  updateTitle: value => dispatch(updateVideoTitle(thematicId, editLocale, value))
 });
 
 export default compose(connect(mapStateToProps, mapDispatchToProps), graphql(uploadDocumentMutation, { name: 'uploadDocument' }))(

--- a/assembl/static2/js/app/components/administration/survey/questionSection.jsx
+++ b/assembl/static2/js/app/components/administration/survey/questionSection.jsx
@@ -28,7 +28,7 @@ class QuestionSection extends React.Component {
   }
 
   render() {
-    const { selectedLocale, thematics } = this.props;
+    const { editLocale, thematics } = this.props;
     const selectedThematicId = this.state.selectedThematicId;
     return (
       <div className="admin-box">
@@ -55,14 +55,14 @@ class QuestionSection extends React.Component {
           {selectedThematicId && (
             <Row>
               <MediaForm
-                key={`media-form-${selectedThematicId}-${selectedLocale}`}
+                key={`media-form-${selectedThematicId}-${editLocale}`}
                 thematicId={selectedThematicId}
-                selectedLocale={selectedLocale}
+                editLocale={editLocale}
               />
               <QuestionsForm
-                key={`questions-form-${selectedThematicId}-${selectedLocale}`}
+                key={`questions-form-${selectedThematicId}-${editLocale}`}
                 thematicId={selectedThematicId}
-                selectedLocale={selectedLocale}
+                editLocale={editLocale}
               />
             </Row>
           )}
@@ -72,9 +72,9 @@ class QuestionSection extends React.Component {
   }
 }
 
-const mapStateToProps = ({ admin: { thematicsById, thematicsInOrder, selectedLocale } }) => ({
+const mapStateToProps = ({ admin: { thematicsById, thematicsInOrder, editLocale } }) => ({
   thematics: thematicsInOrder.filter(id => !thematicsById.getIn([id, 'toDelete'])).toArray(),
-  selectedLocale: selectedLocale
+  editLocale: editLocale
 });
 
 export default connect(mapStateToProps)(QuestionSection);

--- a/assembl/static2/js/app/components/administration/survey/questionTitle.jsx
+++ b/assembl/static2/js/app/components/administration/survey/questionTitle.jsx
@@ -7,10 +7,10 @@ import { removeQuestion, updateQuestionTitle } from '../../../actions/adminActio
 import FormControlWithLabel from '../../common/formControlWithLabel';
 import { deleteQuestionTooltip } from '../../common/tooltips';
 
-const QuestionsTitle = ({ titleEntries, qIndex, remove, selectedLocale, updateTitle }) => {
-  const titleEntry = titleEntries.find(entry => entry.localeCode === selectedLocale);
+const QuestionsTitle = ({ titleEntries, qIndex, remove, editLocale, updateTitle }) => {
+  const titleEntry = titleEntries.find(entry => entry.localeCode === editLocale);
   const title = titleEntry ? titleEntry.value : '';
-  const label = `${I18n.t('administration.question_label')} ${qIndex + 1} ${selectedLocale.toUpperCase()}`;
+  const label = `${I18n.t('administration.question_label')} ${qIndex + 1} ${editLocale.toUpperCase()}`;
   return (
     <div className="question-section">
       <FormControlWithLabel
@@ -32,8 +32,8 @@ const QuestionsTitle = ({ titleEntries, qIndex, remove, selectedLocale, updateTi
   );
 };
 
-export const mapDispatchToProps = (dispatch, { thematicId, qIndex, selectedLocale }) => ({
-  updateTitle: value => dispatch(updateQuestionTitle(thematicId, qIndex, selectedLocale, value)),
+export const mapDispatchToProps = (dispatch, { thematicId, qIndex, editLocale }) => ({
+  updateTitle: value => dispatch(updateQuestionTitle(thematicId, qIndex, editLocale, value)),
   remove: () => dispatch(removeQuestion(thematicId, qIndex))
 });
 export default connect(null, mapDispatchToProps)(QuestionsTitle);

--- a/assembl/static2/js/app/components/administration/survey/questionsForm.jsx
+++ b/assembl/static2/js/app/components/administration/survey/questionsForm.jsx
@@ -6,17 +6,12 @@ import { addQuestionTooltip } from '../../common/tooltips';
 import QuestionTitle from './questionTitle';
 import { addQuestionToThematic } from '../../../actions/adminActions';
 
-const QuestionsForm = ({ addQuestion, selectedLocale, thematicId, questions }) => (
+const QuestionsForm = ({ addQuestion, editLocale, thematicId, questions }) => (
   <div className={thematicId ? 'form-container' : 'hidden'}>
     <div className="margin-xl">
       {questions.map((question, index) => (
         <FormGroup key={index}>
-          <QuestionTitle
-            thematicId={thematicId}
-            qIndex={index}
-            titleEntries={question.titleEntries}
-            selectedLocale={selectedLocale}
-          />
+          <QuestionTitle thematicId={thematicId} qIndex={index} titleEntries={question.titleEntries} editLocale={editLocale} />
         </FormGroup>
       ))}
       <OverlayTrigger placement="top" overlay={addQuestionTooltip}>
@@ -36,8 +31,8 @@ export const mapStateToProps = ({ admin: { thematicsById, thematicsInOrder } }, 
     .toJS()
 });
 
-export const mapDispatchToProps = (dispatch, { thematicId, selectedLocale }) => ({
-  addQuestion: () => dispatch(addQuestionToThematic(thematicId, selectedLocale))
+export const mapDispatchToProps = (dispatch, { thematicId, editLocale }) => ({
+  addQuestion: () => dispatch(addQuestionToThematic(thematicId, editLocale))
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(QuestionsForm);

--- a/assembl/static2/js/app/components/administration/survey/themeForm.jsx
+++ b/assembl/static2/js/app/components/administration/survey/themeForm.jsx
@@ -14,7 +14,7 @@ export const DumbThemeCreationForm = ({
   imgUrl,
   index,
   markAsToDelete,
-  selectedLocale,
+  editLocale,
   title,
   toDelete,
   updateImgUrl,
@@ -24,14 +24,14 @@ export const DumbThemeCreationForm = ({
     return null;
   }
 
-  const handleTitleChange = e => updateTitle(selectedLocale, e.target.value);
+  const handleTitleChange = e => updateTitle(editLocale, e.target.value);
 
   const handleImageChange = (file) => {
     updateImgUrl(file);
   };
 
   const trsl = I18n.t('administration.ph.title');
-  const ph = `${trsl} ${selectedLocale.toUpperCase()}`;
+  const ph = `${trsl} ${editLocale.toUpperCase()}`;
   const num = (Number(index) + 1).toString();
   return (
     <div className="form-container">
@@ -58,12 +58,12 @@ DumbThemeCreationForm.defaultProps = {
   title: ''
 };
 
-const mapStateToProps = ({ admin: { thematicsById } }, { id, selectedLocale }) => {
+const mapStateToProps = ({ admin: { thematicsById } }, { id, editLocale }) => {
   const thematic = thematicsById.get(id);
   return {
     imgMimeType: thematic.getIn(['img', 'mimeType']),
     imgUrl: thematic.getIn(['img', 'externalUrl']),
-    title: getEntryValueForLocale(thematic.get('titleEntries'), selectedLocale, ''),
+    title: getEntryValueForLocale(thematic.get('titleEntries'), editLocale, ''),
     toDelete: thematic.get('toDelete', false)
   };
 };

--- a/assembl/static2/js/app/components/administration/survey/themeSection.jsx
+++ b/assembl/static2/js/app/components/administration/survey/themeSection.jsx
@@ -15,13 +15,13 @@ class ThemeSection extends React.Component {
   }
 
   render() {
-    const { addThematic, selectedLocale, thematics } = this.props;
+    const { addThematic, editLocale, thematics } = this.props;
     return (
       <div className="admin-box">
         <SectionTitle title={I18n.t('administration.survey.0')} annotation={I18n.t('administration.annotation')} />
         <div className="admin-content">
           <form>
-            {thematics.map((id, idx) => <ThemeForm key={id} id={id} index={idx} selectedLocale={selectedLocale} />)}
+            {thematics.map((id, idx) => <ThemeForm key={id} id={id} index={idx} editLocale={editLocale} />)}
             <OverlayTrigger placement="top" overlay={addThematicTooltip}>
               <div onClick={addThematic} className="plus margin-l">
                 +
@@ -34,9 +34,9 @@ class ThemeSection extends React.Component {
   }
 }
 
-const mapStateToProps = ({ admin: { thematicsById, thematicsInOrder, selectedLocale } }) => ({
+const mapStateToProps = ({ admin: { thematicsById, thematicsInOrder, editLocale } }) => ({
   thematics: thematicsInOrder.filter(id => !thematicsById.getIn([id, 'toDelete'])),
-  selectedLocale: selectedLocale
+  editLocale: editLocale
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/assembl/static2/js/app/pages/administration.jsx
+++ b/assembl/static2/js/app/pages/administration.jsx
@@ -145,6 +145,7 @@ class Administration extends React.Component {
     const { timeline } = this.props.debate.debateData;
     const childrenWithProps = React.Children.map(children, child =>
       React.cloneElement(child, {
+        locale: i18n.locale,
         toggleLanguageMenu: this.toggleLanguageMenu
       })
     );

--- a/assembl/static2/js/app/pages/discussionAdmin.jsx
+++ b/assembl/static2/js/app/pages/discussionAdmin.jsx
@@ -19,7 +19,7 @@ const DiscussionAdmin = (props) => {
 };
 
 const mapStateToProps = state => ({
-  selectedLocale: state.admin.selectedLocale
+  editLocale: state.admin.editLocale
 });
 
 export default connect(mapStateToProps)(DiscussionAdmin);

--- a/assembl/static2/js/app/pages/discussionAdmin.jsx
+++ b/assembl/static2/js/app/pages/discussionAdmin.jsx
@@ -12,7 +12,7 @@ const DiscussionAdmin = (props) => {
     <div className="discussion-admin">
       {props.section === '1' && <LanguageSection {...props} />}
       {props.section === '2' && <ManageSectionsForm {...props} />}
-      {props.section === '3' && <LegalNoticeAndTermsForm locale={props.selectedLocale} />}
+      {props.section === '3' && <LegalNoticeAndTermsForm {...props} />}
       {!isNaN(currentStep) && <Navbar currentStep={currentStep} totalSteps={3} phaseIdentifier="discussion" />}
     </div>
   );

--- a/assembl/static2/js/app/pages/resourcesCenterAdmin.jsx
+++ b/assembl/static2/js/app/pages/resourcesCenterAdmin.jsx
@@ -6,16 +6,16 @@ import SectionTitle from '../components/administration/sectionTitle';
 import PageForm from '../components/administration/resourcesCenter/pageForm';
 import ManageResourcesForm from '../components/administration/resourcesCenter/manageResourcesForm';
 
-const ResourcesCenterAdmin = ({ selectedLocale }) => (
+const ResourcesCenterAdmin = ({ editLocale }) => (
   <div className="resources-center-admin admin-box">
     <SectionTitle title={I18n.t('administration.resourcesCenter.title')} annotation={I18n.t('administration.annotation')} />
-    <PageForm selectedLocale={selectedLocale} />
-    <ManageResourcesForm selectedLocale={selectedLocale} />
+    <PageForm editLocale={editLocale} />
+    <ManageResourcesForm editLocale={editLocale} />
   </div>
 );
 
 const mapStateToProps = state => ({
-  selectedLocale: state.admin.selectedLocale
+  editLocale: state.admin.editLocale
 });
 
 export default connect(mapStateToProps)(ResourcesCenterAdmin);

--- a/assembl/static2/js/app/reducers/adminReducer/index.js
+++ b/assembl/static2/js/app/reducers/adminReducer/index.js
@@ -11,11 +11,14 @@ import sections from './adminSections';
 import type { AdminSectionsReducers } from './adminSections';
 import { updateInLangstringEntries } from '../../utils/i18n';
 
-type SelectedLocaleState = string;
-type SelectedLocaleReducer = (SelectedLocaleState, ReduxAction<Action>) => SelectedLocaleState;
-export const selectedLocale: SelectedLocaleReducer = (state = 'fr', action) => {
+type EditLocaleState = string;
+type EditLocaleReducer = (EditLocaleState, ReduxAction<Action>) => EditLocaleState;
+/*
+  The locale that is used to edit the content in the administration
+*/
+export const editLocale: EditLocaleReducer = (state = 'fr', action) => {
   switch (action.type) {
-  case 'UPDATE_SELECTED_LOCALE':
+  case 'UPDATE_EDIT_LOCALE':
     return action.newLocale;
   default:
     return state;
@@ -196,7 +199,7 @@ export const discussionLanguagePreferencesHasChanged: DiscussionLanguagePreferen
 
 type ResourcesCenterReducer = Function; // TODO
 export type AdminReducer = {
-  selectedLocale: SelectedLocaleReducer,
+  editLocale: EditLocaleReducer,
   thematicsHaveChanged: ThematicsHaveChangedReducer,
   thematicsInOrder: ThematicsInOrderReducer,
   thematicsById: ThematicsByIdReducer,
@@ -208,7 +211,7 @@ export type AdminReducer = {
 };
 
 const reducers: AdminReducer = {
-  selectedLocale: selectedLocale,
+  editLocale: editLocale,
   thematicsHaveChanged: thematicsHaveChanged,
   thematicsInOrder: thematicsInOrder,
   thematicsById: thematicsById,

--- a/assembl/static2/js/app/routes.jsx
+++ b/assembl/static2/js/app/routes.jsx
@@ -67,15 +67,15 @@ const AdminChild = (props) => {
   case 'survey':
     return <SurveyAdmin {...props} thematicId={props.location.query.thematic} section={props.location.query.section} />;
   case 'thread':
-    return <ThreadAdmin />;
+    return <ThreadAdmin {...props} />;
   case 'multiColumns':
-    return <MultiColumnsAdmin />;
+    return <MultiColumnsAdmin {...props} />;
   case 'tokenVote':
     return <NotFound />;
   case 'resourcesCenter':
-    return <ResourcesCenterAdmin />;
+    return <ResourcesCenterAdmin {...props} />;
   default:
-    return <ThreadAdmin />;
+    return <ThreadAdmin {...props} />;
   }
 };
 

--- a/assembl/static2/js/app/store/index.js
+++ b/assembl/static2/js/app/store/index.js
@@ -1,6 +1,6 @@
 import { loadTranslations, setLocale, syncTranslationWithStore } from 'react-redux-i18n';
 
-import { updateSelectedLocale } from '../actions/adminActions';
+import { updateEditLocale } from '../actions/adminActions';
 import configureStore from './configureStore';
 import middlewares from './middlewares';
 import rootReducer from '../reducers/rootReducer';
@@ -20,6 +20,6 @@ export default function createAppStore(initialState) {
   syncTranslationWithStore(store);
   store.dispatch(loadTranslations(getTranslations()));
   store.dispatch(setLocale(userLocale));
-  store.dispatch(updateSelectedLocale(userLocale));
+  store.dispatch(updateEditLocale(userLocale));
   return store;
 }

--- a/assembl/static2/tests/unit/actions/adminActions/index.js
+++ b/assembl/static2/tests/unit/actions/adminActions/index.js
@@ -1,14 +1,14 @@
 import * as actions from '../../../../js/app/actions/adminActions';
 
 describe('Admin actions', () => {
-  describe('updateSelectedLocale action', () => {
-    const { updateSelectedLocale } = actions;
-    it('should return a UPDATE_SELECTED_LOCALE action type', () => {
+  describe('updateEditLocale action', () => {
+    const { updateEditLocale } = actions;
+    it('should return a UPDATE_EDIT_LOCALE action type', () => {
       const expected = {
         newLocale: 'de',
-        type: 'UPDATE_SELECTED_LOCALE'
+        type: 'UPDATE_EDIT_LOCALE'
       };
-      const actual = updateSelectedLocale('de');
+      const actual = updateEditLocale('de');
       expect(actual).toEqual(expected);
     });
   });

--- a/assembl/static2/tests/unit/components/administration/discussion/manageSectionsForm.spec.jsx
+++ b/assembl/static2/tests/unit/components/administration/discussion/manageSectionsForm.spec.jsx
@@ -8,7 +8,7 @@ describe('DumbManageSectionsForm component', () => {
     const createSectionSpy = jest.fn(() => {});
     const props = {
       sections: List.of('123', '456', '789'),
-      selectedLocale: 'en',
+      editLocale: 'en',
       createSection: createSectionSpy
     };
     const renderer = new ShallowRenderer();

--- a/assembl/static2/tests/unit/components/administration/resourcesCenter/pageForm.spec.jsx
+++ b/assembl/static2/tests/unit/components/administration/resourcesCenter/pageForm.spec.jsx
@@ -12,7 +12,7 @@ describe('DumbPageForm component', () => {
       handlePageTitleChange: handlePageTitleChangeSpy,
       headerMimeType: 'image/jpeg',
       headerUrl: 'http://www.example.com/documents/myimage/data',
-      selectedLocale: 'fr',
+      editLocale: 'fr',
       title: 'Centre de ressources',
       disabled: false
     };

--- a/assembl/static2/tests/unit/reducers/adminReducer/index.spec.js
+++ b/assembl/static2/tests/unit/reducers/adminReducer/index.spec.js
@@ -3,26 +3,26 @@ import { fromJS, List, Map } from 'immutable';
 import * as reducers from '../../../../js/app/reducers/adminReducer';
 
 describe('Admin reducers', () => {
-  describe('selectedLocale reducer', () => {
-    const { selectedLocale } = reducers;
+  describe('editLocale reducer', () => {
+    const { editLocale } = reducers;
     it('should return the initial state', () => {
-      expect(selectedLocale(undefined, {})).toEqual('fr');
+      expect(editLocale(undefined, {})).toEqual('fr');
     });
 
     it('should return state by default', () => {
       const state = 'en';
       const expected = 'en';
-      const actual = selectedLocale(state, {});
+      const actual = editLocale(state, {});
       expect(actual).toEqual(expected);
     });
 
-    it('should handle UPDATE_SELECTED_LOCALE action type', () => {
+    it('should handle UPDATE_EDIT_LOCALE action type', () => {
       const state = 'en';
       const action = {
-        type: 'UPDATE_SELECTED_LOCALE',
+        type: 'UPDATE_EDIT_LOCALE',
         newLocale: 'fr'
       };
-      const actual = selectedLocale(state, action);
+      const actual = editLocale(state, action);
       const expected = 'fr';
       expect(actual).toEqual(expected);
     });


### PR DESCRIPTION
Fixes DEVAS-1083
I think that we should rename `selectedLocale` and `locale` variables. These names are confusing : 
- `selectedLocale` is the locale selected on the flags in the right column (it allows users to choose the language in which they edit the content)
- `locale` (`state.i18n.locale`) is the locale chosen in the navigation bar to specify the language of the interface

What do you think about it ? Any ideas for better names ?