### PR TITLE
Add Cancel module customization for custom gauges in step 3

### DIFF
--- a/assembl/static2/js/app/actions/actionTypes.js
+++ b/assembl/static2/js/app/actions/actionTypes.js
@@ -74,6 +74,7 @@ export const ADD_MODULE_TO_PROPOSAL: 'ADD_MODULE_TO_PROPOSAL' = 'ADD_MODULE_TO_P
 export const UNDELETE_MODULE: 'UNDELETE_MODULE' = 'UNDELETE_MODULE';
 export const MARK_ALL_DEPENDENCIES_AS_CHANGED: 'MARK_ALL_DEPENDENCIES_AS_CHANGED' = 'MARK_ALL_DEPENDENCIES_AS_CHANGED';
 export const SET_VALIDATION_ERRORS: 'SET_VALIDATION_ERRORS' = 'SET_VALIDATION_ERRORS';
+export const CANCEL_MODULE_CUSTOMIZATION: 'CANCEL_MODULE_CUSTOMIZATION' = 'CANCEL_MODULE_CUSTOMIZATION';
 
 export type UpdateContentLocaleById = {
   type: typeof UPDATE_CONTENT_LOCALE_BY_ID,
@@ -510,6 +511,11 @@ export type SetValidationErrors = {
   errors: ValidationErrors,
   id: string,
   type: typeof SET_VALIDATION_ERRORS
+};
+
+export type CancelModuleCustomization = {
+  id: string,
+  type: typeof CANCEL_MODULE_CUSTOMIZATION
 };
 
 type BasicAction = {

--- a/assembl/static2/js/app/actions/adminActions/voteSession.js
+++ b/assembl/static2/js/app/actions/adminActions/voteSession.js
@@ -285,3 +285,8 @@ export const setValidationErrors = (id: string, errors: ValidationErrors): actio
   id: id,
   type: actionTypes.SET_VALIDATION_ERRORS
 });
+
+export const cancelModuleCustomization = (id: string): actionTypes.CancelModuleCustomization => ({
+  id: id,
+  type: actionTypes.CANCEL_MODULE_CUSTOMIZATION
+});

--- a/assembl/static2/js/app/components/administration/voteSession/voteProposalForm.jsx
+++ b/assembl/static2/js/app/components/administration/voteSession/voteProposalForm.jsx
@@ -15,6 +15,7 @@ import {
   moveProposalUp,
   moveProposalDown,
   addModuleToProposal,
+  cancelModuleCustomization,
   deleteVoteModule,
   undeleteModule
 } from '../../../actions/adminActions/voteSession';
