### PR TITLE
fix survey phase export link

### DIFF
--- a/assembl/static2/js/app/pages/surveyAdmin.jsx
+++ b/assembl/static2/js/app/pages/surveyAdmin.jsx
@@ -104,7 +104,7 @@ class SurveyAdmin extends React.Component {
     const { section, thematicsHaveChanged, debateId, languages } = this.props;
     const { translate } = this.state;
     const exportLocale = this.state.exportLocale || (languages && languages[0].locale);
-    const translation = translate && exportLocale ? `?lang=${exportLocale}` : '';
+    const translation = translate && exportLocale ? `?lang=${exportLocale}` : '?'; // FIXME: using '' instead of '?' does not work
     const exportLink = get('exportSurveyData', { debateId: debateId, translation: translation });
     const currentStep = parseInt(section, 10);
     const saveDisabled = !thematicsHaveChanged;


### PR DESCRIPTION
Empty string does not work, looks like there is a problem in parse() or get() function of literalStringParser.js introduced in https://github.com/assembl/assembl/commit/1a84b7702ec6396ded8e3aa9ba4b6d0eba1133e7#diff-161b47c83cd40ca16c78a9b658c5ca73