### PR TITLE
DEVAS-1282 Collapse message form on input blur if both title and content input are empty

### DIFF
--- a/assembl/static2/js/app/components/common/richTextEditor/index.jsx
+++ b/assembl/static2/js/app/components/common/richTextEditor/index.jsx
@@ -15,6 +15,7 @@ import attachmentsPlugin from './attachmentsPlugin';
 type RichTextEditorProps = {
   rawContentState: RawContentState,
   handleInputFocus: Function,
+  handleInputBlur: Function,
   maxLength: number,
   placeholder: string,
   textareaRef: Function,
@@ -51,6 +52,7 @@ export default class RichTextEditor extends React.Component<Object, RichTextEdit
 
   static defaultProps = {
     handleInputFocus: null,
+    handleInputBlur: null,
     maxLength: 0,
     toolbarPosition: 'top',
     withAttachmentButton: false,
@@ -83,6 +85,7 @@ export default class RichTextEditor extends React.Component<Object, RichTextEdit
       },
       () => {
         this.props.updateContentState(this.getCurrentRawContentState());
+        this.props.handleInputBlur();
       }
     );
   };

--- a/assembl/static2/js/app/components/common/textInputWithRemainingChars.jsx
+++ b/assembl/static2/js/app/components/common/textInputWithRemainingChars.jsx
@@ -9,6 +9,7 @@ export const TextInputWithRemainingChars = ({
   maxLength,
   handleTxtChange,
   handleInputFocus,
+  handleInputBlur,
   isActive
 }) => {
   const remainingChars = maxLength - value.length;
@@ -21,6 +22,7 @@ export const TextInputWithRemainingChars = ({
         maxLength={maxLength}
         value={value}
         onFocus={handleInputFocus || null}
+        onBlur={handleInputBlur || null}
         onChange={handleTxtChange}
       />
       <div className="annotation margin-xs">

--- a/assembl/static2/js/app/components/debate/common/topPostForm.jsx
+++ b/assembl/static2/js/app/components/debate/common/topPostForm.jsx
@@ -125,6 +125,15 @@ class TopPostForm extends React.Component<*, TopPostFormProps, TopPostFormState>
 
   handleInputFocus = promptForLoginOr(() => this.displayForm(true));
 
+  handleInputBlur = () => {
+    // collapse form if both subject and content fields are empty
+    const bodyIsEmpty = !this.state.body || rawContentStateIsEmpty(this.state.body);
+    const subjectIsEmpty = !(this.state.subject && this.state.subject.length);
+    if (subjectIsEmpty && bodyIsEmpty) {
+      this.setState({ isActive: false });
+    }
+  };
+
   updateBody = (newValue) => {
     this.setState({
       body: newValue
@@ -166,6 +175,7 @@ class TopPostForm extends React.Component<*, TopPostFormProps, TopPostFormState>
               maxLength={TEXT_INPUT_MAX_LENGTH}
               handleTxtChange={this.handleSubjectChange}
               handleInputFocus={this.handleInputFocus}
+              handleInputBlur={this.handleInputBlur}
               isActive={this.state.isActive}
             />
           ) : null}
@@ -174,6 +184,7 @@ class TopPostForm extends React.Component<*, TopPostFormProps, TopPostFormState>
               <RichTextEditor
                 rawContentState={this.state.body}
                 handleInputFocus={this.handleInputFocus}
+                handleInputBlur={this.handleInputBlur}
                 maxLength={TEXT_AREA_MAX_LENGTH}
                 placeholder={I18n.t('debate.insert')}
                 updateContentState={this.updateBody}


### PR DESCRIPTION
As I said earlier: While thinking about it and implementing it I saw that if the user clicks on the input to expand then on the content field to fill this one first, then it collapses.
So I guess there is a UX problem in the expected result?
Or maybe the "when i click somewhere else" means outside the whole blue block. Then instead of the browser onblur event we should implement something more complicated, like handleClickOutside in `assembl/static2/js/app/components/debate/navigation/debateLink.jsx` or handleTouchOutside in `assembl/static2/js/app/components/debate/navigation/timelineSegment.jsx`.
I'm waiting for instructions as to keep it as is or implement the second solution.