### PR TITLE
Decrease time for running tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ env:
   - TO_TEST=BACKEND
   - TO_TEST=FRONTEND
 script:
-  - if [ "$TO_TEST" = "BACKEND" ]; then py.test --cov assembl --cov-report term --cov-report html --junit-xml junit.xml assembl; fi
+  - if [ "$TO_TEST" = "BACKEND" ]; then py.test --cov assembl --cov-report term --cov-report html --junit-xml junit.xml --maxfail=2 assembl; fi
   - if [ "$TO_TEST" = "BACKEND" ]; then flake8 assembl; fi
   - cd assembl/static2
   - if [ "$TO_TEST" = "FRONTEND" ]; then npm test; fi

--- a/assembl/models/discussion.py
+++ b/assembl/models/discussion.py
@@ -78,7 +78,7 @@ class Discussion(DiscussionBoundBase, NamedClassMixin):
         Integer(), ForeignKey(LangString.id))
     resources_center_title = relationship(
         LangString,
-        lazy="joined", single_parent=True,
+        lazy="select", single_parent=True,
         primaryjoin=resources_center_title_id == LangString.id,
         backref=backref(
             "discussion_from_resources_center_title", lazy="dynamic"),
@@ -86,12 +86,12 @@ class Discussion(DiscussionBoundBase, NamedClassMixin):
 
     terms_and_conditions_id = Column(Integer(), ForeignKey(LangString.id))
     terms_and_conditions = relationship(
-        LangString, lazy="joined", single_parent=True, primaryjoin=terms_and_conditions_id == LangString.id,
+        LangString, lazy="select", single_parent=True, primaryjoin=terms_and_conditions_id == LangString.id,
         backref=backref("discussion_from_terms_and_conditions", lazy="dynamic"), cascade="all, delete-orphan")
 
     legal_notice_id = Column(Integer(), ForeignKey(LangString.id))
     legal_notice = relationship(
-        LangString, lazy="joined", single_parent=True, primaryjoin=legal_notice_id == LangString.id,
+        LangString, lazy="select", single_parent=True, primaryjoin=legal_notice_id == LangString.id,
         backref=backref("discussion_from_legal_notice", lazy="dynamic"), cascade="all, delete-orphan")
 
     @classmethod

--- a/assembl/tests/fixtures/sections.py
+++ b/assembl/tests/fixtures/sections.py
@@ -3,14 +3,14 @@ import pytest
 
 
 @pytest.fixture(scope="function")
-def sections(request, discussion, test_session):
+def sections(request, discussion_with_default_data, test_session):
     """Create default sections."""
     from assembl.models import Section, LangString
     from assembl.models.section import SectionTypesEnum
-    discussion_id = discussion.id
+    discussion_id = discussion_with_default_data.id
 
-    # default sections are created in the discussion fixture via
-    # create_default_discussion_data
+    # default sections are created in the discussion_with_default_data fixture
+    # via create_default_discussion_data
 
     sections = []
     # add a custom section

--- a/assembl/tests/utils/__init__.py
+++ b/assembl/tests/utils/__init__.py
@@ -122,15 +122,7 @@ def clear_rows(app_settings, session):
 def drop_tables(app_settings, session):
     log.info('Dropping all tables.')
     if not using_virtuoso():
-        # postgres. Thank you to
-        # http://stackoverflow.com/questions/5408156/how-to-drop-a-postgresql-database-if-there-are-active-connections-to-it
         session.close()
-        session.execute(
-            """SELECT pg_terminate_backend(pg_stat_activity.pid)
-                FROM pg_stat_activity
-                WHERE pg_stat_activity.datname = '%s'
-                  AND pid <> pg_backend_pid()""" % (
-                    app_settings.get("db_database")))
 
     try:
         get_metadata().drop_all(session.connection())

--- a/assembl/tests/views_tests/test_graphql.py
+++ b/assembl/tests/views_tests/test_graphql.py
@@ -1997,7 +1997,7 @@ mutation updateResourcesCenter($headerImage:String) {
     assert resources_center['headerImage']['title'] == 'new-img.png'
 
 
-def test_query_sections(discussion, graphql_request, sections):
+def test_query_sections(sections, graphql_request):
     from assembl.models.section import SectionTypesEnum
     query = u"""
 query { sections {
@@ -2091,8 +2091,8 @@ query { sections {
     assert len(result['sections']) == 5
 
 
-def test_mutation_delete_section_fails_for_non_custom_sections(graphql_request, discussion):
-    non_custom_section_id = to_global_id('Section', discussion.sections[1].id)  # Debate section
+def test_mutation_delete_section_fails_for_non_custom_sections(graphql_request, discussion_with_default_data):
+    non_custom_section_id = to_global_id('Section', discussion_with_default_data.sections[1].id)  # Debate section
     variables = {
         'id': non_custom_section_id
     }
@@ -2111,7 +2111,7 @@ mutation deleteSection($id: ID!) {
     assert result['deleteSection']['success'] is False
 
 
-def test_mutation_update_section(graphql_request, sections):
+def test_mutation_update_section(sections, graphql_request):
     section_id = to_global_id('section', sections[-1].id)
     title_entries = [
         {u"value": u"Reddit", u"localeCode": u"fr"},

--- a/assembl/tests/views_tests/test_graphql_user.py
+++ b/assembl/tests/views_tests/test_graphql_user.py
@@ -32,7 +32,7 @@ query User($id: ID!) {
     assert res.data['user']['image'] is None
 
 
-def test_graphql_get_profile_should_not_see_email(graphql_request, participant1_user, participant2_user):
+def test_graphql_get_profile_should_not_see_email(graphql_request, discussion_with_default_data, participant1_user, participant2_user):
     # participant2_user sould not see the email of participant1_user
     graphql_request.authenticated_userid = participant2_user.id
     res = schema.execute(u"""


### PR DESCRIPTION
We did some regressions in the past two months on the time we need to run all tests.
I fixed them.
On my machine `py.test assembl`
`256 passed, 3 skipped, 6 xfailed in 861.87 seconds so 14.33 minutes`
It was before 35 minutes.

On travis, we go from 38 to 24 or 28 minutes.