### PR TITLE
Use uncontrolled component with key pattern for RichTextEditor

### DIFF
--- a/assembl/static2/js/app/components/common/formControlWithLabel.jsx
+++ b/assembl/static2/js/app/components/common/formControlWithLabel.jsx
@@ -98,8 +98,10 @@ class FormControlWithLabel extends React.Component<FormControlWithLabelProps, Fo
 
   renderRichTextEditor = () => {
     const { onChange, value } = this.props;
+    const key = value ? 'notEmpty' : 'empty';
     return (
       <RichTextEditor
+        key={key}
         rawContentState={value}
         placeholder={this.getLabel()}
         toolbarPosition="bottom"

--- a/assembl/static2/js/app/components/common/richTextEditor/index.jsx
+++ b/assembl/static2/js/app/components/common/richTextEditor/index.jsx
@@ -1,4 +1,12 @@
 // @flow
+/*
+  Note that this component is fully uncontrolled
+  Warning: you need to set a key on it to specify if editor state is empty or not
+  Therefore, react will recreate the editor if the status (empty/not empty) changes
+*/
+// eslint-disable-next-line
+// See https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html#recommendation-fully-uncontrolled-component-with-a-key
+
 import * as React from 'react';
 import { Translate, I18n } from 'react-redux-i18n';
 import { convertFromRaw, convertToRaw, Editor, EditorState, RawContentState, RichUtils } from 'draft-js';
@@ -60,12 +68,6 @@ export default class RichTextEditor extends React.Component<RichTextEditorProps,
       editorState: editorState,
       editorHasFocus: false
     };
-  }
-
-  componentWillReceiveProps(nextProps: RichTextEditorProps) {
-    if (this.props.rawContentState !== null && nextProps.rawContentState === null) {
-      this.setState({ editorState: EditorState.createEmpty() });
-    }
   }
 
   getCurrentRawContentState = () => convertToRaw(this.state.editorState.getCurrentContent());

--- a/assembl/static2/js/app/components/debate/thread/answerForm.jsx
+++ b/assembl/static2/js/app/components/debate/thread/answerForm.jsx
@@ -137,6 +137,7 @@ class AnswerForm extends React.PureComponent<AnswerFormProps, AnswerFormState> {
             <div className="answer-form-inner">
               <FormGroup>
                 <RichTextEditor
+                  key={this.state.body ? 'notEmpty' : 'empty'}
                   rawContentState={this.state.body}
                   handleInputFocus={this.handleInputFocus}
                   maxLength={TEXT_AREA_MAX_LENGTH}


### PR DESCRIPTION
Fixes DEVAS-1581
I'm opened to discussion on this one. I recommend that you read https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html (an article from a few days ago that made me chose this solution over continuing to use `componentWillReceiveProps` or `getDerivedStateFromProps`)