@@ -35,6 +36,7 @@ type VoteProposalFormProps = {
   handleUpClick: Function,
   handleDownClick: Function,
   associateModuleToProposal: Function,
+  cancelCustomization: Function,
   deassociateModuleToProposal: Function,
   reactivateModule: Function,
   tokenModules: Object,
@@ -63,6 +65,7 @@ const DumbVoteProposalForm = ({
   gaugeModules,
   proposalModules,
   associateModuleToProposal,
+  cancelCustomization,
   deassociateModuleToProposal,
   reactivateModule,
   refetchVoteSession,
@@ -200,15 +203,29 @@ const DumbVoteProposalForm = ({
 
               {pModule &&
                 pModule.get('id') && (
-                  <span
-                    className="inline settings-link"
-                    onClick={() => {
-                      settingsModal(pModule.get('id'));
-                    }}
-                  >
-                    <i className="assembl-icon-edit" />
-                    <Translate value="administration.voteProposals.gaugeSettings" />
-                  </span>
+                  <div>
+                    <span
+                      className="inline settings-link"
+                      onClick={() => {
+                        settingsModal(pModule.get('id'));
+                      }}
+                    >
+                      <i className="assembl-icon-edit" />
+                      <Translate value="administration.voteProposals.gaugeSettings" />
+                    </span>
+
+                    {pModule.get('isCustom') && (
+                      <span
+                        className="inline settings-link"
+                        onClick={() => {
+                          cancelCustomization(pModule.get('id'));
+                        }}
+                      >
+                        <i className="assembl-icon-cancel" />
+                        <Translate value="administration.voteProposals.cancelCustomization" />
+                      </span>
+                    )}
+                  </div>
                 )}
             </div>
           );
@@ -246,6 +263,7 @@ const mapStateToProps = ({ admin }, { id, editLocale }) => {
 };
 
 const mapDispatchToProps = (dispatch, { id }) => ({
+  cancelCustomization: moduleId => dispatch(cancelModuleCustomization(moduleId)),
   markAsToDelete: () => {
     dispatch(deleteVoteProposal(id));
     closeModal();

--- a/assembl/static2/js/app/reducers/adminReducer/voteSession.js
+++ b/assembl/static2/js/app/reducers/adminReducer/voteSession.js
@@ -42,7 +42,8 @@ import {
   ADD_MODULE_TO_PROPOSAL,
   UNDELETE_MODULE,
   MARK_ALL_DEPENDENCIES_AS_CHANGED,
-  SET_VALIDATION_ERRORS
+  SET_VALIDATION_ERRORS,
+  CANCEL_MODULE_CUSTOMIZATION
 } from '../../actions/actionTypes';
 import { updateInLangstringEntries } from '../../utils/i18n';
 import { pickerColors } from '../../constants';
@@ -354,6 +355,32 @@ export const modulesById = (state: Map<string, Map> = Map(), action: ReduxAction
 
       return voteSpec;
     });
+  case CANCEL_MODULE_CUSTOMIZATION: {
+    const template = state.get(state.getIn([action.id, 'voteSpecTemplateId']));
+    return state
+      .update(action.id, m => m.set('isNumberGauge', template.get('isNumberGauge')))
+      .update(action.id, m =>
+        m
+          .set('instructionsEntries', template.get('instructionsEntries'))
+          .set('isCustom', false)
+          .set('_hasChanged', true)
+      )
+      .update(action.id, (m) => {
+        if (m.get('isNumberGauge')) {
+          return m
+            .delete('choices')
+            .set('unit', template.get('unit'))
+            .set('max', template.get('max'))
+            .set('min', template.get('min'));
+        }
+
+        return m
+          .set('choices', template.get('choices'))
+          .delete('max')
+          .delete('min')
+          .delete('unit');
+      });
+  }
   default:
     return state;
   }
@@ -431,6 +458,7 @@ export const voteProposalsHaveChanged = (state: boolean = false, action: ReduxAc
   case ADD_MODULE_TO_PROPOSAL:
   case DELETE_VOTE_MODULE:
   case MARK_ALL_DEPENDENCIES_AS_CHANGED:
+  case CANCEL_MODULE_CUSTOMIZATION:
     return true;
   case UPDATE_VOTE_PROPOSALS:
     return false;

--- a/assembl/static2/js/app/utils/translations.js
+++ b/assembl/static2/js/app/utils/translations.js
@@ -450,6 +450,7 @@ const Translations = {
         gauge: "Jauge %{number}",
         customGauge: "Jauge %{number} (modifiée pour cette proposition)",
         gaugeSettings: "Modifier le paramétrage",
+        cancelCustomization: "Annuler le paramétrage",
         validationErrors: {
           atLeastOneModule: "Vous devez sélectionner au moins un module."
         }
@@ -1053,6 +1054,7 @@ const Translations = {
         description: "Description*",
         tokenVote: "Token vote",
         gaugeSettings: "Edit settings",
+        cancelCustomization: "Cancel settings",
         validationErrors: {
           atLeastOneModule: "You should select at least one module."
         }

--- a/assembl/static2/tests/unit/actions/adminActions/voteSession.spec.js
+++ b/assembl/static2/tests/unit/actions/adminActions/voteSession.spec.js
@@ -175,4 +175,16 @@ describe('voteSession admin actions', () => {
       expect(actual).toEqual(expected);
     });
   });
+
+  describe('cancelModuleCustomization', () => {
+    const { cancelModuleCustomization } = actions;
+    it('should return a CANCEL_MODULE_CUSTOMIZATION action', () => {
+      const actual = cancelModuleCustomization('my-module');
+      const expected = {
+        id: 'my-module',
+        type: actionTypes.CANCEL_MODULE_CUSTOMIZATION
+      };
+      expect(actual).toEqual(expected);
+    });
+  });
 });

--- a/assembl/static2/tests/unit/reducers/adminReducer/voteSession.spec.js
+++ b/assembl/static2/tests/unit/reducers/adminReducer/voteSession.spec.js
@@ -282,6 +282,125 @@ describe('voteSession admin reducers', () => {
     });
   });
 
+  describe('voteProposalsHaveChanged reducer', () => {
+    const { voteProposalsHaveChanged } = reducers;
+    it('should handle CREATE_VOTE_PROPOSAL action', () => {
+      const action = {
+        id: 'my-proposal',
+        type: actionTypes.CREATE_VOTE_PROPOSAL
+      };
+      const expected = true;
+      const actual = voteProposalsHaveChanged(false, action);
+      expect(actual).toEqual(expected);
+    });
+
+    it('should handle DELETE_VOTE_PROPOSAL action', () => {
+      const action = {
+        id: 'my-proposal',
+        type: actionTypes.DELETE_VOTE_PROPOSAL
+      };
+      const expected = true;
+      const actual = voteProposalsHaveChanged(false, action);
+      expect(actual).toEqual(expected);
+    });
+
+    it('should handle MOVE_PROPOSAL_DOWN action', () => {
+      const action = {
+        id: 'my-proposal',
+        type: actionTypes.MOVE_PROPOSAL_DOWN
+      };
+      const expected = true;
+      const actual = voteProposalsHaveChanged(false, action);
+      expect(actual).toEqual(expected);
+    });
+
+    it('should handle MOVE_PROPOSAL_UP action', () => {
+      const action = {
+        id: 'my-proposal',
+        type: actionTypes.MOVE_PROPOSAL_UP
+      };
+      const expected = true;
+      const actual = voteProposalsHaveChanged(false, action);
+      expect(actual).toEqual(expected);
+    });
+
+    it('should handle UPDATE_VOTE_PROPOSAL_TITLE action', () => {
+      const action = {
+        id: 'my-proposal',
+        locale: 'en',
+        value: 'The XML interface is down, override the virtual alarm so we can parse the SAS firewall!',
+        type: actionTypes.UPDATE_VOTE_PROPOSAL_TITLE
+      };
+      const expected = true;
+      const actual = voteProposalsHaveChanged(false, action);
+      expect(actual).toEqual(expected);
+    });
+
+    it('should handle UPDATE_VOTE_PROPOSAL_DESCRIPTION action', () => {
+      const action = {
+        id: 'my-proposal',
+        locale: 'en',
+        value: 'We need to transmit the open-source PNG bus!',
+        type: actionTypes.UPDATE_VOTE_PROPOSAL_DESCRIPTION
+      };
+      const expected = true;
+      const actual = voteProposalsHaveChanged(false, action);
+      expect(actual).toEqual(expected);
+    });
+
+    it('should handle ADD_MODULE_TO_PROPOSAL action', () => {
+      const action = {
+        id: 'my-module',
+        voteSpecTemplateId: 'my-template',
+        proposalId: 'my-proposal',
+        type: actionTypes.ADD_MODULE_TO_PROPOSAL
+      };
+      const expected = true;
+      const actual = voteProposalsHaveChanged(false, action);
+      expect(actual).toEqual(expected);
+    });
+
+    it('should handle DELETE_VOTE_MODULE action', () => {
+      const action = {
+        id: 'my-module',
+        type: actionTypes.DELETE_VOTE_MODULE
+      };
+      const expected = true;
+      const actual = voteProposalsHaveChanged(false, action);
+      expect(actual).toEqual(expected);
+    });
+
+    it('should handle MARK_ALL_DEPENDENCIES_AS_CHANGED action', () => {
+      const action = {
+        id: 'my-module',
+        type: actionTypes.MARK_ALL_DEPENDENCIES_AS_CHANGED
+      };
+      const expected = true;
+      const actual = voteProposalsHaveChanged(false, action);
+      expect(actual).toEqual(expected);
+    });
+
+    it('should handle CANCEL_MODULE_CUSTOMIZATION action', () => {
+      const action = {
+        id: 'my-module',
+        type: actionTypes.CANCEL_MODULE_CUSTOMIZATION
+      };
+      const expected = true;
+      const actual = voteProposalsHaveChanged(false, action);
+      expect(actual).toEqual(expected);
+    });
+
+    it('should handle UPDATE_VOTE_PROPOSALS action', () => {
+      const action = {
+        voteProposals: [],
+        type: actionTypes.UPDATE_VOTE_PROPOSALS
+      };
+      const expected = false;
+      const actual = voteProposalsHaveChanged(true, action);
+      expect(actual).toEqual(expected);
+    });
+  });
+
   describe('voteProposalsById reducer', () => {
     const { voteProposalsById, voteProposalsHaveChanged } = reducers;
 
@@ -1150,6 +1269,265 @@ describe('voteSession admin reducers', () => {
           id: 'template',
           voteSpecTemplateId: null,
           proposalId: null
+        }
+      };
+      const actual = modulesById(state, action);
+      expect(actual.toJS()).toEqual(expected);
+    });
+
+    it('should handle CANCEL_MODULE_CUSTOMIZATION action type (choice gauge)', () => {
+      const state = fromJS({
+        customGauge: {
+          _hasChanged: false,
+          _isNew: false,
+          _toDelete: false,
+          isCustom: true,
+          isNumberGauge: false,
+          id: 'customGauge',
+          voteSpecTemplateId: 'template',
+          proposalId: 'proposal1',
+          instructionsEntries: [
+            {
+              localeCode: 'en',
+              value: 'My custom instructions'
+            }
+          ],
+          choices: ['custom-choice1', 'custom-choice2']
+        },
+        template: {
+          _hasChanged: false,
+          _isNew: false,
+          _toDelete: true,
+          isNumberGauge: false,
+          tokenCategories: [],
+          voteType: 'tokens',
+          id: 'template',
+          voteSpecTemplateId: null,
+          proposalId: null,
+          instructionsEntries: [
+            {
+              localeCode: 'en',
+              value: 'My template instructions'
+            }
+          ],
+          choices: ['template-choice1']
+        }
+      });
+      const action = {
+        id: 'customGauge',
+        type: actionTypes.CANCEL_MODULE_CUSTOMIZATION
+      };
+      const expected = {
+        customGauge: {
+          _hasChanged: true,
+          _isNew: false,
+          _toDelete: false,
+          isCustom: false,
+          isNumberGauge: false,
+          id: 'customGauge',
+          voteSpecTemplateId: 'template',
+          proposalId: 'proposal1',
+          instructionsEntries: [
+            {
+              localeCode: 'en',
+              value: 'My template instructions'
+            }
+          ],
+          choices: ['template-choice1']
+        },
+        template: {
+          _hasChanged: false,
+          _isNew: false,
+          _toDelete: true,
+          isNumberGauge: false,
+          tokenCategories: [],
+          voteType: 'tokens',
+          id: 'template',
+          voteSpecTemplateId: null,
+          proposalId: null,
+          instructionsEntries: [
+            {
+              localeCode: 'en',
+              value: 'My template instructions'
+            }
+          ],
+          choices: ['template-choice1']
+        }
+      };
+      const actual = modulesById(state, action);
+      expect(actual.toJS()).toEqual(expected);
+    });
+
+    it('should handle CANCEL_MODULE_CUSTOMIZATION action type (number gauge)', () => {
+      const state = fromJS({
+        customGauge: {
+          _hasChanged: false,
+          _isNew: false,
+          _toDelete: false,
+          isCustom: true,
+          isNumberGauge: true,
+          id: 'customGauge',
+          voteSpecTemplateId: 'template',
+          proposalId: 'proposal1',
+          instructionsEntries: [
+            {
+              localeCode: 'en',
+              value: 'My custom instructions'
+            }
+          ],
+          unit: 'custom unit',
+          min: 0,
+          max: 10
+        },
+        template: {
+          _hasChanged: false,
+          _isNew: false,
+          _toDelete: true,
+          isNumberGauge: true,
+          tokenCategories: [],
+          voteType: 'tokens',
+          id: 'template',
+          voteSpecTemplateId: null,
+          proposalId: null,
+          instructionsEntries: [
+            {
+              localeCode: 'en',
+              value: 'My template instructions'
+            }
+          ],
+          unit: 'template unit',
+          min: 100,
+          max: 1000
+        }
+      });
+      const action = {
+        id: 'customGauge',
+        type: actionTypes.CANCEL_MODULE_CUSTOMIZATION
+      };
+      const expected = {
+        customGauge: {
+          _hasChanged: true,
+          _isNew: false,
+          _toDelete: false,
+          isCustom: false,
+          isNumberGauge: true,
+          id: 'customGauge',
+          voteSpecTemplateId: 'template',
+          proposalId: 'proposal1',
+          instructionsEntries: [
+            {
+              localeCode: 'en',
+              value: 'My template instructions'
+            }
+          ],
+          unit: 'template unit',
+          min: 100,
+          max: 1000
+        },
+        template: {
+          _hasChanged: false,
+          _isNew: false,
+          _toDelete: true,
+          isNumberGauge: true,
+          tokenCategories: [],
+          voteType: 'tokens',
+          id: 'template',
+          voteSpecTemplateId: null,
+          proposalId: null,
+          instructionsEntries: [
+            {
+              localeCode: 'en',
+              value: 'My template instructions'
+            }
+          ],
+          unit: 'template unit',
+          min: 100,
+          max: 1000
+        }
+      };
+      const actual = modulesById(state, action);
+      expect(actual.toJS()).toEqual(expected);
+    });
+
+    it('should handle CANCEL_MODULE_CUSTOMIZATION action type (change gauge type)', () => {
+      const state = fromJS({
+        customGauge: {
+          _hasChanged: false,
+          _isNew: false,
+          _toDelete: false,
+          isCustom: true,
+          isNumberGauge: true,
+          id: 'customGauge',
+          voteSpecTemplateId: 'template',
+          proposalId: 'proposal1',
+          instructionsEntries: [
+            {
+              localeCode: 'en',
+              value: 'My custom instructions'
+            }
+          ],
+          unit: 'custom unit',
+          min: 0,
+          max: 10
+        },
+        template: {
+          _hasChanged: false,
+          _isNew: false,
+          _toDelete: true,
+          isNumberGauge: false,
+          tokenCategories: [],
+          voteType: 'tokens',
+          id: 'template',
+          voteSpecTemplateId: null,
+          proposalId: null,
+          instructionsEntries: [
+            {
+              localeCode: 'en',
+              value: 'My template instructions'
+            }
+          ],
+          choices: ['template-choice1']
+        }
+      });
+      const action = {
+        id: 'customGauge',
+        type: actionTypes.CANCEL_MODULE_CUSTOMIZATION
+      };
+      const expected = {
+        customGauge: {
+          _hasChanged: true,
+          _isNew: false,
+          _toDelete: false,
+          isCustom: false,
+          isNumberGauge: false,
+          id: 'customGauge',
+          voteSpecTemplateId: 'template',
+          proposalId: 'proposal1',
+          instructionsEntries: [
+            {
+              localeCode: 'en',
+              value: 'My template instructions'
+            }
+          ],
+          choices: ['template-choice1']
+        },
+        template: {
+          _hasChanged: false,
+          _isNew: false,
+          _toDelete: true,
+          isNumberGauge: false,
+          tokenCategories: [],
+          voteType: 'tokens',
+          id: 'template',
+          voteSpecTemplateId: null,
+          proposalId: null,
+          instructionsEntries: [
+            {
+              localeCode: 'en',
+              value: 'My template instructions'
+            }
+          ],
+          choices: ['template-choice1']
         }
       };
       const actual = modulesById(state, action);


### PR DESCRIPTION
If the gauge is custom, display a "Cancel settings" link that replaces customization by the template data
Closes DEVAS-1367