### PR TITLE
Fix snapshot tests missing translation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,7 @@ script:
   - if [ "$TO_TEST" = "FRONTEND" ]; then npm run eslint; fi
   - if [ "$TO_TEST" = "FRONTEND" ]; then npm run flow; fi
   - if [ "$TO_TEST" = "FRONTEND" ]; then npm run stylelint; fi
+  - if [ "$TO_TEST" = "FRONTEND" ]; then grep -R 'Missing translation' tests/unit/; test -z "`grep -R 'Missing translation' tests/unit/`"; fi
   - if [ "$TO_TEST" = "FRONTEND" ]; then bash -c "npm run build >/dev/null && test `ls -l build/bundle.js|awk '{print $5}'` -gt 3145728 && echo 'build/bundle.js size exceed 3 MB, is this normal? It was previously around 2.8 MB. If this is normal, please update this check in .travis.yml (3 MB = 3*1024*1024 = 3145728)' && exit 1 || exit 0"; fi
   - ls -l build/bundle.js
 notifications:

--- a/assembl/static2/js/app/utils/translations.js
+++ b/assembl/static2/js/app/utils/translations.js
@@ -554,13 +554,13 @@ const Translations = {
             "Il s'agit d'un bandeau de redirection vers un module chatbot messenger dédié à la consultation. Vous devez renseigner le titre, l'url du chatbot messenger et l'intitulé du bouton de redirection.",
           news:
             "Permet de mettre en avant une ou plusieurs actualités en rapport avec la consultation (publication d'une nouvelle synthèse, création d'une nouvelle thématique, …) avec des liens de redirection.",
-          introduction: "",
-          data: "",
-          footer: "",
-          video: "",
-          contact: "",
-          top_thematics: "",
-          partners: ""
+          introduction: " ",
+          data: " ",
+          footer: " ",
+          video: " ",
+          contact: " ",
+          top_thematics: " ",
+          partners: " "
         }
       },
       videoHelp:
@@ -1175,17 +1175,17 @@ const Translations = {
         landingPage: {
           header:
             "Top page header. It contains the consultation's title and subtitle and a button to access to the consultation.",
-          timeline: "",
-          tweets: "",
-          chatbot: "",
-          news: "",
-          introduction: "",
-          data: "",
-          footer: "",
-          video: "",
-          contact: "",
-          top_thematics: "",
-          partners: ""
+          timeline: " ",
+          tweets: " ",
+          chatbot: " ",
+          news: " ",
+          introduction: " ",
+          data: " ",
+          footer: " ",
+          video: " ",
+          contact: " ",
+          top_thematics: " ",
+          partners: " "
         }
       },
       videoHelp:

--- a/assembl/static2/tests/unit/components/administration/__snapshots__/saveButton.spec.jsx.snap
+++ b/assembl/static2/tests/unit/components/administration/__snapshots__/saveButton.spec.jsx.snap
@@ -11,7 +11,7 @@ exports[`Save button component should render a disabled save button 1`] = `
     className={undefined}
     style={undefined}
   >
-    Save Themes
+    Save
   </span>
 </button>
 `;
@@ -27,7 +27,7 @@ exports[`Save button component should render a save button 1`] = `
     className={undefined}
     style={undefined}
   >
-    Save Themes
+    Save
   </span>
 </button>
 `;
