### PR TITLE
Migration delete extra fields for deleted users

### DIFF
--- a/assembl/alembic/versions/7bf35c9261d9_delete_extra_fields_for_deleted_users.py
+++ b/assembl/alembic/versions/7bf35c9261d9_delete_extra_fields_for_deleted_users.py
@@ -1,0 +1,36 @@
+"""delete_extra_fields_for_deleted_users
+
+Revision ID: 7bf35c9261d9
+Revises: e3f681bd70e0
+Create Date: 2018-06-13 14:14:41.037265
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '7bf35c9261d9'
+down_revision = 'e3f681bd70e0'
+
+from alembic import context, op
+import sqlalchemy as sa
+import transaction
+
+
+from assembl.lib import config
+
+
+def upgrade(pyramid_env):
+    with context.begin_transaction():
+        pass
+
+    # Do stuff with the app's models here.
+    from assembl import models as m
+    db = m.get_session_maker()()
+    with transaction.manager:
+        extra_fields = db.query(m.ProfileField).join(m.User).filter(m.User.is_deleted).all()
+        for ef in extra_fields:
+            db.delete_extra_field
+
+
+def downgrade(pyramid_env):
+    with context.begin_transaction():
+        pass

--- a/assembl/alembic/versions/7bf35c9261d9_delete_extra_fields_for_deleted_users.py
+++ b/assembl/alembic/versions/7bf35c9261d9_delete_extra_fields_for_deleted_users.py
@@ -28,7 +28,7 @@ def upgrade(pyramid_env):
         ids = [id for (id,) in ids]
         for pf in db.query(m.ProfileField).all():
 			if pf.id in ids:
-				pf.delete()
+				db.delete(pf)
 
 
 def downgrade(pyramid_env):

--- a/assembl/alembic/versions/7bf35c9261d9_delete_extra_fields_for_deleted_users.py
+++ b/assembl/alembic/versions/7bf35c9261d9_delete_extra_fields_for_deleted_users.py
@@ -8,7 +8,7 @@ Create Date: 2018-06-13 14:14:41.037265
 
 # revision identifiers, used by Alembic.
 revision = '7bf35c9261d9'
-down_revision = 'e3f681bd70e0'
+down_revision = 'e757aefa55e1'
 
 from alembic import context, op
 import sqlalchemy as sa
@@ -22,7 +22,11 @@ def upgrade(pyramid_env):
     from assembl import models as m
     db = m.get_session_maker()()
     with transaction.manager:
-        db.query(m.ProfileField).join(m.User).filter(m.User.is_deleted).delete()
+        ids=db.query(m.ProfileField.id).join(m.User).filter(m.User.is_deleted==True).all()
+        ids = [id for (id,) in ids]
+        for pf in db.query(m.ProfileField).all():
+			if pf.id in ids:
+				pf.delete()
 
 
 def downgrade(pyramid_env):

--- a/assembl/alembic/versions/7bf35c9261d9_delete_extra_fields_for_deleted_users.py
+++ b/assembl/alembic/versions/7bf35c9261d9_delete_extra_fields_for_deleted_users.py
@@ -22,9 +22,7 @@ def upgrade(pyramid_env):
     from assembl import models as m
     db = m.get_session_maker()()
     with transaction.manager:
-        extra_fields = db.query(m.ProfileField).join(m.User).filter(m.User.is_deleted).all()
-        for ef in extra_fields:
-            db.delele(ef)
+        db.query(m.ProfileField).join(m.User).filter(m.User.is_deleted).delete()
 
 
 def downgrade(pyramid_env):

--- a/assembl/alembic/versions/7bf35c9261d9_delete_extra_fields_for_deleted_users.py
+++ b/assembl/alembic/versions/7bf35c9261d9_delete_extra_fields_for_deleted_users.py
@@ -24,11 +24,10 @@ def upgrade(pyramid_env):
     with transaction.manager:
 	# SQL Alchemy can't delete after a join operation, so we are getting the ids first
 	# and deleting the corresponding profile fields
-        ids=db.query(m.ProfileField.id).join(m.User).filter(m.User.is_deleted==True).all()
-        ids = [id for (id,) in ids]
-        for pf in db.query(m.ProfileField).all():
-			if pf.id in ids:
-				db.delete(pf)
+        ids_query=db.query(m.ProfileField.id).join(m.User).filter(m.User.is_deleted==True).all()
+        for (id,) in ids_query:
+            profile = m.ProfileField.get(id)
+            db.delete(profile)
 
 
 def downgrade(pyramid_env):

--- a/assembl/alembic/versions/7bf35c9261d9_delete_extra_fields_for_deleted_users.py
+++ b/assembl/alembic/versions/7bf35c9261d9_delete_extra_fields_for_deleted_users.py
@@ -19,16 +19,12 @@ from assembl.lib import config
 
 
 def upgrade(pyramid_env):
-    with context.begin_transaction():
-        pass
-
-    # Do stuff with the app's models here.
     from assembl import models as m
     db = m.get_session_maker()()
     with transaction.manager:
         extra_fields = db.query(m.ProfileField).join(m.User).filter(m.User.is_deleted).all()
         for ef in extra_fields:
-            db.delete_extra_field
+            db.delele(ef)
 
 
 def downgrade(pyramid_env):

--- a/assembl/alembic/versions/7bf35c9261d9_delete_extra_fields_for_deleted_users.py
+++ b/assembl/alembic/versions/7bf35c9261d9_delete_extra_fields_for_deleted_users.py
@@ -22,6 +22,8 @@ def upgrade(pyramid_env):
     from assembl import models as m
     db = m.get_session_maker()()
     with transaction.manager:
+	# SQL Alchemy can't delete after a join operation, so we are getting the ids first
+	# and deleting the corresponding profile fields
         ids=db.query(m.ProfileField.id).join(m.User).filter(m.User.is_deleted==True).all()
         ids = [id for (id,) in ids]
         for pf in db.query(m.ProfileField).all():


### PR DESCRIPTION
When We export the extra fields, even though some users are deleted, their extra fields are still in teh database, which is not compliant with GDPR. This is because  we deployed the delete user feature before adding deletion of the extra fields. this migration is to delete all extra fields for all deleted users.