### PR TITLE
Prevent crash if a discussion phase has no .start or .end date

### DIFF
--- a/assembl/lib/frontend_urls.py
+++ b/assembl/lib/frontend_urls.py
@@ -59,10 +59,8 @@ def get_timeline_for_date(discussion, date):
     """
     if isinstance(date, basestring):
         date = dateutil.parser.parse(date)
-    mindate = datetime.date(datetime.MINYEAR, 1, 1)
-    mindate = datetime.datetime.combine(mindate, datetime.datetime.min.time())
-    maxdate = datetime.date(datetime.MAXYEAR, 1, 1)
-    maxdate = datetime.datetime.combine(maxdate, datetime.datetime.max.time())
+    mindate = datetime.datetime(datetime.MINYEAR, 1, 1)
+    maxdate = datetime.datetime(datetime.MAXYEAR, 1, 1)
     phases = sorted(discussion.timeline_phases, key=lambda p: p.start or mindate)
     actual_phase = None
     for index, phase in enumerate(phases):

--- a/assembl/lib/frontend_urls.py
+++ b/assembl/lib/frontend_urls.py
@@ -59,12 +59,15 @@ def get_timeline_for_date(discussion, date):
     """
     if isinstance(date, basestring):
         date = dateutil.parser.parse(date)
-
-    phases = sorted(discussion.timeline_phases, key=lambda p: p.start)
+    mindate = datetime.date(datetime.MINYEAR, 1, 1)
+    mindate = datetime.datetime.combine(mindate, datetime.datetime.min.time())
+    maxdate = datetime.date(datetime.MAXYEAR, 1, 1)
+    maxdate = datetime.datetime.combine(maxdate, datetime.datetime.max.time())
+    phases = sorted(discussion.timeline_phases, key=lambda p: p.start or mindate)
     actual_phase = None
     for index, phase in enumerate(phases):
         # Assume all dates are in utc, no tz_info however
-        if phase.start <= date < phase.end:
+        if (phase.start or mindate) <= date < (phase.end or maxdate):
             actual_phase = phase
             break
     return actual_phase


### PR DESCRIPTION
I found it because if a phase has no date it crashes the notifications tasks

The new behavior is rough but it prevents the crash in this case