@@ -43,7 +43,7 @@ exports[`Save button component should render a save button with specific classes
     className={undefined}
     style={undefined}
   >
-    Save Themes
+    Save
   </span>
 </button>
 `;

--- a/assembl/static2/tests/unit/components/administration/discussion/__snapshots__/editSectionForm.spec.jsx.snap
+++ b/assembl/static2/tests/unit/components/administration/discussion/__snapshots__/editSectionForm.spec.jsx.snap
@@ -40,7 +40,7 @@ exports[`DumbEditSectionForm component should render a form to edit a section of
             }
           }
         >
-          Missing translation: administration.sections.externalPage
+          Use external page
         </span>
       </label>
     </div>
@@ -52,7 +52,7 @@ exports[`DumbEditSectionForm component should render a form to edit a section of
       className="control-label"
       htmlFor={undefined}
     >
-      Missing translation: administration.sections.urlPh
+      URL
     </label>
     <input
       className="form-control"
@@ -60,7 +60,7 @@ exports[`DumbEditSectionForm component should render a form to edit a section of
       id={undefined}
       onBlur={[Function]}
       onChange={[Function]}
-      placeholder="Missing translation: administration.sections.urlPh"
+      placeholder="URL"
       type="text"
       value="www.google.fr"
     />

--- a/assembl/static2/tests/unit/components/administration/discussion/__snapshots__/legalNoticeAndTermsForm.spec.jsx.snap
+++ b/assembl/static2/tests/unit/components/administration/discussion/__snapshots__/legalNoticeAndTermsForm.spec.jsx.snap
@@ -5,8 +5,8 @@ exports[`LegalNoticeAndTermsForm dumb component should render a form to edit leg
   className="admin-box"
 >
   <SectionTitle
-    annotation="Missing translation: administration.annotation"
-    title="Missing translation: administration.discussion.3"
+    annotation="* Fields are required."
+    title="Terms & Conditions and Legal Notice"
   />
   <div
     className="admin-content"
@@ -20,7 +20,7 @@ exports[`LegalNoticeAndTermsForm dumb component should render a form to edit leg
       >
         <FormControlWithLabel
           helperUrl=""
-          label="Missing translation: administration.legalNoticeAndTerms.termsAndConditionsLabel"
+          label="Terms and conditions"
           labelAlwaysVisible={false}
           onChange={[Function]}
           required={true}
@@ -33,7 +33,7 @@ exports[`LegalNoticeAndTermsForm dumb component should render a form to edit leg
         />
         <FormControlWithLabel
           helperUrl=""
-          label="Missing translation: administration.legalNoticeAndTerms.legalNoticeLabel"
+          label="Legal notice"
           labelAlwaysVisible={false}
           onChange={[Function]}
           required={true}

--- a/assembl/static2/tests/unit/components/administration/discussion/__snapshots__/manageSectionsForm.spec.jsx.snap
+++ b/assembl/static2/tests/unit/components/administration/discussion/__snapshots__/manageSectionsForm.spec.jsx.snap
@@ -5,8 +5,8 @@ exports[`DumbManageSectionsForm component should render a list of forms to edit 
   className="admin-box"
 >
   <SectionTitle
-    annotation="Missing translation: administration.annotation"
-    title="Missing translation: administration.sections.sectionsTitle"
+    annotation="* Fields are required."
+    title="Set sections"
   />
   <div
     className="admin-content"

--- a/assembl/static2/tests/unit/components/administration/discussion/editSectionForm.spec.jsx
+++ b/assembl/static2/tests/unit/components/administration/discussion/editSectionForm.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 
 import { DumbEditSectionForm } from '../../../../../js/app/components/administration/discussion/editSectionForm';
+import '../../../../helpers/setupTranslations';
 
 describe('DumbEditSectionForm component', () => {
   it('should render a form to edit a section of Assembl', () => {

--- a/assembl/static2/tests/unit/components/administration/discussion/legalNoticeAndTermsForm.spec.jsx
+++ b/assembl/static2/tests/unit/components/administration/discussion/legalNoticeAndTermsForm.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ShallowRenderer from 'react-test-renderer/shallow';
 
 import { DumbLegalNoticeAndTermsForm } from '../../../../../js/app/components/administration/discussion/legalNoticeAndTermsForm';
+import '../../../../helpers/setupTranslations';
 
 describe('LegalNoticeAndTermsForm dumb component', () => {
   it('should render a form to edit legal notice and terms and conditions', () => {

--- a/assembl/static2/tests/unit/components/administration/discussion/manageSectionsForm.spec.jsx
+++ b/assembl/static2/tests/unit/components/administration/discussion/manageSectionsForm.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { List } from 'immutable';
 import ShallowRenderer from 'react-test-renderer/shallow';
 import { DumbManageSectionsForm } from '../../../../../js/app/components/administration/discussion/manageSectionsForm';
+import '../../../../helpers/setupTranslations';
 
 describe('DumbManageSectionsForm component', () => {
   it('should render a list of forms to edit Assembl sections', () => {

--- a/assembl/static2/tests/unit/components/administration/landingPage/__snapshots__/manageModules.spec.jsx.snap
+++ b/assembl/static2/tests/unit/components/administration/landingPage/__snapshots__/manageModules.spec.jsx.snap
@@ -5,8 +5,8 @@ exports[`ManageModules component should render a form to manage the landing page
   className="admin-box"
 >
   <SectionTitle
-    annotation="Annotation"
-    title="Title"
+    annotation="* Fields are required."
+    title="Manage the modules"
   />
   <div
     className="admin-content form-container"

--- a/assembl/static2/tests/unit/components/administration/landingPage/__snapshots__/selectModulesForm.spec.jsx.snap
+++ b/assembl/static2/tests/unit/components/administration/landingPage/__snapshots__/selectModulesForm.spec.jsx.snap
@@ -34,7 +34,7 @@ exports[`DumbSelectModulesForm component should render a form to select the land
       <Helper
         additionalTextClasses=""
         classname="margin-left-20"
-        helperText="Missing translation: administration.helpers.landingPage.introduction"
+        helperText=" "
         helperUrl="/static2/img/helpers/landing_page_admin/introduction.png"
         label="Introduction"
       />
@@ -50,7 +50,7 @@ exports[`DumbSelectModulesForm component should render a form to select the land
       <Helper
         additionalTextClasses=""
         classname="margin-left-20"
-        helperText="Missing translation: administration.helpers.landingPage.video"
+        helperText=" "
         helperUrl="/static2/img/helpers/landing_page_admin/video.png"
         label="Video"
       />
@@ -66,7 +66,7 @@ exports[`DumbSelectModulesForm component should render a form to select the land
       <Helper
         additionalTextClasses=""
         classname="margin-left-20"
-        helperText="Missing translation: administration.helpers.landingPage.footer"
+        helperText=" "
         helperUrl="/static2/img/helpers/landing_page_admin/footer.png"
         label="Footer"
       />

--- a/assembl/static2/tests/unit/components/administration/landingPage/__snapshots__/selectModulesForm.spec.jsx.snap
+++ b/assembl/static2/tests/unit/components/administration/landingPage/__snapshots__/selectModulesForm.spec.jsx.snap
@@ -18,7 +18,7 @@ exports[`DumbSelectModulesForm component should render a form to select the land
       <Helper
         additionalTextClasses=""
         classname="margin-left-20"
-        helperText="Header"
+        helperText="Top page header. It contains the consultation's title and subtitle and a button to access to the consultation."
         helperUrl="/static2/img/helpers/landing_page_admin/header.png"
         label="Header"
       />
@@ -34,7 +34,7 @@ exports[`DumbSelectModulesForm component should render a form to select the land
       <Helper
         additionalTextClasses=""
         classname="margin-left-20"
-        helperText="Introduction"
+        helperText="Missing translation: administration.helpers.landingPage.introduction"
         helperUrl="/static2/img/helpers/landing_page_admin/introduction.png"
         label="Introduction"
       />
@@ -50,7 +50,7 @@ exports[`DumbSelectModulesForm component should render a form to select the land
       <Helper
         additionalTextClasses=""
         classname="margin-left-20"
-        helperText="Video"
+        helperText="Missing translation: administration.helpers.landingPage.video"
         helperUrl="/static2/img/helpers/landing_page_admin/video.png"
         label="Video"
       />
@@ -66,7 +66,7 @@ exports[`DumbSelectModulesForm component should render a form to select the land
       <Helper
         additionalTextClasses=""
         classname="margin-left-20"
-        helperText="Footer"
+        helperText="Missing translation: administration.helpers.landingPage.footer"
         helperUrl="/static2/img/helpers/landing_page_admin/footer.png"
         label="Footer"
       />

--- a/assembl/static2/tests/unit/components/administration/landingPage/manageModules.spec.jsx
+++ b/assembl/static2/tests/unit/components/administration/landingPage/manageModules.spec.jsx
@@ -3,6 +3,7 @@ import ShallowRenderer from 'react-test-renderer/shallow';
 
 import { DumbManageModules } from '../../../../../js/app/components/administration/landingPage/manageModules';
 import { enabledModulesInOrder, modulesByIdentifier } from './fakeData';
+import '../../../../helpers/setupTranslations';
 
 describe('ManageModules component', () => {
   it('should render a form to manage the landing page modules', () => {

--- a/assembl/static2/tests/unit/components/administration/landingPage/moduleBlock.spec.jsx
+++ b/assembl/static2/tests/unit/components/administration/landingPage/moduleBlock.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 
 import ModuleBlock from '../../../../../js/app/components/administration/landingPage/moduleBlock';
+import '../../../../helpers/setupTranslations';
 
 describe('ModuleBlock component', () => {
   it('should render a block that represents the module', () => {

--- a/assembl/static2/tests/unit/components/administration/landingPage/modulesPreview.spec.jsx
+++ b/assembl/static2/tests/unit/components/administration/landingPage/modulesPreview.spec.jsx
@@ -4,6 +4,7 @@ import { List } from 'immutable';
 
 import ModulesPreview from '../../../../../js/app/components/administration/landingPage/modulesPreview';
 import { enabledModulesInOrder } from './fakeData';
+import '../../../../helpers/setupTranslations';
 
 describe('ModulesPreview component', () => {
   it('should render a preview of the enabled modules', () => {

--- a/assembl/static2/tests/unit/components/administration/landingPage/selectModulesForm.spec.jsx
+++ b/assembl/static2/tests/unit/components/administration/landingPage/selectModulesForm.spec.jsx
@@ -3,6 +3,7 @@ import ShallowRenderer from 'react-test-renderer/shallow';
 
 import { DumbSelectModulesForm } from '../../../../../js/app/components/administration/landingPage/selectModulesForm';
 import { modulesByIdentifier, modulesTypes } from './fakeData';
+import '../../../../helpers/setupTranslations';
 
 describe('DumbSelectModulesForm component', () => {
   it('should render a form to select the landing page modules', () => {

--- a/assembl/static2/tests/unit/components/administration/resourcesCenter/__snapshots__/pageForm.spec.jsx.snap
+++ b/assembl/static2/tests/unit/components/administration/resourcesCenter/__snapshots__/pageForm.spec.jsx.snap
@@ -11,7 +11,7 @@ exports[`DumbPageForm component should render a form to update the resources cen
       className="control-label"
       htmlFor={undefined}
     >
-      Missing translation: administration.resourcesCenter.pageTitleLabel
+      Page title
     </label>
     <input
       className="form-control"
@@ -19,7 +19,7 @@ exports[`DumbPageForm component should render a form to update the resources cen
       id={undefined}
       onBlur={[Function]}
       onChange={[Function]}
-      placeholder="Missing translation: administration.resourcesCenter.pageTitleLabel"
+      placeholder="Page title"
       type="text"
       value="Centre de ressources"
     />
@@ -34,7 +34,7 @@ exports[`DumbPageForm component should render a form to update the resources cen
         className={undefined}
         style={undefined}
       >
-        Missing translation: administration.resourcesCenter.headerImageLabel
+        Header image
       </span>
     </label>
     <div>
@@ -48,7 +48,7 @@ exports[`DumbPageForm component should render a form to update the resources cen
           className={undefined}
           style={undefined}
         >
-          Missing translation: common.uploadButton
+          Choose a file to upload
         </span>
       </button>
       <div

--- a/assembl/static2/tests/unit/components/administration/resourcesCenter/pageForm.spec.jsx
+++ b/assembl/static2/tests/unit/components/administration/resourcesCenter/pageForm.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 
 import { DumbPageForm } from '../../../../../js/app/components/administration/resourcesCenter/pageForm';
+import '../../../../helpers/setupTranslations';
 
 describe('DumbPageForm component', () => {
   it('should render a form to update the resources center page title and header', () => {

--- a/assembl/static2/tests/unit/components/administration/saveButton.spec.jsx
+++ b/assembl/static2/tests/unit/components/administration/saveButton.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 
 import * as saveButton from '../../../../js/app/components/administration/saveButton';
+import '../../../helpers/setupTranslations';
 
 describe('runSerial function', () => {
   const { runSerial } = saveButton;

--- a/assembl/static2/tests/unit/components/administration/sectionTitle.spec.jsx
+++ b/assembl/static2/tests/unit/components/administration/sectionTitle.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 
 import SectionTitle from '../../../../js/app/components/administration/sectionTitle';
+import '../../../helpers/setupTranslations';
 
 describe('SectionTitle component', () => {
   it('should render an admin section title', () => {

--- a/assembl/static2/tests/unit/components/administration/voteSession/__snapshots__/gaugeForm.spec.jsx.snap
+++ b/assembl/static2/tests/unit/components/administration/voteSession/__snapshots__/gaugeForm.spec.jsx.snap
@@ -12,9 +12,9 @@ exports[`GaugeForm component should render a form to set up a gauge and a number
     className="flex margin-m"
   >
     <FormControlWithLabel
-      helperText="Missing translation: administration.helpers.gaugeVoteInstructions"
+      helperText="Depending on the objective of the gauge module, incite the participants to take action."
       helperUrl="/static2/img/helpers/helper6.png"
-      label="Missing translation: administration.gaugeVoteInstructions"
+      label="Instructions for the gauge vote"
       labelAlwaysVisible={false}
       onChange={[Function]}
       required={true}
@@ -184,9 +184,9 @@ exports[`GaugeForm component should render a form to set up a gauge and a textGa
     className="flex margin-m"
   >
     <FormControlWithLabel
-      helperText="Missing translation: administration.helpers.gaugeVoteInstructions"
+      helperText="Depending on the objective of the gauge module, incite the participants to take action."
       helperUrl="/static2/img/helpers/helper6.png"
-      label="Missing translation: administration.gaugeVoteInstructions"
+      label="Instructions for the gauge vote"
       labelAlwaysVisible={false}
       onChange={[Function]}
       required={true}
@@ -366,9 +366,9 @@ exports[`GaugeForm component should render a gauge form with no radio if canChan
     className="flex margin-m"
   >
     <FormControlWithLabel
-      helperText="Missing translation: administration.helpers.gaugeVoteInstructions"
+      helperText="Depending on the objective of the gauge module, incite the participants to take action."
       helperUrl="/static2/img/helpers/helper6.png"
-      label="Missing translation: administration.gaugeVoteInstructions"
+      label="Instructions for the gauge vote"
       labelAlwaysVisible={false}
       onChange={[Function]}
       required={true}

--- a/assembl/static2/tests/unit/components/administration/voteSession/__snapshots__/modulesSection.spec.jsx.snap
+++ b/assembl/static2/tests/unit/components/administration/voteSession/__snapshots__/modulesSection.spec.jsx.snap
@@ -5,8 +5,8 @@ exports[`ModulesSection component should render a ModuleSection component with t
   className="admin-box"
 >
   <SectionTitle
-    annotation="Missing translation: administration.annotation"
-    title="Missing translation: administration.voteSession.1"
+    annotation="* Fields are required."
+    title="Configure the voting modules"
   />
   <div
     className="admin-content"
@@ -28,9 +28,9 @@ exports[`ModulesSection component should render a ModuleSection component with t
           <Helper
             additionalTextClasses=""
             classname="inline checkbox-title"
-            helperText="Missing translation: administration.tokenVoteCheckbox"
+            helperText="The token vote module allows you to select propositions proportionnaly. Each participant has a certain amount of tokens et will have to spread them on the different propositions"
             helperUrl="/static2/img/helpers/helper4.png"
-            label="Missing translation: administration.voteWithTokens"
+            label="Tokens vote"
           />
         </Checkbox>
         Immutable.List [
@@ -49,9 +49,9 @@ exports[`ModulesSection component should render a ModuleSection component with t
           <Helper
             additionalTextClasses=""
             classname="inline checkbox-title"
-            helperText="Missing translation: administration.gaugeVoteCheckbox"
+            helperText="You can choose to have one or several gages"
             helperUrl="/static2/img/helpers/helper3.png"
-            label="Missing translation: administration.voteWithGauges"
+            label="Gauge(s) vote"
           />
         </Checkbox>
         <div
@@ -70,7 +70,7 @@ exports[`ModulesSection component should render a ModuleSection component with t
             <Helper
               additionalTextClasses=""
               classname=""
-              helperText="Missing translation: administration.defineGaugeNumer"
+              helperText="Define gauges number"
               helperUrl="/static2/img/helpers/helper2.png"
               label=""
             />
@@ -230,8 +230,8 @@ exports[`ModulesSection component should render a ModulesSection component witho
   className="admin-box"
 >
   <SectionTitle
-    annotation="Missing translation: administration.annotation"
-    title="Missing translation: administration.voteSession.1"
+    annotation="* Fields are required."
+    title="Configure the voting modules"
   />
   <div
     className="admin-content"
@@ -253,9 +253,9 @@ exports[`ModulesSection component should render a ModulesSection component witho
           <Helper
             additionalTextClasses=""
             classname="inline checkbox-title"
-            helperText="Missing translation: administration.tokenVoteCheckbox"
+            helperText="The token vote module allows you to select propositions proportionnaly. Each participant has a certain amount of tokens et will have to spread them on the different propositions"
             helperUrl="/static2/img/helpers/helper4.png"
-            label="Missing translation: administration.voteWithTokens"
+            label="Tokens vote"
           />
         </Checkbox>
         Immutable.List [
@@ -271,9 +271,9 @@ exports[`ModulesSection component should render a ModulesSection component witho
           <Helper
             additionalTextClasses=""
             classname="inline checkbox-title"
-            helperText="Missing translation: administration.gaugeVoteCheckbox"
+            helperText="You can choose to have one or several gages"
             helperUrl="/static2/img/helpers/helper3.png"
-            label="Missing translation: administration.voteWithGauges"
+            label="Gauge(s) vote"
           />
         </Checkbox>
         Immutable.List [

--- a/assembl/static2/tests/unit/components/administration/voteSession/__snapshots__/numberGaugeForm.spec.jsx.snap
+++ b/assembl/static2/tests/unit/components/administration/voteSession/__snapshots__/numberGaugeForm.spec.jsx.snap
@@ -7,7 +7,7 @@ exports[`DumbNumberGaugeForm component should render a form to set up a numeral 
   >
     <FormControlWithLabel
       helperUrl=""
-      label="Missing translation: administration.minValue"
+      label="Minimum value"
       labelAlwaysVisible={false}
       onChange={[Function]}
       required={true}
@@ -17,7 +17,7 @@ exports[`DumbNumberGaugeForm component should render a form to set up a numeral 
     />
     <FormControlWithLabel
       helperUrl=""
-      label="Missing translation: administration.maxValue"
+      label="Maximum value"
       labelAlwaysVisible={false}
       onChange={[Function]}
       required={true}
@@ -27,7 +27,7 @@ exports[`DumbNumberGaugeForm component should render a form to set up a numeral 
     />
     <FormControlWithLabel
       helperUrl=""
-      label="Missing translation: administration.unit"
+      label="Unit"
       labelAlwaysVisible={false}
       onChange={[Function]}
       required={true}

--- a/assembl/static2/tests/unit/components/administration/voteSession/__snapshots__/pageForm.spec.jsx.snap
+++ b/assembl/static2/tests/unit/components/administration/voteSession/__snapshots__/pageForm.spec.jsx.snap
@@ -5,8 +5,8 @@ exports[`Vote Session DumbPageForm component should render a form to update the 
   className="admin-box"
 >
   <SectionTitle
-    annotation="Missing translation: administration.annotation"
-    title="Missing translation: administration.voteSession.0"
+    annotation="* Fields are required."
+    title="Page configuration"
   />
   <div
     className="intro-text"
@@ -45,13 +45,13 @@ exports[`Vote Session DumbPageForm component should render a form to update the 
         <Helper
           additionalTextClasses=""
           classname="title"
-          helperText="Missing translation: administration.helpers.voteSessionHeader"
+          helperText="The top page header must contain an image and a title. The subtitle is optional."
           helperUrl="/static2/img/helpers/helper1.png"
-          label="Missing translation: administration.headerTitle"
+          label="Top page Header configuration"
         />
         <FormControlWithLabel
           helperUrl=""
-          label="Missing translation: administration.ph.headerTitle FR"
+          label="Header title FR"
           labelAlwaysVisible={false}
           onChange={[Function]}
           required={true}
@@ -61,7 +61,7 @@ exports[`Vote Session DumbPageForm component should render a form to update the 
         />
         <FormControlWithLabel
           helperUrl=""
-          label="Missing translation: administration.ph.headerSubtitle FR"
+          label="Header subtitle FR"
           labelAlwaysVisible={false}
           onChange={[Function]}
           required={false}
@@ -100,13 +100,13 @@ exports[`Vote Session DumbPageForm component should render a form to update the 
       <Helper
         additionalTextClasses=""
         classname="title"
-        helperText="Missing translation: administration.helpers.voteSessionInstructions"
+        helperText="The instructions section must contain a title and a description that will guide the participants for their contribution."
         helperUrl="/static2/img/helpers/helper2.png"
-        label="Missing translation: administration.instructions"
+        label="Instructions section configuration"
       />
       <FormControlWithLabel
         helperUrl=""
-        label="Missing translation: administration.ph.instructionsTitle FR"
+        label="Instructions title FR"
         labelAlwaysVisible={false}
         onChange={[Function]}
         required={true}
@@ -116,7 +116,7 @@ exports[`Vote Session DumbPageForm component should render a form to update the 
       />
       <FormControlWithLabel
         helperUrl=""
-        label="Missing translation: administration.ph.instructionsContent FR"
+        label="Instructions content FR"
         labelAlwaysVisible={false}
         onChange={[Function]}
         required={true}
@@ -145,13 +145,13 @@ exports[`Vote Session DumbPageForm component should render a form to update the 
       <Helper
         additionalTextClasses=""
         classname="title"
-        helperText="Missing translation: administration.helpers.voteSessionProposalSection"
+        helperText="The proposals section is introduced by a title. You define the title based on the proposal content."
         helperUrl="/static2/img/helpers/helper3.png"
-        label="Missing translation: administration.proposalSectionTitle"
+        label="Proposal section title configuration"
       />
       <FormControlWithLabel
         helperUrl=""
-        label="Missing translation: administration.ph.propositionSectionTitle FR"
+        label="Section title FR"
         labelAlwaysVisible={false}
         onChange={[Function]}
         required={true}

--- a/assembl/static2/tests/unit/components/administration/voteSession/__snapshots__/textGaugeForm.spec.jsx.snap
+++ b/assembl/static2/tests/unit/components/administration/voteSession/__snapshots__/textGaugeForm.spec.jsx.snap
@@ -6,7 +6,7 @@ exports[`DumbTextGaugeForm component should render a form to set up a textual ga
     <div>
       <FormControlWithLabel
         helperUrl=""
-        label="Missing translation: administration.valueTitle 1"
+        label="Value title 1"
         labelAlwaysVisible={false}
         onChange={[Function]}
         required={true}
@@ -18,7 +18,7 @@ exports[`DumbTextGaugeForm component should render a form to set up a textual ga
     <div>
       <FormControlWithLabel
         helperUrl=""
-        label="Missing translation: administration.valueTitle 2"
+        label="Value title 2"
         labelAlwaysVisible={false}
         onChange={[Function]}
         required={true}

--- a/assembl/static2/tests/unit/components/administration/voteSession/__snapshots__/tokenCategoryForm.spec.jsx.snap
+++ b/assembl/static2/tests/unit/components/administration/voteSession/__snapshots__/tokenCategoryForm.spec.jsx.snap
@@ -13,7 +13,7 @@ exports[`tokenTypeForm component should render a TokenCategoryForm component 1`]
   >
     <FormControlWithLabel
       helperUrl=""
-      label="Missing translation: administration.tokenTitle"
+      label="Token title"
       labelAlwaysVisible={false}
       onChange={[Function]}
       required={true}
@@ -28,7 +28,7 @@ exports[`tokenTypeForm component should render a TokenCategoryForm component 1`]
         }
       }
       helperUrl=""
-      label="Missing translation: administration.tokenNumber"
+      label="Number of tokens per participant"
       labelAlwaysVisible={false}
       onChange={undefined}
       required={true}
@@ -39,7 +39,7 @@ exports[`tokenTypeForm component should render a TokenCategoryForm component 1`]
     <label
       htmlFor="color-picker"
     >
-      Missing translation: administration.tokenColor
+      Color of the token
     </label>
     <ColorPicker
       className="no-box-shadow"

--- a/assembl/static2/tests/unit/components/administration/voteSession/__snapshots__/tokensForm.spec.jsx.snap
+++ b/assembl/static2/tests/unit/components/administration/voteSession/__snapshots__/tokensForm.spec.jsx.snap
@@ -6,9 +6,9 @@ exports[`tokensForm component should render a form to configure a token vote wit
 >
   <form>
     <FormControlWithLabel
-      helperText="Missing translation: administration.helpers.tokenVoteInstructions"
+      helperText="Depending on the objective of the token module, incite the participants to take action."
       helperUrl="/static2/img/helpers/helper5.png"
-      label="Missing translation: administration.tokenVoteInstructions"
+      label="Instructions for the token vote"
       labelAlwaysVisible={false}
       onChange={[Function]}
       required={true}
@@ -19,7 +19,7 @@ exports[`tokensForm component should render a form to configure a token vote wit
     <label
       htmlFor="input-dropdown-addon"
     >
-      Missing translation: administration.tokenCategoryNumber
+      Number of token types
     </label>
     <div
       className="inline"
@@ -27,7 +27,7 @@ exports[`tokensForm component should render a form to configure a token vote wit
       <Helper
         additionalTextClasses=""
         classname=""
-        helperText="Missing translation: administration.helpers.tokenCategoryNumber"
+        helperText="Select the number of different token types for this vote"
         helperUrl="/static2/img/helpers/helper2.png"
         label=""
       />
@@ -142,12 +142,12 @@ exports[`tokensForm component should render a form to configure a token vote wit
       <label
         htmlFor="input-dropdown-exclusive"
       >
-        Missing translation: administration.exclusive
+        Exclusive
       </label>
       <Helper
         additionalTextClasses="helper-text-only"
         classname="inline"
-        helperText="Missing translation: administration.helpers.exclusive"
+        helperText="You can decide wether the participant can distribute a single type of token (exclusive) or several types of token per proposal."
         helperUrl=""
         label=""
       />
@@ -155,7 +155,7 @@ exports[`tokensForm component should render a form to configure a token vote wit
         className="admin-dropdown"
         id="input-dropdown-exclusive"
         onSelect={[Function]}
-        title="Missing translation: administration.notExclusive"
+        title="Not exclusive"
       >
         <MenuItem
           bsClass="dropdown"
@@ -217,9 +217,9 @@ exports[`tokensForm component should render a form to configure a token vote wit
 >
   <form>
     <FormControlWithLabel
-      helperText="Missing translation: administration.helpers.tokenVoteInstructions"
+      helperText="Depending on the objective of the token module, incite the participants to take action."
       helperUrl="/static2/img/helpers/helper5.png"
-      label="Missing translation: administration.tokenVoteInstructions"
+      label="Instructions for the token vote"
       labelAlwaysVisible={false}
       onChange={[Function]}
       required={true}
@@ -230,7 +230,7 @@ exports[`tokensForm component should render a form to configure a token vote wit
     <label
       htmlFor="input-dropdown-addon"
     >
-      Missing translation: administration.tokenCategoryNumber
+      Number of token types
     </label>
     <div
       className="inline"
@@ -238,7 +238,7 @@ exports[`tokensForm component should render a form to configure a token vote wit
       <Helper
         additionalTextClasses=""
         classname=""
-        helperText="Missing translation: administration.helpers.tokenCategoryNumber"
+        helperText="Select the number of different token types for this vote"
         helperUrl="/static2/img/helpers/helper2.png"
         label=""
       />

--- a/assembl/static2/tests/unit/components/administration/voteSession/__snapshots__/voteProposalForm.spec.jsx.snap
+++ b/assembl/static2/tests/unit/components/administration/voteSession/__snapshots__/voteProposalForm.spec.jsx.snap
@@ -23,7 +23,7 @@ exports[`VoteProposalForm component should render an empty form to create a vote
   </div>
   <FormControlWithLabel
     helperUrl=""
-    label="Missing translation: administration.voteProposals.title"
+    label="Title of the proposal"
     labelAlwaysVisible={false}
     onChange={[Function]}
     required={true}
@@ -40,7 +40,7 @@ exports[`VoteProposalForm component should render an empty form to create a vote
   />
   <FormControlWithLabel
     helperUrl=""
-    label="Missing translation: administration.voteProposals.description"
+    label="Description"
     labelAlwaysVisible={false}
     onChange={[Function]}
     required={true}
@@ -86,7 +86,7 @@ exports[`VoteProposalForm component should render an empty form to create a vote
   </div>
   <FormControlWithLabel
     helperUrl=""
-    label="Missing translation: administration.voteProposals.title"
+    label="Title of the proposal"
     labelAlwaysVisible={false}
     onChange={[Function]}
     required={true}
@@ -96,7 +96,7 @@ exports[`VoteProposalForm component should render an empty form to create a vote
   />
   <FormControlWithLabel
     helperUrl=""
-    label="Missing translation: administration.voteProposals.description"
+    label="Description"
     labelAlwaysVisible={false}
     onChange={[Function]}
     required={true}

--- a/assembl/static2/tests/unit/components/administration/voteSession/__snapshots__/voteProposalsSection.spec.jsx.snap
+++ b/assembl/static2/tests/unit/components/administration/voteSession/__snapshots__/voteProposalsSection.spec.jsx.snap
@@ -8,8 +8,8 @@ exports[`VoteProposalsSection component should render a VoteProposalsSection com
     className="admin-box"
   >
     <SectionTitle
-      annotation="Missing translation: administration.annotation"
-      title="Missing translation: administration.voteProposals.sectionTitle"
+      annotation="* Fields are required."
+      title="Configure the proposals associated to the vote modules"
     />
     <div
       className="admin-content"
@@ -59,8 +59,8 @@ exports[`VoteProposalsSection component should render a voteProposalsSection wit
     className="admin-box"
   >
     <SectionTitle
-      annotation="Missing translation: administration.annotation"
-      title="Missing translation: administration.voteProposals.sectionTitle"
+      annotation="* Fields are required."
+      title="Configure the proposals associated to the vote modules"
     />
     <div
       className="admin-content"

--- a/assembl/static2/tests/unit/components/administration/voteSession/customizeGaugeForm.spec.jsx
+++ b/assembl/static2/tests/unit/components/administration/voteSession/customizeGaugeForm.spec.jsx
@@ -3,6 +3,7 @@ import ShallowRenderer from 'react-test-renderer/shallow';
 import { List, Map } from 'immutable';
 
 import { DumbCustomizeGaugeForm } from '../../../../../js/app/components/administration/voteSession/customizeGaugeForm';
+import '../../../../helpers/setupTranslations';
 
 describe('DumbCustomizeGaugeForm component', () => {
   const closeSpy = jest.fn();

--- a/assembl/static2/tests/unit/components/administration/voteSession/gaugeForm.spec.jsx
+++ b/assembl/static2/tests/unit/components/administration/voteSession/gaugeForm.spec.jsx
@@ -3,6 +3,7 @@ import ShallowRenderer from 'react-test-renderer/shallow';
 
 import { DumbGaugeForm } from '../../../../../js/app/components/administration/voteSession/gaugeForm';
 import { textChoices } from './fakeData';
+import '../../../../helpers/setupTranslations';
 
 describe('GaugeForm component', () => {
   const handleInstructionsChange = jest.fn(() => {});

--- a/assembl/static2/tests/unit/components/administration/voteSession/modulesSection.spec.jsx
+++ b/assembl/static2/tests/unit/components/administration/voteSession/modulesSection.spec.jsx
@@ -3,6 +3,7 @@ import ShallowRenderer from 'react-test-renderer/shallow';
 import { List, Map } from 'immutable';
 
 import { DumbModulesSection } from '../../../../../js/app/components/administration/voteSession/modulesSection';
+import '../../../../helpers/setupTranslations';
 
 describe('ModulesSection component', () => {
   const toggleModuleCheckboxSpy = jest.fn();

--- a/assembl/static2/tests/unit/components/administration/voteSession/numberGaugeForm.spec.jsx
+++ b/assembl/static2/tests/unit/components/administration/voteSession/numberGaugeForm.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ShallowRenderer from 'react-test-renderer/shallow';
 
 import DumbNumberGaugeForm from '../../../../../js/app/components/administration/voteSession/numberGaugeForm';
+import '../../../../helpers/setupTranslations';
 
 describe('DumbNumberGaugeForm component', () => {
   const handleMinChange = jest.fn(() => {});

--- a/assembl/static2/tests/unit/components/administration/voteSession/pageForm.spec.jsx
+++ b/assembl/static2/tests/unit/components/administration/voteSession/pageForm.spec.jsx
@@ -4,6 +4,7 @@ import ShallowRenderer from 'react-test-renderer/shallow';
 import { convertToRaw, ContentState } from 'draft-js';
 
 import { DumbPageForm } from '../../../../../js/app/components/administration/voteSession/pageForm';
+import '../../../../helpers/setupTranslations';
 
 describe('Vote Session DumbPageForm component', () => {
   it('should render a form to update the vote session page data', () => {

--- a/assembl/static2/tests/unit/components/administration/voteSession/textGaugeForm.spec.jsx
+++ b/assembl/static2/tests/unit/components/administration/voteSession/textGaugeForm.spec.jsx
@@ -3,6 +3,7 @@ import ShallowRenderer from 'react-test-renderer/shallow';
 import { List, Map } from 'immutable';
 
 import DumbTextGaugeForm from '../../../../../js/app/components/administration/voteSession/textGaugeForm';
+import '../../../../helpers/setupTranslations';
 
 describe('DumbTextGaugeForm component', () => {
   const handleGaugeChoiceLabelChange = jest.fn();

--- a/assembl/static2/tests/unit/components/administration/voteSession/tokenCategoryForm.spec.jsx
+++ b/assembl/static2/tests/unit/components/administration/voteSession/tokenCategoryForm.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ShallowRenderer from 'react-test-renderer/shallow';
 
 import { DumbTokenCategoryForm } from '../../../../../js/app/components/administration/voteSession/tokenCategoryForm';
+import '../../../../helpers/setupTranslations';
 
 describe('tokenTypeForm component', () => {
   it('should render a TokenCategoryForm component', () => {

--- a/assembl/static2/tests/unit/components/administration/voteSession/tokensForm.spec.jsx
+++ b/assembl/static2/tests/unit/components/administration/voteSession/tokensForm.spec.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import ShallowRenderer from 'react-test-renderer/shallow';
 
 import { DumbTokensForm } from '../../../../../js/app/components/administration/voteSession/tokensForm';
+import '../../../../helpers/setupTranslations';
 
 describe('tokensForm component', () => {
   const handleInstructionsChangeSpy = jest.fn();

--- a/assembl/static2/tests/unit/components/administration/voteSession/voteProposalForm.spec.jsx
+++ b/assembl/static2/tests/unit/components/administration/voteSession/voteProposalForm.spec.jsx
@@ -3,6 +3,7 @@ import ShallowRenderer from 'react-test-renderer/shallow';
 import { List } from 'immutable';
 
 import { DumbVoteProposalForm } from '../../../../../js/app/components/administration/voteSession/voteProposalForm';
+import '../../../../helpers/setupTranslations';
 
 describe('VoteProposalForm component', () => {
   const markAsToDelete = jest.fn(() => {});

--- a/assembl/static2/tests/unit/components/administration/voteSession/voteProposalsSection.spec.jsx
+++ b/assembl/static2/tests/unit/components/administration/voteSession/voteProposalsSection.spec.jsx
@@ -4,6 +4,7 @@ import { List } from 'immutable';
 import { voteProposalsInOrder } from './fakeData';
 
 import { DumbVoteProposalsSection } from '../../../../../js/app/components/administration/voteSession/voteProposalsSection';
+import '../../../../helpers/setupTranslations';
 
 describe('VoteProposalsSection component', () => {
   const addVoteProposalSpy = jest.fn();

--- a/assembl/static2/tests/unit/components/common/FormControlWithLabel.spec.jsx
+++ b/assembl/static2/tests/unit/components/common/FormControlWithLabel.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 
 import FormControlWithLabel from '../../../../js/app/components/common/formControlWithLabel';
+import '../../../helpers/setupTranslations';
 
 describe('FormControlWithLabel component', () => {
   const onChangeSpy = jest.fn(() => {});

--- a/assembl/static2/tests/unit/components/common/__snapshots__/boxWithHyphen.spec.jsx.snap
+++ b/assembl/static2/tests/unit/components/common/__snapshots__/boxWithHyphen.spec.jsx.snap
@@ -36,7 +36,7 @@ exports[`BoxWithHyphen component should not render a link that wraps the box if 
         className={undefined}
         style={undefined}
       >
-        For5pmt2
+        2017-01-01
       </span>
     </div>
     <div
@@ -93,7 +93,7 @@ exports[`BoxWithHyphen component should render a box with hyphen with its data 1
           className={undefined}
           style={undefined}
         >
-          For5pmt2
+          2017-01-01
         </span>
       </div>
       <div

--- a/assembl/static2/tests/unit/components/common/__snapshots__/fileUploader.spec.jsx.snap
+++ b/assembl/static2/tests/unit/components/common/__snapshots__/fileUploader.spec.jsx.snap
@@ -12,7 +12,7 @@ exports[`FileUploader component should render a file uploader for an image file 
       className={undefined}
       style={undefined}
     >
-      Upload Button
+      Choose a file to upload
     </span>
   </button>
   <div
@@ -44,7 +44,7 @@ exports[`FileUploader component should render a file uploader with the filename 
       className={undefined}
       style={undefined}
     >
-      Upload Button
+      Choose a file to upload
     </span>
   </button>
   <div
@@ -73,7 +73,7 @@ exports[`FileUploader component should render a file uploader with the filename 
       className={undefined}
       style={undefined}
     >
-      Upload Button
+      Choose a file to upload
     </span>
   </button>
   <div
@@ -102,7 +102,7 @@ exports[`FileUploader component should render a file uploader without preview 1`
       className={undefined}
       style={undefined}
     >
-      Upload Button
+      Choose a file to upload
     </span>
   </button>
   <div

--- a/assembl/static2/tests/unit/components/common/__snapshots__/section.spec.jsx.snap
+++ b/assembl/static2/tests/unit/components/common/__snapshots__/section.spec.jsx.snap
@@ -130,7 +130,7 @@ exports[`Section component should match Section with translate prop 1`] = `
             className={undefined}
             style={undefined}
           >
-            Missing translation: FooBar
+            home
           </span>
         </h1>
       </div>

--- a/assembl/static2/tests/unit/components/common/__snapshots__/section.spec.jsx.snap
+++ b/assembl/static2/tests/unit/components/common/__snapshots__/section.spec.jsx.snap
@@ -130,7 +130,7 @@ exports[`Section component should match Section with translate prop 1`] = `
             className={undefined}
             style={undefined}
           >
-            Foo Bar
+            Missing translation: FooBar
           </span>
         </h1>
       </div>

--- a/assembl/static2/tests/unit/components/common/attachments.spec.jsx
+++ b/assembl/static2/tests/unit/components/common/attachments.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 
 import Attachments from '../../../../js/app/components/common/attachments';
+import '../../../helpers/setupTranslations';
 
 describe('Attachments component', () => {
   it('should render the list of attachments', () => {

--- a/assembl/static2/tests/unit/components/common/boxWithHyphen.spec.jsx
+++ b/assembl/static2/tests/unit/components/common/boxWithHyphen.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 
 import BoxWithHyphen from '../../../../js/app/components/common/boxWithHyphen';
+import '../../../helpers/setupTranslations';
 
 describe('BoxWithHyphen component', () => {
   it('should render a box with hyphen with its data', () => {

--- a/assembl/static2/tests/unit/components/common/card.spec.jsx
+++ b/assembl/static2/tests/unit/components/common/card.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 
 import Card from '../../../../js/app/components/common/card';
+import '../../../helpers/setupTranslations';
 
 describe('Card component', () => {
   it('should match Card snapshot', () => {

--- a/assembl/static2/tests/unit/components/common/cardList.spec.jsx
+++ b/assembl/static2/tests/unit/components/common/cardList.spec.jsx
@@ -3,6 +3,7 @@ import renderer from 'react-test-renderer';
 
 import CardList from '../../../../js/app/components/common/cardList';
 import { CLASS_NAME_GENERATOR } from '../../../../js/app/utils/cardList';
+import '../../../helpers/setupTranslations';
 
 describe('CardList component', () => {
   it('should match CardList snapshot', () => {

--- a/assembl/static2/tests/unit/components/common/documentExtensionIcon.spec.jsx
+++ b/assembl/static2/tests/unit/components/common/documentExtensionIcon.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 
 import DocumentExtensionIcon, { getExtension, getIconPath } from '../../../../js/app/components/common/documentExtensionIcon';
+import '../../../helpers/setupTranslations';
 
 describe('getExtension function', () => {
   it('should return the extension from filename', () => {

--- a/assembl/static2/tests/unit/components/common/fileUploader.spec.jsx
+++ b/assembl/static2/tests/unit/components/common/fileUploader.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 
 import FileUploader from '../../../../js/app/components/common/fileUploader';
+import '../../../helpers/setupTranslations';
 
 describe('FileUploader component', () => {
   it('should render a file uploader for an image file', () => {

--- a/assembl/static2/tests/unit/components/common/flatList.spec.jsx
+++ b/assembl/static2/tests/unit/components/common/flatList.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ShallowRenderer from 'react-test-renderer/shallow';
 
 import FlatList from '../../../../js/app/components/common/flatList';
+import '../../../helpers/setupTranslations';
 
 describe('FlatList component', () => {
   it('should match FlatList loading snapshot', () => {

--- a/assembl/static2/tests/unit/components/common/messagePage.spec.jsx
+++ b/assembl/static2/tests/unit/components/common/messagePage.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 
 import MessagePage from '../../../../js/app/components/common/messagePage';
+import '../../../helpers/setupTranslations';
 
 describe('MessagePage component', () => {
   it('should render a MessagePage component', () => {

--- a/assembl/static2/tests/unit/components/common/richTextEditor/__snapshots__/toolbar.spec.jsx.snap
+++ b/assembl/static2/tests/unit/components/common/richTextEditor/__snapshots__/toolbar.spec.jsx.snap
@@ -28,7 +28,7 @@ exports[`Toolbar component should render a toolbar 1`] = `
       disabled={false}
       onClick={[Function]}
       onMouseDown={[Function]}
-      title="Attachment"
+      title="Add a file"
       type="button"
     >
       <span

--- a/assembl/static2/tests/unit/components/common/richTextEditor/atomicBlockRenderer.spec.jsx
+++ b/assembl/static2/tests/unit/components/common/richTextEditor/atomicBlockRenderer.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 
 import AtomicBlockRenderer from '../../../../../js/app/components/common/richTextEditor/atomicBlockRenderer';
+import '../../../../helpers/setupTranslations';
 
 function Entity(data, type) {
   this.data = data;

--- a/assembl/static2/tests/unit/components/common/richTextEditor/attachmentsPlugin.spec.jsx
+++ b/assembl/static2/tests/unit/components/common/richTextEditor/attachmentsPlugin.spec.jsx
@@ -1,6 +1,7 @@
 import { convertFromRaw, convertToRaw, ContentState, Entity } from 'draft-js';
 
 import plugin from '../../../../../js/app/components/common/richTextEditor/attachmentsPlugin';
+import '../../../../helpers/setupTranslations';
 
 // see draft-convert convertFromHTML.js
 let contentState = ContentState.createFromText('');

--- a/assembl/static2/tests/unit/components/common/richTextEditor/index.spec.jsx
+++ b/assembl/static2/tests/unit/components/common/richTextEditor/index.spec.jsx
@@ -3,6 +3,7 @@ import ShallowRenderer from 'react-test-renderer/shallow';
 import { ContentState, convertToRaw, RichUtils } from 'draft-js';
 
 import RichTextEditor from '../../../../../js/app/components/common/richTextEditor';
+import '../../../../helpers/setupTranslations';
 
 describe('RichTextEditor component', () => {
   it.skip('should render a rich text editor', () => {

--- a/assembl/static2/tests/unit/components/common/richTextEditor/toolbar.spec.jsx
+++ b/assembl/static2/tests/unit/components/common/richTextEditor/toolbar.spec.jsx
@@ -3,6 +3,7 @@ import renderer from 'react-test-renderer';
 import { EditorState } from 'draft-js';
 
 import Toolbar from '../../../../../js/app/components/common/richTextEditor/toolbar';
+import '../../../../helpers/setupTranslations';
 
 describe('Toolbar component', () => {
   it('should render a toolbar', () => {

--- a/assembl/static2/tests/unit/components/common/richTextEditor/toolbarButton.spec.jsx
+++ b/assembl/static2/tests/unit/components/common/richTextEditor/toolbarButton.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 
 import ToolbarButton from '../../../../../js/app/components/common/richTextEditor/toolbarButton';
+import '../../../../helpers/setupTranslations';
 
 describe('ToolbarButton component', () => {
   const onToggleSpy = jest.fn(() => {});

--- a/assembl/static2/tests/unit/components/common/scrollOnePageButton.spec.jsx
+++ b/assembl/static2/tests/unit/components/common/scrollOnePageButton.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 
 import { DumbScrollOnePageButton } from '../../../../js/app/components/common/scrollOnePageButton';
+import '../../../helpers/setupTranslations';
 
 describe('DumbScrollOnePageButton component', () => {
   it('should render a button to scroll one page down', () => {

--- a/assembl/static2/tests/unit/components/common/section.spec.jsx
+++ b/assembl/static2/tests/unit/components/common/section.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 
 import Section from '../../../../js/app/components/common/section';
+import '../../../helpers/setupTranslations';
 
 describe('Section component', () => {
   it('should match Section snapshot', () => {

--- a/assembl/static2/tests/unit/components/common/section.spec.jsx
+++ b/assembl/static2/tests/unit/components/common/section.spec.jsx
@@ -41,7 +41,7 @@ describe('Section component', () => {
   it('should match Section with translate prop', () => {
     const rendered = renderer
       .create(
-        <Section title="FooBar" displayIndex translate>
+        <Section title="navbar.home" displayIndex translate>
           <div>Section content</div>
         </Section>
       )

--- a/assembl/static2/tests/unit/components/common/synthesis/sideMenu.spec.jsx
+++ b/assembl/static2/tests/unit/components/common/synthesis/sideMenu.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ShallowRenderer from 'react-test-renderer/shallow';
 
 import SideMenu from '../../../../../js/app/components/synthesis/sideMenu';
+import '../../../../helpers/setupTranslations';
 
 describe('SideMenu component', () => {
   it('should render a SideMenu component', () => {

--- a/assembl/static2/tests/unit/components/common/synthesis/sideMenuTree.spec.jsx
+++ b/assembl/static2/tests/unit/components/common/synthesis/sideMenuTree.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ShallowRenderer from 'react-test-renderer/shallow';
 
 import SideMenuTree from '../../../../../js/app/components/synthesis/sideMenuTree';
+import '../../../../helpers/setupTranslations';
 
 describe('SideMenuTree component', () => {
   const indexGenerator = jest.fn(() => {});

--- a/assembl/static2/tests/unit/components/common/termsForm.spec.jsx
+++ b/assembl/static2/tests/unit/components/common/termsForm.spec.jsx
@@ -4,6 +4,7 @@ import ShallowRenderer from 'react-test-renderer/shallow';
 import { DumbTermsForm, mapDataToProps } from '../../../../js/app/components/common/termsForm';
 
 import { closeModal } from '../../../../js/app/utils/utilityManager';
+import '../../../helpers/setupTranslations';
 
 jest.mock('../../../../js/app/utils/utilityManager');
 

--- a/assembl/static2/tests/unit/components/common/textAreaWithRemainingChars.spec.jsx
+++ b/assembl/static2/tests/unit/components/common/textAreaWithRemainingChars.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ShallowRenderer from 'react-test-renderer/shallow';
 
 import TestedComponent from '../../../../js/app/components/common/textAreaWithRemainingChars';
+import '../../../helpers/setupTranslations';
 
 describe('TextAreaWithRemainingChars component', () => {
   const onChangeSpy = jest.fn(() => {});

--- a/assembl/static2/tests/unit/components/common/textWithHeaderPage.spec.jsx
+++ b/assembl/static2/tests/unit/components/common/textWithHeaderPage.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ShallowRenderer from 'react-test-renderer/shallow';
 
 import { DumbTextWithHeaderPage } from '../../../../js/app/components/common/textWithHeaderPage';
+import '../../../helpers/setupTranslations';
 
 describe('TextWithHeaderPage component', () => {
   it('should render the header with a title and a block of text', () => {

--- a/assembl/static2/tests/unit/components/debate/common/headerActions.spec.jsx
+++ b/assembl/static2/tests/unit/components/debate/common/headerActions.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 
 import HeaderActions from '../../../../../js/app/components/debate/common/headerActions';
+import '../../../../helpers/setupTranslations';
 
 describe('headerActions component', () => {
   it('should render a headerActions component', () => {

--- a/assembl/static2/tests/unit/components/debate/common/post/foldedPost.spec.jsx
+++ b/assembl/static2/tests/unit/components/debate/common/post/foldedPost.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ShallowRenderer from 'react-test-renderer/shallow';
 
 import FoldedPost from '../../../../../../js/app/components/debate/common/post/foldedPost';
+import '../../../../../helpers/setupTranslations';
 
 describe('FoldedPost component', () => {
   it('should render a folded post', () => {

--- a/assembl/static2/tests/unit/components/debate/common/post/index.spec.jsx
+++ b/assembl/static2/tests/unit/components/debate/common/post/index.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ShallowRenderer from 'react-test-renderer/shallow';
 
 import { DumbPost } from '../../../../../../js/app/components/debate/common/post';
+import '../../../../../helpers/setupTranslations';
 
 const handleEditClickSpy = jest.fn();
 const refetchIdeaSpy = jest.fn();

--- a/assembl/static2/tests/unit/components/debate/common/post/postBody.spec.jsx
+++ b/assembl/static2/tests/unit/components/debate/common/post/postBody.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ShallowRenderer from 'react-test-renderer/shallow';
 
 import PostBody from '../../../../../../js/app/components/debate/common/post/postBody';
+import '../../../../../helpers/setupTranslations';
 
 describe('PostBody component', () => {
   it('should render a post body', () => {

--- a/assembl/static2/tests/unit/components/debate/common/post/postView.spec.jsx
+++ b/assembl/static2/tests/unit/components/debate/common/post/postView.spec.jsx
@@ -3,6 +3,7 @@ import ShallowRenderer from 'react-test-renderer/shallow';
 
 import PostView from '../../../../../../js/app/components/debate/common/post/postView';
 import { postProps } from './index.spec';
+import '../../../../../helpers/setupTranslations';
 
 describe('PostView component', () => {
   it('should render a post in view mode', () => {

--- a/assembl/static2/tests/unit/components/debate/common/post/relatedIdeas.spec.jsx
+++ b/assembl/static2/tests/unit/components/debate/common/post/relatedIdeas.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ShallowRenderer from 'react-test-renderer/shallow';
 
 import RelatedIdeas from '../../../../../../js/app/components/debate/common/post/relatedIdeas';
+import '../../../../../helpers/setupTranslations';
 
 describe('RelatedIdeas component', () => {
   it('should render related ideas', () => {

--- a/assembl/static2/tests/unit/components/debate/multicolumn/columnSynthesis.spec.jsx
+++ b/assembl/static2/tests/unit/components/debate/multicolumn/columnSynthesis.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ShallowRenderer from 'react-test-renderer/shallow';
 
 import ColumnSynthesis from '../../../../../js/app/components/debate/multiColumns/columnSynthesis';
+import '../../../../helpers/setupTranslations';
 
 describe('ColumnSynthesis component', () => {
   it('should render a folded post', () => {

--- a/assembl/static2/tests/unit/components/debate/navigation/debateLink.spec.jsx
+++ b/assembl/static2/tests/unit/components/debate/navigation/debateLink.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ShallowRenderer from 'react-test-renderer/shallow';
 
 import DebateLink from '../../../../../js/app/components/debate/navigation/debateLink';
+import '../../../../helpers/setupTranslations';
 
 describe('DebateLink component', () => {
   it('should match the DebateLink', () => {

--- a/assembl/static2/tests/unit/components/debate/navigation/menuItem.spec.jsx
+++ b/assembl/static2/tests/unit/components/debate/navigation/menuItem.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ShallowRenderer from 'react-test-renderer/shallow';
 
 import { DumbMenuItem } from '../../../../../js/app/components/debate/navigation/menuItem';
+import '../../../../helpers/setupTranslations';
 
 describe('DumbMenuItem component', () => {
   it('should match a selected menu item', () => {

--- a/assembl/static2/tests/unit/components/debate/navigation/menuTable.spec.jsx
+++ b/assembl/static2/tests/unit/components/debate/navigation/menuTable.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ShallowRenderer from 'react-test-renderer/shallow';
 
 import MenuTable from '../../../../../js/app/components/debate/navigation/menuTable';
+import '../../../../helpers/setupTranslations';
 
 describe('MenuTable component', () => {
   it('should match the survey table', () => {

--- a/assembl/static2/tests/unit/components/debate/navigation/tables/ideasTable.spec.jsx
+++ b/assembl/static2/tests/unit/components/debate/navigation/tables/ideasTable.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ShallowRenderer from 'react-test-renderer/shallow';
 
 import { DumbIdeasTable } from '../../../../../../js/app/components/debate/navigation/tables/ideasTable';
+import '../../../../../helpers/setupTranslations';
 
 describe('IdeasTable component', () => {
   it('should match the IdeasTable', () => {

--- a/assembl/static2/tests/unit/components/debate/navigation/tables/menuList.spec.jsx
+++ b/assembl/static2/tests/unit/components/debate/navigation/tables/menuList.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ShallowRenderer from 'react-test-renderer/shallow';
 
 import MenuList from '../../../../../../js/app/components/debate/navigation/tables/menuList';
+import '../../../../../helpers/setupTranslations';
 
 describe('MenuList component', () => {
   it('should match the MenuList', () => {

--- a/assembl/static2/tests/unit/components/debate/navigation/tables/surveyTable.spec.jsx
+++ b/assembl/static2/tests/unit/components/debate/navigation/tables/surveyTable.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ShallowRenderer from 'react-test-renderer/shallow';
 
 import { DumbSurveyTable } from '../../../../../../js/app/components/debate/navigation/tables/surveyTable';
+import '../../../../../helpers/setupTranslations';
 
 describe('SurveyTable component', () => {
   it('should match the SurveyTable', () => {

--- a/assembl/static2/tests/unit/components/debate/navigation/timeline.spec.jsx
+++ b/assembl/static2/tests/unit/components/debate/navigation/timeline.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ShallowRenderer from 'react-test-renderer/shallow';
 
 import { DumbTimeline } from '../../../../../js/app/components/debate/navigation/timeline';
+import '../../../../helpers/setupTranslations';
 
 describe('DumbTimeline component', () => {
   it('should match the DumbTimeline', () => {

--- a/assembl/static2/tests/unit/components/debate/navigation/timelineSegment.spec.jsx
+++ b/assembl/static2/tests/unit/components/debate/navigation/timelineSegment.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ShallowRenderer from 'react-test-renderer/shallow';
 
 import { DumbTimelineSegment } from '../../../../../js/app/components/debate/navigation/timelineSegment';
+import '../../../../helpers/setupTranslations';
 
 describe('DumbTimeline component', () => {
   it('should match the DumbTimeline', () => {

--- a/assembl/static2/tests/unit/components/debate/survey/posts.spec.jsx
+++ b/assembl/static2/tests/unit/components/debate/survey/posts.spec.jsx
@@ -3,6 +3,7 @@ import ShallowRenderer from 'react-test-renderer/shallow';
 import { Map } from 'immutable';
 
 import { DumbPosts } from '../../../../../js/app/components/debate/survey/posts';
+import '../../../../helpers/setupTranslations';
 
 describe('FlatList component', () => {
   it('should match Posts with data snapshot', () => {

--- a/assembl/static2/tests/unit/components/harvesting/harvestingAnchor.spec.jsx
+++ b/assembl/static2/tests/unit/components/harvesting/harvestingAnchor.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ShallowRenderer from 'react-test-renderer/shallow';
 
 import HarvestingAnchor from '../../../../js/app/components/harvesting/harvestingAnchor';
+import '../../../helpers/setupTranslations';
 
 describe('harvestingAnchor component', () => {
   it('should match harvestingAnchor snapshot', () => {

--- a/assembl/static2/tests/unit/components/harvesting/harvestingBox.spec.jsx
+++ b/assembl/static2/tests/unit/components/harvesting/harvestingBox.spec.jsx
@@ -3,6 +3,7 @@ import ShallowRenderer from 'react-test-renderer/shallow';
 
 import { DumbHarvestingBox } from '../../../../js/app/components/harvesting/harvestingBox';
 import * as fakeData from './fakeData';
+import '../../../helpers/setupTranslations';
 
 describe('harvestingBox component', () => {
   it('should match harvestingBox snapshot', () => {

--- a/assembl/static2/tests/unit/components/harvesting/harvestingMenu.spec.jsx
+++ b/assembl/static2/tests/unit/components/harvesting/harvestingMenu.spec.jsx
@@ -3,6 +3,7 @@ import ShallowRenderer from 'react-test-renderer/shallow';
 
 import HarvestingMenu from '../../../../js/app/components/harvesting/harvestingMenu';
 import * as fakeData from './fakeData';
+import '../../../helpers/setupTranslations';
 
 describe('harvestingMenu component', () => {
   beforeAll(() => {

--- a/assembl/static2/tests/unit/components/harvesting/taxonomyOverflowMenu.spec.jsx
+++ b/assembl/static2/tests/unit/components/harvesting/taxonomyOverflowMenu.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ShallowRenderer from 'react-test-renderer/shallow';
 
 import TaxonomyOverflowMenu from '../../../../js/app/components/harvesting/taxonomyOverflowMenu';
+import '../../../helpers/setupTranslations';
 
 describe('taxonomyOverflowMenu component', () => {
   it('should match harvestingMenu snapshot', () => {

--- a/assembl/static2/tests/unit/components/navbar/navbar.spec.jsx
+++ b/assembl/static2/tests/unit/components/navbar/navbar.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ShallowRenderer from 'react-test-renderer/shallow';
 
 import { AssemblNavbar, mapSectionToElement } from '../../../../js/app/components/navbar/navbar';
+import '../../../helpers/setupTranslations';
 
 describe('mapSectionToElement function', () => {
   it('should return a SectionLink element that matches the snapshot', () => {

--- a/assembl/static2/tests/unit/components/resourcesCenter/index.spec.jsx
+++ b/assembl/static2/tests/unit/components/resourcesCenter/index.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ShallowRenderer from 'react-test-renderer/shallow';
 
 import ResourcesCenter from '../../../../js/app/components/resourcesCenter';
+import '../../../helpers/setupTranslations';
 
 describe('ResourcesCenter component', () => {
   it('should render the list of resources', () => {

--- a/assembl/static2/tests/unit/components/voteSession/Proposal.spec.jsx
+++ b/assembl/static2/tests/unit/components/voteSession/Proposal.spec.jsx
@@ -3,6 +3,7 @@ import renderer from 'react-test-renderer';
 
 import Proposal from '../../../../js/app/components/voteSession/proposal';
 import * as fakeData from './fakeData';
+import '../../../helpers/setupTranslations';
 
 describe('Proposal component', () => {
   const voteForProposalSpy = jest.fn();

--- a/assembl/static2/tests/unit/components/voteSession/Proposals.spec.jsx
+++ b/assembl/static2/tests/unit/components/voteSession/Proposals.spec.jsx
@@ -3,6 +3,7 @@ import renderer from 'react-test-renderer';
 
 import Proposals from '../../../../js/app/components/voteSession/proposals';
 import * as fakeData from './fakeData';
+import '../../../helpers/setupTranslations';
 
 describe('Proposals component', () => {
   it('should match Proposals snapshot', () => {

--- a/assembl/static2/tests/unit/components/voteSession/__snapshots__/Proposal.spec.jsx.snap
+++ b/assembl/static2/tests/unit/components/voteSession/__snapshots__/Proposal.spec.jsx.snap
@@ -892,7 +892,7 @@ exports[`Proposal component should match Proposal snapshot 1`] = `
             className={undefined}
             style={undefined}
           >
-            Show Votes In Progress
+            Show votes of the community
           </span>
         </button>
       </div>

--- a/assembl/static2/tests/unit/components/voteSession/__snapshots__/Proposals.spec.jsx.snap
+++ b/assembl/static2/tests/unit/components/voteSession/__snapshots__/Proposals.spec.jsx.snap
@@ -788,7 +788,7 @@ exports[`Proposals component should match Proposals snapshot 1`] = `
               className={undefined}
               style={undefined}
             >
-              Show Votes In Progress
+              Show votes of the community
             </span>
           </button>
         </div>
@@ -1686,7 +1686,7 @@ exports[`Proposals component should match Proposals snapshot 1`] = `
               className={undefined}
               style={undefined}
             >
-              Show Votes In Progress
+              Show votes of the community
             </span>
           </button>
         </div>

--- a/assembl/static2/tests/unit/components/voteSession/__snapshots__/availableTokens.spec.jsx.snap
+++ b/assembl/static2/tests/unit/components/voteSession/__snapshots__/availableTokens.spec.jsx.snap
@@ -36,7 +36,7 @@ exports[`AvailableTokens component should match AvailableTokens snapshot (non st
                 className={undefined}
                 style={undefined}
               >
-                Remaining Tokens
+                You have 3 tokens remaining.
               </span>
             </div>
             <div
@@ -75,7 +75,7 @@ exports[`AvailableTokens component should match AvailableTokens snapshot (non st
                 className={undefined}
                 style={undefined}
               >
-                Remaining Tokens
+                You have , tokens remaining.
               </span>
             </div>
             <div
@@ -114,7 +114,7 @@ exports[`AvailableTokens component should match AvailableTokens snapshot (non st
                 className={undefined}
                 style={undefined}
               >
-                Remaining Tokens
+                You have , tokens remaining.
               </span>
             </div>
             <div
@@ -153,7 +153,7 @@ exports[`AvailableTokens component should match AvailableTokens snapshot (non st
                 className={undefined}
                 style={undefined}
               >
-                Remaining Tokens
+                You have 10 tokens remaining.
               </span>
             </div>
             <div
@@ -208,7 +208,7 @@ exports[`AvailableTokens component should match AvailableTokens snapshot (non st
                 className={undefined}
                 style={undefined}
               >
-                Remaining Tokens
+                You have 3 tokens remaining.
               </span>
             </div>
             <div
@@ -488,7 +488,7 @@ exports[`AvailableTokens component should match AvailableTokens snapshot (non st
                 className={undefined}
                 style={undefined}
               >
-                Remaining Tokens
+                You have 10 tokens remaining.
               </span>
             </div>
             <div
@@ -744,7 +744,7 @@ exports[`AvailableTokens component should match AvailableTokens snapshot (sticky
                 className={undefined}
                 style={undefined}
               >
-                Remaining Tokens
+                You have 3 tokens remaining.
               </span>
             </div>
             <div
@@ -1024,7 +1024,7 @@ exports[`AvailableTokens component should match AvailableTokens snapshot (sticky
                 className={undefined}
                 style={undefined}
               >
-                Remaining Tokens
+                You have 10 tokens remaining.
               </span>
             </div>
             <div

--- a/assembl/static2/tests/unit/components/voteSession/__snapshots__/availableTokens.spec.jsx.snap
+++ b/assembl/static2/tests/unit/components/voteSession/__snapshots__/availableTokens.spec.jsx.snap
@@ -75,7 +75,7 @@ exports[`AvailableTokens component should match AvailableTokens snapshot (non st
                 className={undefined}
                 style={undefined}
               >
-                You have , tokens remaining.
+                You have 6 tokens remaining.
               </span>
             </div>
             <div
@@ -114,7 +114,7 @@ exports[`AvailableTokens component should match AvailableTokens snapshot (non st
                 className={undefined}
                 style={undefined}
               >
-                You have , tokens remaining.
+                You have 4 tokens remaining.
               </span>
             </div>
             <div

--- a/assembl/static2/tests/unit/components/voteSession/__snapshots__/participantsCount.spec.jsx.snap
+++ b/assembl/static2/tests/unit/components/voteSession/__snapshots__/participantsCount.spec.jsx.snap
@@ -14,7 +14,7 @@ exports[`ParticipantsCount component should match ParticipantsCount snapshot 1`]
       className={undefined}
       style={undefined}
     >
-      Participants Count
+      666 participants voted!
     </span>
   </div>
 </div>

--- a/assembl/static2/tests/unit/components/voteSession/availableTokens.spec.jsx
+++ b/assembl/static2/tests/unit/components/voteSession/availableTokens.spec.jsx
@@ -4,6 +4,7 @@ import { Map } from 'immutable';
 
 import AvailableTokens from '../../../../js/app/components/voteSession/availableTokens';
 import { tokenCategories } from './fakeData';
+import '../../../helpers/setupTranslations';
 
 describe('AvailableTokens component', () => {
   it('should match AvailableTokens snapshot (non sticky version)', () => {

--- a/assembl/static2/tests/unit/components/voteSession/availableTokens.spec.jsx
+++ b/assembl/static2/tests/unit/components/voteSession/availableTokens.spec.jsx
@@ -46,6 +46,8 @@ describe('AvailableTokens component', () => {
     const props = {
       remainingTokensByCategory: Map({
         category1: 3,
+        category2: 6,
+        category3: 4,
         category4: 10
       }),
       sticky: false,

--- a/assembl/static2/tests/unit/components/voteSession/participantsCount.spec.jsx
+++ b/assembl/static2/tests/unit/components/voteSession/participantsCount.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 
 import ParticipantsCount from '../../../../js/app/components/voteSession/participantsCount';
+import '../../../helpers/setupTranslations';
 
 describe('ParticipantsCount component', () => {
   it('should match ParticipantsCount snapshot', () => {

--- a/assembl/static2/tests/unit/components/voteSession/tokenVoteForProposal.spec.jsx
+++ b/assembl/static2/tests/unit/components/voteSession/tokenVoteForProposal.spec.jsx
@@ -3,6 +3,7 @@ import ShallowRenderer from 'react-test-renderer/shallow';
 
 import TokenVoteForProposal from '../../../../js/app/components/voteSession/tokenVoteForProposal';
 import * as fakeData from './fakeData';
+import '../../../helpers/setupTranslations';
 
 describe('TokenVoteForProposal component', () => {
   const { proposal1Votes, remainingTokensByCategory, tokenCategories } = fakeData;

--- a/assembl/static2/tests/unit/pages/__snapshots__/syntheses.spec.jsx.snap
+++ b/assembl/static2/tests/unit/pages/__snapshots__/syntheses.spec.jsx.snap
@@ -69,7 +69,7 @@ exports[`Syntheses component should match Syntheses snapshot 1`] = `
                     className={undefined}
                     style={undefined}
                   >
-                    For15amt2
+                    2017-02-10
                   </span>
                 </h4>
               </div>
@@ -125,7 +125,7 @@ exports[`Syntheses component should match Syntheses snapshot 1`] = `
                     className={undefined}
                     style={undefined}
                   >
-                    For15amt2
+                    2017-02-10
                   </span>
                 </h4>
               </div>
@@ -192,7 +192,7 @@ exports[`Syntheses component should match empty Syntheses snapshot 1`] = `
           className={undefined}
           style={undefined}
         >
-          No Synthesis Yet
+          There is no synthesis available yet.
         </span>
       </h2>
     </div>

--- a/assembl/static2/tests/unit/pages/__snapshots__/voteSession.spec.jsx.snap
+++ b/assembl/static2/tests/unit/pages/__snapshots__/voteSession.spec.jsx.snap
@@ -255,8 +255,8 @@ exports[`VoteSession component should match VoteSession snapshot 1`] = `
 
 exports[`VoteSession component should match VoteSession snapshot when vote session is not configured 1`] = `
 <MessagePage
-  text="Text"
-  title="Title"
+  text="An administrator must configure the vote session"
+  title="Vote session is not configured"
 />
 `;
 

--- a/assembl/static2/tests/unit/pages/question.spec.jsx
+++ b/assembl/static2/tests/unit/pages/question.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ShallowRenderer from 'react-test-renderer/shallow';
 
 import { DumbQuestion } from '../../../js/app/pages/question';
+import '../../helpers/setupTranslations';
 
 describe('Question page', () => {
   it('should match Question with data snapshot', () => {

--- a/assembl/static2/tests/unit/pages/syntheses.spec.jsx
+++ b/assembl/static2/tests/unit/pages/syntheses.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 
 import { DumbSyntheses } from '../../../js/app/pages/syntheses';
+import '../../helpers/setupTranslations';
 
 describe('Syntheses component', () => {
   it('should match Syntheses snapshot', () => {

--- a/assembl/static2/tests/unit/pages/synthesis.spec.jsx
+++ b/assembl/static2/tests/unit/pages/synthesis.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ShallowRenderer from 'react-test-renderer/shallow';
 
 import { DumbSynthesis } from '../../../js/app/pages/synthesis';
+import '../../helpers/setupTranslations';
 
 describe('Synthesis component', () => {
   it('should match Synthesis snapshot', () => {

--- a/assembl/static2/tests/unit/pages/voteSession.spec.jsx
+++ b/assembl/static2/tests/unit/pages/voteSession.spec.jsx
@@ -3,6 +3,7 @@ import ShallowRenderer from 'react-test-renderer/shallow';
 
 import * as fakeData from '../components/voteSession/fakeData';
 import { DumbVoteSession } from '../../../js/app/pages/voteSession';
+import '../../helpers/setupTranslations';
 
 describe('VoteSession component', () => {
   it('should match VoteSession snapshot when vote session is not configured', () => {

--- a/assembl/static2/tests/unit/pages/voteSessionAdmin.spec.jsx
+++ b/assembl/static2/tests/unit/pages/voteSessionAdmin.spec.jsx
@@ -1,6 +1,7 @@
 import { List, Map } from 'immutable';
 
 import * as voteSessionAdmin from '../../../js/app/pages/voteSessionAdmin';
+import '../../helpers/setupTranslations';
 
 describe('getProposalValidationErrors', () => {
   const { getProposalValidationErrors } = voteSessionAdmin;


### PR DESCRIPTION
Now import setupTranslations in each test file adding snapshots tests to have the English message in the snapshots. I added a travis test to verify there is no "Missing translation" in future snapshot tests.

I can merge a rebased version of this branch when all other feature branches have been merged to not bother you with some tests failures.