### PR TITLE
Hotfix/fix empty locales list

### DIFF
--- a/assembl/static2/css/components/posts.scss
+++ b/assembl/static2/css/components/posts.scss
@@ -644,6 +644,10 @@ $deleted-post-border: 1px solid $grey1 !default;
 }
 
 .column-post {
+  .post-body-title {
+    display: none;
+  }
+
   .box {
     border: none;
   }


### PR DESCRIPTION
In multi columns, the user doesn't enter a post subject, so when creating a post (for example Norwegian) without subject, it will uses the first original of thematic title https://github.com/assembl/assembl/blob/179bbac9f154b80afb6c9378392f2aecaf64e383/assembl/graphql/post.py#L302
which can be any language, here it happened to be Turkish. The frontend shows subject and body in original language by default, if you enable translation to French, it will correctly translate Turkish to French and Norwegian to French.
Moreover if the thematic title changes, it won't change the subject of existing posts.
For me the quickest fix we can do here is to just hide the post subject in css, which I did in my hotfix.
I did another fix in my hotfix to correctly get the full list of locales, fallback to English if no locale translation found for target language.