### PR TITLE
Fix gauge vote wrongly tombstoned

### DIFF
--- a/assembl/models/votes.py
+++ b/assembl/models/votes.py
@@ -925,7 +925,9 @@ class AbstractIdeaVote(HistoryMixin, DiscussionBoundBase):
         idea_id = self.idea_id or (self.idea.id if self.idea else None)
         widget_id = self.widget_id or (self.widget.id if self.widget else None)
         voter_id = self.voter_id or (self.voter.id if self.voter else None)
+        vote_spec_id = self.vote_spec_id or (self.vote_spec.id if self.vote_spec else None)
         return (query.filter_by(
+            vote_spec_id=vote_spec_id,
             idea_id=idea_id, widget_id=widget_id, voter_id=voter_id), True)
 
     crud_permissions = CrudPermissions(


### PR DESCRIPTION
There is an issue when you have several gauges on a proposal, only the last gauge is actually saved, all the previous gauges votes for the proposal are tombstoned. This is because the duplicate handling logic doesn't use vote_spec_id for the unique_query.