### PR TITLE
refactor cookieToggle to deal with the various cases of cookies

### DIFF
--- a/assembl/static2/css/components/cookiesSelector.scss
+++ b/assembl/static2/css/components/cookiesSelector.scss
@@ -32,14 +32,14 @@
   }
 
   .cookie-title {
-    width: 50%;
+    width: 40%;
     margin-left: 20px;
     display: flex;
   }
 
   .cookie-with-link {
     display: flex;
-    width: 60%;
+    width: 80%;
 
     .matomo-settings-link {
       width: 100%;

--- a/assembl/static2/css/components/cookiesSelector.scss
+++ b/assembl/static2/css/components/cookiesSelector.scss
@@ -31,6 +31,11 @@
     font-size: $font-size-sm;
   }
 
+  .helper-popover {
+    min-width: 320px !important;
+    padding: 0 0 0 10px !important;
+  }
+
   .cookie-title {
     width: 40%;
     margin-left: 20px;
@@ -53,6 +58,11 @@
 
     .cookie-helper {
       margin-top: 3px;
+    }
+
+    .cookie-helper-popover {
+      width: 320px;
+      padding-bottom: 10px;
     }
 
     .rsbc-switch-button {

--- a/assembl/static2/css/components/cookiesSelector.scss
+++ b/assembl/static2/css/components/cookiesSelector.scss
@@ -31,11 +31,6 @@
     font-size: $font-size-sm;
   }
 
-  .helper-popover {
-    min-width: 320px !important;
-    padding: 0 0 0 10px !important;
-  }
-
   .cookie-title {
     width: 40%;
     margin-left: 20px;

--- a/assembl/static2/flow/globals.flow.js
+++ b/assembl/static2/flow/globals.flow.js
@@ -1,5 +1,3 @@
 // @flow
 
-declare var globalAnalytics: { piwik?: { host: string },
-                               isActive?: boolean
-                             }
+declare var globalAnalytics: { piwik?: { host: string, isActive: boolean }}

--- a/assembl/static2/flow/globals.flow.js
+++ b/assembl/static2/flow/globals.flow.js
@@ -1,0 +1,5 @@
+// @flow
+
+declare var globalAnalytics: { piwik?: { host: string },
+                               isActive?: boolean
+                             }

--- a/assembl/static2/js/app/components/common/helper.jsx
+++ b/assembl/static2/js/app/components/common/helper.jsx
@@ -8,20 +8,21 @@ type HelperProps = {
   helperUrl?: string,
   helperText: string,
   classname?: string,
-  additionalTextClasses?: string
+  additionalTextClasses?: string,
+  popOverClass?: string
 };
 
-const overflowMenu = (helperUrl, helperText, additionalTextClasses) => {
+const overflowMenu = (helperUrl, helperText, additionalTextClasses, popOverClass) => {
   const helperTextClasses = classnames([additionalTextClasses], 'helper-text');
   return (
-    <Popover id="admin-title-helper" className="helper-popover">
+    <Popover id="admin-title-helper" className={popOverClass || 'helper-popover'}>
       {helperUrl && <img src={helperUrl} width="300" height="auto" alt="admin-helper" />}
       <div className={helperTextClasses}>{helperText}</div>
     </Popover>
   );
 };
 
-const Helper = ({ label, helperUrl, helperText, classname, additionalTextClasses }: HelperProps) => (
+const Helper = ({ label, helperUrl, helperText, classname, additionalTextClasses, popOverClass }: HelperProps) => (
   <div className={classname}>
     {label && label}
     &nbsp;
@@ -29,7 +30,7 @@ const Helper = ({ label, helperUrl, helperText, classname, additionalTextClasses
       trigger={['hover', 'focus']}
       rootClose
       placement="right"
-      overlay={overflowMenu(helperUrl, helperText, additionalTextClasses)}
+      overlay={overflowMenu(helperUrl, helperText, additionalTextClasses, popOverClass)}
     >
       <span className="assembl-icon-faq grey pointer" />
     </OverlayTrigger>
@@ -40,7 +41,8 @@ Helper.defaultProps = {
   label: '',
   helperUrl: '',
   classname: '',
-  additionalTextClasses: ''
+  additionalTextClasses: '',
+  popOverClass: ''
 };
 
 export default Helper;

--- a/assembl/static2/js/app/components/cookies/cookieSetter.jsx
+++ b/assembl/static2/js/app/components/cookies/cookieSetter.jsx
@@ -17,7 +17,7 @@ export type CookieObject = {
   cookieType: string
 };
 
-type cookieSetterProps = {
+type CookieSetterProps = {
   handleToggle: Function,
   cookie: CookieObject,
   toggleCookieType: Function,
@@ -27,7 +27,7 @@ type cookieSetterProps = {
 // @$FlowFixMe globalAnalytics is a global variable
 const matomoHost = globalAnalytics.piwik ? globalAnalytics.piwik.host : null;
 
-const cookieSetter = ({ handleToggle, cookie, toggleCookieType, locale }: cookieSetterProps) => {
+const CookieSetter = ({ handleToggle, cookie, toggleCookieType, locale }: CookieSetterProps) => {
   const toggleSwitch = () => {
     const { accepted, cookieType } = cookie;
     const updatedCookie = { ...cookie, accepted: !accepted, cookieType: toggleCookieType(cookieType) };
@@ -69,4 +69,4 @@ const cookieSetter = ({ handleToggle, cookie, toggleCookieType, locale }: cookie
   );
 };
 
-export default cookieSetter;
+export default CookieSetter;

--- a/assembl/static2/js/app/components/cookies/cookieSetter.jsx
+++ b/assembl/static2/js/app/components/cookies/cookieSetter.jsx
@@ -8,7 +8,7 @@ import classnames from 'classnames';
 import Helper from '../common/helper';
 import CookieSwitch from './cookieSwitch';
 
-import { COOKIE_TRANSLATION_KEYS } from '../../constants';
+import { COOKIE_TRANSLATION_KEYS, COOKIES_CATEGORIES } from '../../constants';
 
 export type CookieObject = {
   name: string,
@@ -37,12 +37,12 @@ const cookieSetter = ({ handleToggle, cookie, toggleCookieType, locale }: cookie
   const { name, category, accepted } = cookie;
 
   const cookieName = Object.keys(COOKIE_TRANSLATION_KEYS).includes(name) ? I18n.t(`cookies.${name}`) : name;
-  const cookieIsMatomo = name === 'matomo';
+  const cookieIsMatomo = name === COOKIE_TRANSLATION_KEYS.matomo;
   const matomoOptOutLink = matomoHost ?
     `https://${matomoHost}/index.php?module=CoreAdminHome&action=optOut&language=${locale}`
     : null;
 
-  const required = category === 'essential';
+  const required = category === COOKIES_CATEGORIES.essential;
 
   return (
     <div

--- a/assembl/static2/js/app/components/cookies/cookieSetter.jsx
+++ b/assembl/static2/js/app/components/cookies/cookieSetter.jsx
@@ -24,7 +24,6 @@ type CookieSetterProps = {
   locale: string
 };
 
-// @$FlowFixMe globalAnalytics is a global variable
 const matomoHost = globalAnalytics.piwik ? globalAnalytics.piwik.host : null;
 
 const CookieSetter = ({ handleToggle, cookie, toggleCookieType, locale }: CookieSetterProps) => {

--- a/assembl/static2/js/app/components/cookies/cookieSetter.jsx
+++ b/assembl/static2/js/app/components/cookies/cookieSetter.jsx
@@ -53,6 +53,7 @@ const CookieSetter = ({ handleToggle, cookie, toggleCookieType, locale }: Cookie
         <span className="dark-title-3 ellipsis">{cookieName}</span>
         <Helper
           helperText={I18n.t(`cookies.${name}Helper`)}
+          popOverClass="cookie-helper-popover"
           classname="cookie-helper"
         />
       </div>

--- a/assembl/static2/js/app/components/cookies/cookieSetter.jsx
+++ b/assembl/static2/js/app/components/cookies/cookieSetter.jsx
@@ -1,0 +1,72 @@
+// @flow
+/* global globalAnalytics */
+import React from 'react';
+import { I18n } from 'react-redux-i18n';
+import classnames from 'classnames';
+
+// Components
+import Helper from '../common/helper';
+import CookieSwitch from './cookieSwitch';
+
+import { COOKIE_TRANSLATION_KEYS } from '../../constants';
+
+export type CookieObject = {
+  name: string,
+  category: string,
+  accepted: boolean,
+  cookieType: string
+};
+
+type cookieSetterProps = {
+  handleToggle: Function,
+  cookie: CookieObject,
+  toggleCookieType: Function,
+  locale: string
+};
+
+// @$FlowFixMe globalAnalytics is a global variable
+const matomoHost = globalAnalytics.piwik ? globalAnalytics.piwik.host : null;
+
+const cookieSetter = ({ handleToggle, cookie, toggleCookieType, locale }: cookieSetterProps) => {
+  const toggleSwitch = () => {
+    const { accepted, cookieType } = cookie;
+    const updatedCookie = { ...cookie, accepted: !accepted, cookieType: toggleCookieType(cookieType) };
+    handleToggle(updatedCookie);
+  };
+
+  const { name, category, accepted } = cookie;
+
+  const cookieName = Object.keys(COOKIE_TRANSLATION_KEYS).includes(name) ? I18n.t(`cookies.${name}`) : name;
+  const cookieIsMatomo = name === 'matomo';
+  const matomoOptOutLink = matomoHost ?
+    `https://${matomoHost}/index.php?module=CoreAdminHome&action=optOut&language=${locale}`
+    : null;
+
+  const required = category === 'essential';
+
+  return (
+    <div
+      className={classnames({
+        'cookie-with-link': (cookieIsMatomo && matomoOptOutLink) || required,
+        'cookie-toggle': !required && !matomoOptOutLink })}
+    >
+      <div className="cookie-title">
+        <span className="dark-title-3 ellipsis">{cookieName}</span>
+        <Helper
+          helperText={I18n.t(`cookies.${name}Helper`)}
+          classname="cookie-helper"
+        />
+      </div>
+      <CookieSwitch
+        cookieIsMatomo={cookieIsMatomo}
+        matomoOptOutLink={matomoOptOutLink}
+        toggleSwitch={toggleSwitch}
+        accepted={accepted}
+        name={name}
+        required={required}
+      />
+    </div>
+  );
+};
+
+export default cookieSetter;

--- a/assembl/static2/js/app/components/cookies/cookieSwitch.jsx
+++ b/assembl/static2/js/app/components/cookies/cookieSwitch.jsx
@@ -4,7 +4,7 @@ import { Translate, I18n } from 'react-redux-i18n';
 
 import SwitchButton from '../common/switchButton';
 
-type cookieToggleProps = {
+type CookieSwitchProps = {
   cookieIsMatomo: boolean,
   matomoOptOutLink: ?string,
   toggleSwitch: Function,
@@ -13,7 +13,7 @@ type cookieToggleProps = {
   required: boolean
 }
 
-const cookieSwitch = ({ cookieIsMatomo, matomoOptOutLink, toggleSwitch, accepted, name, required }: cookieToggleProps) => {
+const CookieSwitch = ({ cookieIsMatomo, matomoOptOutLink, toggleSwitch, accepted, name, required }: CookieSwitchProps) => {
   if (cookieIsMatomo && matomoOptOutLink) {
     return (
       <a
@@ -43,4 +43,4 @@ const cookieSwitch = ({ cookieIsMatomo, matomoOptOutLink, toggleSwitch, accepted
   );
 };
 
-export default cookieSwitch;
+export default CookieSwitch;

--- a/assembl/static2/js/app/components/cookies/cookieSwitch.jsx
+++ b/assembl/static2/js/app/components/cookies/cookieSwitch.jsx
@@ -1,0 +1,46 @@
+// @flow
+import * as React from 'react';
+import { Translate, I18n } from 'react-redux-i18n';
+
+import SwitchButton from '../common/switchButton';
+
+type cookieToggleProps = {
+  cookieIsMatomo: boolean,
+  matomoOptOutLink: ?string,
+  toggleSwitch: Function,
+  accepted: boolean,
+  name: string,
+  required: boolean
+}
+
+const cookieSwitch = ({ cookieIsMatomo, matomoOptOutLink, toggleSwitch, accepted, name, required }: cookieToggleProps) => {
+  if (cookieIsMatomo && matomoOptOutLink) {
+    return (
+      <a
+        // if the matomo website is not available in the locale it falls back to english
+        href={matomoOptOutLink}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="matomo-settings-link"
+      >
+        <Translate value="cookies.matomoSettings" />
+      </a>
+    );
+  }
+
+  if (required) {
+    return <Translate value="cookies.required" />;
+  }
+
+  return (
+    <SwitchButton
+      label={I18n.t('refuse')}
+      labelRight={I18n.t('accept')}
+      onChange={toggleSwitch}
+      checked={!accepted}
+      name={name}
+    />
+  );
+};
+
+export default cookieSwitch;

--- a/assembl/static2/js/app/components/cookies/cookiesSelector.jsx
+++ b/assembl/static2/js/app/components/cookies/cookiesSelector.jsx
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 import CookieSetter from './cookieSetter';
 import type { CookiesObject } from './cookiesSelectorContainer';
 
-type Props = {
+type CookiesSelectorProps = {
   activeKey: ?string,
   show: boolean,
   cookies: ?CookiesObject,
@@ -28,7 +28,7 @@ const CookiesSelector = ({
   toggleCookieType,
   locale,
   settingsHaveChanged
-}: Props) => (
+}: CookiesSelectorProps) => (
   <div className="cookies-selector">
     <h2 className="dark-title-2">
       <Translate value="profile.cookies" />

--- a/assembl/static2/js/app/components/cookies/cookiesSelector.jsx
+++ b/assembl/static2/js/app/components/cookies/cookiesSelector.jsx
@@ -39,7 +39,7 @@ const CookiesSelector = ({
           Object.keys(cookies).map((category) => {
             const isActiveKey = category === activeKey;
             return (
-              <div key={`category-${category}`}>
+              <div key={category}>
                 <div
                   className="cookies-category-selector"
                   onClick={() => {

--- a/assembl/static2/js/app/components/cookies/cookiesSelector.jsx
+++ b/assembl/static2/js/app/components/cookies/cookiesSelector.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Translate } from 'react-redux-i18n';
 import { Button } from 'react-bootstrap';
 import classnames from 'classnames';
-import CookieToggle from './cookieToggle';
+import CookieSetter from './cookieSetter';
 import type { CookiesObject } from './cookiesSelectorContainer';
 
 type Props = {
@@ -36,36 +36,36 @@ const CookiesSelector = ({
     <Translate value="cookiesPolicy.instructions" className="cookies-instructions" />
     <div className="cookies-categories">
       {cookies &&
-        Object.keys(cookies).map((category) => {
-          const isActiveKey = category === activeKey;
-          return (
-            <div key={`category-${category}`}>
-              <div
-                className="cookies-category-selector"
-                onClick={() => {
-                  handleCategorySelection(category);
-                }}
-              >
-                <span className={classnames('assembl-icon-right-dir', { 'active-arrow': isActiveKey })} />
-                <Translate value={`cookiesPolicy.${category}`} className="dark-title-3" />
+          Object.keys(cookies).map((category) => {
+            const isActiveKey = category === activeKey;
+            return (
+              <div key={`category-${category}`}>
+                <div
+                  className="cookies-category-selector"
+                  onClick={() => {
+                    handleCategorySelection(category);
+                  }}
+                >
+                  <span className={classnames('assembl-icon-right-dir', { 'active-arrow': isActiveKey })} />
+                  <Translate value={`cookiesPolicy.${category}`} className="dark-title-3" />
+                </div>
+                <div className="cookies-toggles">
+                  {isActiveKey &&
+                    show &&
+                    cookies[category] &&
+                    cookies[category].map(cookie => (
+                      <CookieSetter
+                        cookie={cookie}
+                        key={cookie.name}
+                        handleToggle={handleToggle}
+                        toggleCookieType={toggleCookieType}
+                        locale={locale}
+                      />
+                    ))}
+                </div>
               </div>
-              <div className="cookies-toggles">
-                {isActiveKey &&
-                  show &&
-                  cookies[category] &&
-                  cookies[category].map(cookie => (
-                    <CookieToggle
-                      cookie={cookie}
-                      key={cookie.name}
-                      handleToggle={handleToggle}
-                      toggleCookieType={toggleCookieType}
-                      locale={locale}
-                    />
-                  ))}
-              </div>
-            </div>
-          );
-        })}
+            );
+          })}
     </div>
     <div className="submit-button-container">
       <Button onClick={handleSave} className={settingsHaveChanged ? 'button-submit button-dark' : 'hidden'}>

--- a/assembl/static2/js/app/components/cookies/cookiesSelector.jsx
+++ b/assembl/static2/js/app/components/cookies/cookiesSelector.jsx
@@ -5,6 +5,7 @@ import { Button } from 'react-bootstrap';
 import classnames from 'classnames';
 import CookieSetter from './cookieSetter';
 import type { CookiesObject } from './cookiesSelectorContainer';
+import { moveElementToFirstPosition } from '../../utils/globalFunctions';
 
 type CookiesSelectorProps = {
   activeKey: ?string,
@@ -28,15 +29,18 @@ const CookiesSelector = ({
   toggleCookieType,
   locale,
   settingsHaveChanged
-}: CookiesSelectorProps) => (
-  <div className="cookies-selector">
-    <h2 className="dark-title-2">
-      <Translate value="profile.cookies" />
-    </h2>
-    <Translate value="cookiesPolicy.instructions" className="cookies-instructions" />
-    <div className="cookies-categories">
-      {cookies &&
-          Object.keys(cookies).map((category) => {
+}: CookiesSelectorProps) => {
+  // putting 'essential' as the first element of the array
+  const categoriesArray = cookies && moveElementToFirstPosition(Object.keys(cookies), 'essential');
+  return (
+    <div className="cookies-selector">
+      <h2 className="dark-title-2">
+        <Translate value="profile.cookies" />
+      </h2>
+      <Translate value="cookiesPolicy.instructions" className="cookies-instructions" />
+      <div className="cookies-categories">
+        {categoriesArray &&
+          categoriesArray.map((category) => {
             const isActiveKey = category === activeKey;
             return (
               <div key={category}>
@@ -52,6 +56,7 @@ const CookiesSelector = ({
                 <div className="cookies-toggles">
                   {isActiveKey &&
                     show &&
+                    cookies &&
                     cookies[category] &&
                     cookies[category].map(cookie => (
                       <CookieSetter
@@ -66,13 +71,14 @@ const CookiesSelector = ({
               </div>
             );
           })}
+      </div>
+      <div className="submit-button-container">
+        <Button onClick={handleSave} className={settingsHaveChanged ? 'button-submit button-dark' : 'hidden'}>
+          <Translate value="profile.save" />
+        </Button>
+      </div>
     </div>
-    <div className="submit-button-container">
-      <Button onClick={handleSave} className={settingsHaveChanged ? 'button-submit button-dark' : 'hidden'}>
-        <Translate value="profile.save" />
-      </Button>
-    </div>
-  </div>
-);
+  );
+};
 
 export default CookiesSelector;

--- a/assembl/static2/js/app/components/cookies/cookiesSelectorContainer.jsx
+++ b/assembl/static2/js/app/components/cookies/cookiesSelectorContainer.jsx
@@ -14,7 +14,7 @@ import updateAcceptedCookies from '../../graphql/mutations/updateAcceptedCookies
 import withLoadingIndicator from '../common/withLoadingIndicator';
 
 import type { CookieObject } from './cookieSetter';
-import { COOKIE_TRANSLATION_KEYS, COOKIE_TYPES } from '../../constants';
+import { COOKIE_TRANSLATION_KEYS, COOKIE_TYPES, COOKIES_CATEGORIES } from '../../constants';
 
 type Props = {
   updateAcceptedCookies: Function,
@@ -34,6 +34,9 @@ type State = {
   cookies: ?CookiesObject,
   settingsHaveChanged: boolean
 };
+
+const { userSession, locale, matomo, privacyPolicy, cgu } = COOKIE_TRANSLATION_KEYS;
+const { essential, analytics, other } = COOKIES_CATEGORIES;
 
 export class DumbCookiesSelectorContainer extends React.Component<Props, State> {
   constructor(props: Props) {
@@ -75,21 +78,21 @@ export class DumbCookiesSelectorContainer extends React.Component<Props, State> 
 
   getCookieObjectData = (cookie: string) => {
     if (cookie.includes('SESSION_ON_DISCUSSION')) {
-      return { category: 'essential', name: COOKIE_TRANSLATION_KEYS.userSession };
+      return { category: essential, name: userSession };
     }
     if (cookie.includes('LOCALE')) {
-      return { category: 'essential', name: COOKIE_TRANSLATION_KEYS.locale };
+      return { category: essential, name: locale };
     }
     if (cookie.includes('TRACKING_ON_DISCUSSION')) {
-      return { category: 'analytics', name: COOKIE_TRANSLATION_KEYS.matomo };
+      return { category: analytics, name: matomo };
     }
     if (cookie.includes('PRIVACY_POLICY_ON_DISCUSSION')) {
-      return { category: 'essential', name: COOKIE_TRANSLATION_KEYS.privacyPolicy };
+      return { category: essential, name: privacyPolicy };
     }
     if (cookie.includes('CGU')) {
-      return { category: 'essential', name: COOKIE_TRANSLATION_KEYS.cgu };
+      return { category: essential, name: cgu };
     }
-    return { category: 'other', name: cookie };
+    return { category: other, name: cookie };
   };
 
   getCookiesObjectFromArray = (cookiesArray: Array<CookieObject>) => {

--- a/assembl/static2/js/app/components/cookies/cookiesSelectorContainer.jsx
+++ b/assembl/static2/js/app/components/cookies/cookiesSelectorContainer.jsx
@@ -13,7 +13,7 @@ import acceptedCookiesQuery from '../../graphql/acceptedCookiesQuery.graphql';
 import updateAcceptedCookies from '../../graphql/mutations/updateAcceptedCookies.graphql';
 import withLoadingIndicator from '../common/withLoadingIndicator';
 
-import type { CookieObject } from './cookieToggle';
+import type { CookieObject } from './cookieSetter';
 import { COOKIE_TRANSLATION_KEYS, COOKIE_TYPES } from '../../constants';
 
 type Props = {

--- a/assembl/static2/js/app/constants.js
+++ b/assembl/static2/js/app/constants.js
@@ -87,6 +87,12 @@ export const COOKIE_TRANSLATION_KEYS = {
   cgu: 'cgu'
 };
 
+export const COOKIES_CATEGORIES = {
+  essential: 'essential',
+  analytics: 'analytics',
+  other: 'other'
+};
+
 // Those states lists need to be kept in sync with models/post.py
 export const PublicationStates = {
   DRAFT: 'DRAFT',

--- a/assembl/static2/js/app/utils/globalFunctions.js
+++ b/assembl/static2/js/app/utils/globalFunctions.js
@@ -33,6 +33,11 @@ export const getConnectedUserId = (base64: boolean = false) => {
 
 export const getConnectedUserName = () => getInputValue('user-displayname');
 
+export const moveElementToFirstPosition = (array: Array<any>, targetElement: any) => {
+  const others = array.filter(elelement => elelement !== targetElement);
+  return [targetElement, ...others];
+};
+
 // cache permissions to avoid accessing the dom at each permission check
 let permissions;
 export const getConnectedUserPermissions = () => {

--- a/assembl/static2/js/app/utils/translations.js
+++ b/assembl/static2/js/app/utils/translations.js
@@ -54,7 +54,7 @@ const Translations = {
       matomo: "Matomo",
       privacyPolicy: "Politique de confidentialité",
       cgu: "Conditions générales d'utilisation",
-      matomoSettings: "Pour modifier les paramètres de ce cookie veuillez cliquer ici",
+      matomoSettings: "Pour modifier les paramètres de ce cookie, veuillez cliquer ici",
       userSessionHelper: "Ce cookie est nécessaire pour vous maintenir connecté sur Assembl.",
       localeHelper: "Ce cookie est nécessaire afin d'afficher les textes dans la langue de votre nagigateur ou bien celle que vous avez sélectionné dans la barre de navigation.",
       privacyPolicyHelper: "Ce cookie permet d'enregistrer que vous avez accepté la politique de confidentialité de la consultation.",

--- a/assembl/static2/js/app/utils/translations.js
+++ b/assembl/static2/js/app/utils/translations.js
@@ -59,7 +59,8 @@ const Translations = {
       localeHelper: "Ce cookie est nécessaire afin d'afficher les textes dans la langue de votre nagigateur ou bien celle que vous avez sélectionné dans la barre de navigation.",
       privacyPolicyHelper: "Ce cookie permet d'enregistrer que vous avez accepté la politique de confidentialité de la consultation.",
       cguHelper: "Ce cookie permet d'enregistrer que vous avez accepté les conditions générales d'utilisation.",
-      matomoHelper: "Ce cookie est utilisé à des fins statistiques concernant les participants à la consultation."
+      matomoHelper: "Ce cookie est utilisé à des fins statistiques concernant les participants à la consultation.",
+      required: "Ce cookie est requis pour le bon fonctionnement d'Assembl"
     },
     search: {
       reset: {
@@ -888,7 +889,8 @@ const Translations = {
       localeHelper: "This cookie is necessary to display the texts in the language of your browser or the one you selected in the navigation bar.",
       privacyPolicyHelper: "This cookie registers that you have accepted the privacy policy of the consultation.",
       cguHelper: "This cookie registers that you have accepted the terms and conditions of the consultation.",
-      matomoHelper: "This cookie is used for stasticial purposes regarding the participants of the consultation."
+      matomoHelper: "This cookie is used for stasticial purposes regarding the participants of the consultation.",
+      required: "This cookie is required for Assembl to work properly"
     },
     search: {
       reset: {

--- a/assembl/static2/tests/unit/components/administration/landingPage/__snapshots__/customizeHeader.spec.jsx.snap
+++ b/assembl/static2/tests/unit/components/administration/landingPage/__snapshots__/customizeHeader.spec.jsx.snap
@@ -20,6 +20,7 @@ exports[`ManageModules component should render a page to manage the landing page
         helperText="Top page header. It contains the consultation's title and subtitle and a button to access to the consultation."
         helperUrl="/static2/img/helpers/landing_page_admin/header.png"
         label="Customize appearance of the header."
+        popOverClass=""
       />
       <div
         className="margin-l"

--- a/assembl/static2/tests/unit/components/administration/landingPage/__snapshots__/selectModulesForm.spec.jsx.snap
+++ b/assembl/static2/tests/unit/components/administration/landingPage/__snapshots__/selectModulesForm.spec.jsx.snap
@@ -21,6 +21,7 @@ exports[`DumbSelectModulesForm component should render a form to select the land
         helperText="Top page header. It contains the consultation's title and subtitle and a button to access to the consultation."
         helperUrl="/static2/img/helpers/landing_page_admin/header.png"
         label="Header"
+        popOverClass=""
       />
     </Checkbox>
     <Checkbox
@@ -37,6 +38,7 @@ exports[`DumbSelectModulesForm component should render a form to select the land
         helperText=" "
         helperUrl="/static2/img/helpers/landing_page_admin/introduction.png"
         label="Introduction"
+        popOverClass=""
       />
     </Checkbox>
     <Checkbox
@@ -53,6 +55,7 @@ exports[`DumbSelectModulesForm component should render a form to select the land
         helperText=" "
         helperUrl="/static2/img/helpers/landing_page_admin/video.png"
         label="Video"
+        popOverClass=""
       />
     </Checkbox>
     <Checkbox
@@ -69,6 +72,7 @@ exports[`DumbSelectModulesForm component should render a form to select the land
         helperText=" "
         helperUrl="/static2/img/helpers/landing_page_admin/footer.png"
         label="Footer"
+        popOverClass=""
       />
     </Checkbox>
   </FormGroup>

--- a/assembl/static2/tests/unit/components/administration/voteSession/__snapshots__/modulesSection.spec.jsx.snap
+++ b/assembl/static2/tests/unit/components/administration/voteSession/__snapshots__/modulesSection.spec.jsx.snap
@@ -32,6 +32,7 @@ exports[`ModulesSection component should render a ModuleSection component with t
             helperText="The token vote module allows you to select propositions proportionnaly. Each participant has a certain amount of tokens et will have to spread them on the different propositions"
             helperUrl="/static2/img/helpers/helper4.png"
             label="Tokens vote"
+            popOverClass=""
           />
         </Checkbox>
         Immutable.List [
@@ -54,6 +55,7 @@ exports[`ModulesSection component should render a ModuleSection component with t
             helperText="You can choose to have one or several gages"
             helperUrl="/static2/img/helpers/helper3.png"
             label="Gauge(s) vote"
+            popOverClass=""
           />
         </Checkbox>
         <div
@@ -75,6 +77,7 @@ exports[`ModulesSection component should render a ModuleSection component with t
               helperText="Define gauges number"
               helperUrl="/static2/img/helpers/helper2.jpg"
               label=""
+              popOverClass=""
             />
           </div>
           <SplitButton
@@ -259,6 +262,7 @@ exports[`ModulesSection component should render a ModulesSection component witho
             helperText="The token vote module allows you to select propositions proportionnaly. Each participant has a certain amount of tokens et will have to spread them on the different propositions"
             helperUrl="/static2/img/helpers/helper4.png"
             label="Tokens vote"
+            popOverClass=""
           />
         </Checkbox>
         Immutable.List [
@@ -278,6 +282,7 @@ exports[`ModulesSection component should render a ModulesSection component witho
             helperText="You can choose to have one or several gages"
             helperUrl="/static2/img/helpers/helper3.png"
             label="Gauge(s) vote"
+            popOverClass=""
           />
         </Checkbox>
         Immutable.List [

--- a/assembl/static2/tests/unit/components/administration/voteSession/__snapshots__/pageForm.spec.jsx.snap
+++ b/assembl/static2/tests/unit/components/administration/voteSession/__snapshots__/pageForm.spec.jsx.snap
@@ -48,6 +48,7 @@ exports[`Vote Session DumbPageForm component should render a form to update the 
           helperText="The top page header must contain an image and a title. The subtitle is optional."
           helperUrl="/static2/img/helpers/helper1.png"
           label="Top page Header configuration"
+          popOverClass=""
         />
         <FormControlWithLabel
           componentClass={undefined}
@@ -128,6 +129,7 @@ exports[`Vote Session DumbPageForm component should render a form to update the 
         helperText="The instructions section must contain a title and a description that will guide the participants for their contribution."
         helperUrl="/static2/img/helpers/helper2.jpg"
         label="Instructions section configuration"
+        popOverClass=""
       />
       <FormControlWithLabel
         componentClass={undefined}
@@ -185,6 +187,7 @@ exports[`Vote Session DumbPageForm component should render a form to update the 
         helperText="The proposals section is introduced by a title. You define the title based on the proposal content."
         helperUrl="/static2/img/helpers/helper3.png"
         label="Proposal section title configuration"
+        popOverClass=""
       />
       <FormControlWithLabel
         componentClass={undefined}

--- a/assembl/static2/tests/unit/components/administration/voteSession/__snapshots__/tokensForm.spec.jsx.snap
+++ b/assembl/static2/tests/unit/components/administration/voteSession/__snapshots__/tokensForm.spec.jsx.snap
@@ -35,6 +35,7 @@ exports[`tokensForm component should render a form to configure a token vote wit
         helperText="Select the number of different token types for this vote"
         helperUrl="/static2/img/helpers/helper2.jpg"
         label=""
+        popOverClass=""
       />
     </div>
     <div>
@@ -155,6 +156,7 @@ exports[`tokensForm component should render a form to configure a token vote wit
         helperText="You can decide wether the participant can distribute a single type of token (exclusive) or several types of token per proposal."
         helperUrl=""
         label=""
+        popOverClass=""
       />
       <SplitButton
         className="admin-dropdown"
@@ -251,6 +253,7 @@ exports[`tokensForm component should render a form to configure a token vote wit
         helperText="Select the number of different token types for this vote"
         helperUrl="/static2/img/helpers/helper2.jpg"
         label=""
+        popOverClass=""
       />
     </div>
     <div>

--- a/assembl/static2/tests/unit/components/cookies/__snapshots__/cookieToggle.spec.jsx.snap
+++ b/assembl/static2/tests/unit/components/cookies/__snapshots__/cookieToggle.spec.jsx.snap
@@ -1,57 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CookieToggle component should render a cookie's name with a toggle to change its setting 1`] = `
+exports[`CookieSwitch component should render a cookie's name with a toggle to change its setting 1`] = `
 <div
-  className="cookie-toggle"
+  className="rsbc-switch-button rsbc-mode-switch rsbc-switch-button-flat-round"
 >
-  <div
-    className="cookie-title"
+  <label
+    htmlFor="switch-button"
   >
-    <span
-      className="dark-title-3 ellipsis"
-    >
-      User Session
-    </span>
-    <div
-      className="cookie-helper"
-    >
-      
-       
-      <span
-        className="assembl-icon-faq grey pointer"
-        onBlur={[Function]}
-        onClick={null}
-        onFocus={[Function]}
-        onMouseOut={[Function]}
-        onMouseOver={[Function]}
-      />
-    </div>
-  </div>
-  <div
-    className="rsbc-switch-button rsbc-mode-switch rsbc-switch-button-flat-round disabled"
+    Refuse
+  </label>
+  <input
+    checked={true}
+    disabled={false}
+    id="switch-button"
+    name="switch-button"
+    onChange={[Function]}
+    type="checkbox"
+    value="1"
+  />
+  <label
+    htmlFor="switch-button"
+  />
+  <label
+    htmlFor="switch-button"
   >
-    <label
-      htmlFor="userSession"
-    >
-      Refuse
-    </label>
-    <input
-      checked={false}
-      disabled={true}
-      id="userSession"
-      name="userSession"
-      onChange={[Function]}
-      type="checkbox"
-      value="1"
-    />
-    <label
-      htmlFor="userSession"
-    />
-    <label
-      htmlFor="userSession"
-    >
-      Accept
-    </label>
-  </div>
+    Accept
+  </label>
 </div>
 `;

--- a/assembl/static2/tests/unit/components/cookies/__snapshots__/cookiesSelector.spec.jsx.snap
+++ b/assembl/static2/tests/unit/components/cookies/__snapshots__/cookiesSelector.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CookiesSelector component should render a list of cookieToggle components set in different categories 1`] = `
+exports[`CookiesSelector component should render a list of cookieSetter components set in different categories 1`] = `
 <div
   className="cookies-selector"
 >
@@ -42,7 +42,7 @@ exports[`CookiesSelector component should render a list of cookieToggle componen
         className="cookies-toggles"
       >
         <div
-          className="cookie-toggle"
+          className="cookie-with-link"
         >
           <div
             className="cookie-title"
@@ -67,32 +67,12 @@ exports[`CookiesSelector component should render a list of cookieToggle componen
               />
             </div>
           </div>
-          <div
-            className="rsbc-switch-button rsbc-mode-switch rsbc-switch-button-flat-round disabled"
+          <span
+            className={undefined}
+            style={undefined}
           >
-            <label
-              htmlFor="locale"
-            >
-              Refuse
-            </label>
-            <input
-              checked={false}
-              disabled={true}
-              id="locale"
-              name="locale"
-              onChange={[Function]}
-              type="checkbox"
-              value="1"
-            />
-            <label
-              htmlFor="locale"
-            />
-            <label
-              htmlFor="locale"
-            >
-              Accept
-            </label>
-          </div>
+            This cookie is required for Assembl to work properly
+          </span>
         </div>
       </div>
     </div>

--- a/assembl/static2/tests/unit/components/cookies/cookieToggle.spec.jsx
+++ b/assembl/static2/tests/unit/components/cookies/cookieToggle.spec.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
-import CookieToggle from '../../../../js/app/components/cookies/cookieToggle';
+import CookieSwitch from '../../../../js/app/components/cookies/cookieSwitch';
 
-describe('CookieToggle component', () => {
+describe('CookieSwitch component', () => {
   const handleToggleSpy = jest.fn(() => {});
   it('should render a cookie\'s name with a toggle to change its setting', () => {
     const props = {
@@ -13,7 +13,7 @@ describe('CookieToggle component', () => {
       },
       handleToggle: handleToggleSpy
     };
-    const rendered = renderer.create(<CookieToggle {...props} />);
+    const rendered = renderer.create(<CookieSwitch {...props} />);
     expect(rendered).toMatchSnapshot();
   });
 });

--- a/assembl/static2/tests/unit/components/cookies/cookiesSelector.spec.jsx
+++ b/assembl/static2/tests/unit/components/cookies/cookiesSelector.spec.jsx
@@ -7,7 +7,7 @@ describe('CookiesSelector component', () => {
   const handleSaveSpy = jest.fn(() => {});
   const handleToggleSpy = jest.fn(() => {});
 
-  it('should render a list of cookieToggle components set in different categories', () => {
+  it('should render a list of cookieSetter components set in different categories', () => {
     const props = {
       cookies: {
         essential: [

--- a/assembl/static2/tests/unit/utils/globalFunctions.spec.js
+++ b/assembl/static2/tests/unit/utils/globalFunctions.spec.js
@@ -4,7 +4,8 @@ import {
   getBasename,
   hexToRgb,
   encodeUserIdBase64,
-  isHarvestable
+  isHarvestable,
+  moveElementToFirstPosition
 } from '../../../js/app/utils/globalFunctions';
 
 describe('This test concern GlobalFunctions Class', () => {
@@ -124,5 +125,13 @@ describe('isHarvestable function', () => {
       phase: 'multiColumns'
     };
     expect(isHarvestable(params)).toBeTruthy();
+  });
+});
+
+describe('moveElementToFirstPosition function', () => {
+  it('should put bar as the first element of the array', () => {
+    const array = ['foo', 'bar', 'baz'];
+    const element = 'bar';
+    expect(moveElementToFirstPosition(array, element)).toEqual(['bar', 'foo', 'baz']);
   });
 });


### PR DESCRIPTION
This is a quick rearrangement of the cookieToggle component (now cookieSetter) because another requirement was added to this component: to display a message indicating that a cookie is required instead of having a toggle set on Accepted and disabled. I already had a ternary operator in cookieToggle's return so I created a sub component dealing with the 3 cases:

1. The cookie is required: show a message saying so.
2. The cookie is not required but is concerning the matomo settings: show a link sending the user to the matomo optout page.
3. The cookie is a regular cookie to be configured with a switch button: show a switch button. (At this point we have no cookie entering this category but we might in the future)