### PR TITLE
DEVAS1711: filter out brightmirror posts from elasticsearch

### DIFF
--- a/assembl/indexing/reindex.py
+++ b/assembl/indexing/reindex.py
@@ -95,7 +95,8 @@ def reindex_content(content, action='update'):
             changes.unindex_content(content)
     elif isinstance(content, Post):
         if (content.publication_state == PublicationStates.PUBLISHED and
-                not content.hidden and content.tombstone_date is None):
+                not content.hidden and content.tombstone_date is None and
+                not content.is_bright_mirror_fiction()):
             changes.index_content(content)
         else:
             changes.unindex_content(content)

--- a/assembl/indexing/utils.py
+++ b/assembl/indexing/utils.py
@@ -134,6 +134,10 @@ def get_data(content):
         if not data['idea_id']:
             return None, None
 
+        # If the post is a fiction for Bright Mirror, don't index it.
+        if Idea.get(data['idea_id'][0]).message_view_override == 'brightMirror':
+            return None, None
+
         # If the idea is now in multi columns mode and the post was created before that, don't index it.
         if Idea.get(data['idea_id'][0]).message_columns and content.message_classifier is None:
             return None, None

--- a/assembl/indexing/utils.py
+++ b/assembl/indexing/utils.py
@@ -118,7 +118,7 @@ def get_data(content):
         return get_uid(content), data
 
     elif isinstance(content, Post):
-        from assembl.models.timeline import Phases
+        from assembl.models.idea import MessageView
         data = {}
         data['_parent'] = 'user:{}'.format(content.creator_id)
         if content.parent_id is not None:
@@ -136,7 +136,7 @@ def get_data(content):
             return None, None
 
         # If the post is a fiction for Bright Mirror, don't index it.
-        if Idea.get(data['idea_id'][0]).message_view_override == Phases.brightMirror.value:
+        if Idea.get(data['idea_id'][0]).message_view_override == MessageView.brightMirror.value:
             return None, None
 
         # If the idea is now in multi columns mode and the post was created before that, don't index it.

--- a/assembl/indexing/utils.py
+++ b/assembl/indexing/utils.py
@@ -118,6 +118,7 @@ def get_data(content):
         return get_uid(content), data
 
     elif isinstance(content, Post):
+        from assembl.models.timeline import Phases
         data = {}
         data['_parent'] = 'user:{}'.format(content.creator_id)
         if content.parent_id is not None:
@@ -135,7 +136,7 @@ def get_data(content):
             return None, None
 
         # If the post is a fiction for Bright Mirror, don't index it.
-        if Idea.get(data['idea_id'][0]).message_view_override == 'brightMirror':
+        if Idea.get(data['idea_id'][0]).message_view_override == Phases.brightMirror.value:
             return None, None
 
         # If the idea is now in multi columns mode and the post was created before that, don't index it.

--- a/assembl/models/idea.py
+++ b/assembl/models/idea.py
@@ -5,6 +5,7 @@ from itertools import chain
 from collections import defaultdict
 from abc import ABCMeta, abstractmethod
 from datetime import datetime
+from enum import Enum
 
 from ..lib.clean_input import sanitize_text
 from sqlalchemy.orm import relationship, backref, aliased, contains_eager, column_property, with_polymorphic
@@ -39,6 +40,11 @@ from sqlalchemy.types import TIMESTAMP as Timestamp
 
 
 _ = TranslationStringFactory('assembl')
+
+
+class MessageView(Enum):
+    multiColumns = 'multiColumns'
+    brightMirror = 'brightMirror'
 
 
 class defaultdictlist(defaultdict):

--- a/assembl/models/post.py
+++ b/assembl/models/post.py
@@ -33,6 +33,7 @@ from ..lib import config
 from .langstrings import LangString, LangStringEntry
 from assembl.views.traversal import AbstractCollectionDefinition
 import assembl.graphql.docstrings as docs
+from assembl.models.timeline import Phases
 
 log = logging.getLogger('assembl')
 
@@ -562,7 +563,7 @@ class Post(Content):
 
     def is_bright_mirror_fiction(self):
         parent_idea = [link.idea for link in self.indirect_idea_content_links_without_cache() if link.__class__.__name__ == 'IdeaRelatedPostLink']
-        return len(parent_idea) != 0 and parent_idea[0].message_view_override == 'brightMirror'
+        return len(parent_idea) != 0 and parent_idea[0].message_view_override == Phases.brightMirror.value
 
 
 def orm_insert_listener(mapper, connection, target):

--- a/assembl/models/post.py
+++ b/assembl/models/post.py
@@ -560,6 +560,10 @@ class Post(Content):
         "filter query according to object owners"
         return query.filter(cls.creator_id == user_id)
 
+    def is_bright_mirror_fiction(self):
+        parent_idea = self.indirect_idea_content_links_without_cache()
+        return len(parent_idea) != 0 and parent_idea[0].idea.message_view_override == 'brightMirror'
+
 
 def orm_insert_listener(mapper, connection, target):
     """ This is to allow the root idea to send update to "All posts",

--- a/assembl/models/post.py
+++ b/assembl/models/post.py
@@ -33,7 +33,7 @@ from ..lib import config
 from .langstrings import LangString, LangStringEntry
 from assembl.views.traversal import AbstractCollectionDefinition
 import assembl.graphql.docstrings as docs
-from assembl.models.timeline import Phases
+from assembl.models.idea import MessageView
 
 log = logging.getLogger('assembl')
 
@@ -563,7 +563,7 @@ class Post(Content):
 
     def is_bright_mirror_fiction(self):
         parent_idea = [link.idea for link in self.indirect_idea_content_links_without_cache() if link.__class__.__name__ == 'IdeaRelatedPostLink']
-        return len(parent_idea) != 0 and parent_idea[0].message_view_override == Phases.brightMirror.value
+        return len(parent_idea) != 0 and parent_idea[0].message_view_override == MessageView.brightMirror.value
 
 
 def orm_insert_listener(mapper, connection, target):

--- a/assembl/models/post.py
+++ b/assembl/models/post.py
@@ -561,8 +561,8 @@ class Post(Content):
         return query.filter(cls.creator_id == user_id)
 
     def is_bright_mirror_fiction(self):
-        parent_idea = self.indirect_idea_content_links_without_cache()
-        return len(parent_idea) != 0 and parent_idea[0].idea.message_view_override == 'brightMirror'
+        parent_idea = [link.idea for link in self.indirect_idea_content_links_without_cache() if link.__class__.__name__ == 'IdeaRelatedPostLink']
+        return len(parent_idea) != 0 and parent_idea[0].message_view_override == 'brightMirror'
 
 
 def orm_insert_listener(mapper, connection, target):


### PR DESCRIPTION
Filter when insert/update/delete and when reindexing with fab command. Doesn't break indexing of other posts.

**Note: I couldn't filter out the posts in "get_indexable_contents" as Aliases classes are used and not all fields/methods are available for filtering but it's done later by "get_data" in utils.py