### PR TITLE
Updating documentation for production instance installation

### DIFF
--- a/doc/INSTALL.rst
+++ b/doc/INSTALL.rst
@@ -332,6 +332,7 @@ If you do not have an SSL certificate, then you have to set ``accept_secure_conn
     exit  # this logs out from the assembl_user user, back to the initial sudoer account
     cd /home/assembl_user/assembl
     fab -c configs/develop.rc install_single_server
+    fab -c configs/develop.rc check_and_create_database_user
     sudo -u assembl_user -i  # back to the assembl user
     cd /home/assembl_user/assembl
     fab -c configs/develop.rc bootstrap_from_checkout


### PR DESCRIPTION
Currently, if you run the `bootstrap_from_checkout` command using the `assembl_user`, it will request for a sudo password on when executing `check_and_create_database_user`.  But `assembl_user` is not supposed to be sudoer so `check_and_create_database` should be executed with your sudoer user.