### PR TITLE
RichTextEditor use editor state

### DIFF
--- a/assembl/static2/.flowconfig
+++ b/assembl/static2/.flowconfig
@@ -1,6 +1,10 @@
 [ignore]
-# ignore this file until these issues are fixed : https://github.com/facebook/draft-js/issues/1272
-<PROJECT_ROOT>/node_modules/draft-js/lib/getTextContentFromFiles.js.flow
+<PROJECT_ROOT>/node_modules/draft-js/lib/ContentBlock.js.flow
+<PROJECT_ROOT>/node_modules/draft-js/lib/ContentBlockNode.js.flow
+<PROJECT_ROOT>/node_modules/draft-js/lib/DraftEditor.react.js.flow
+<PROJECT_ROOT>/node_modules/draft-js/lib/DraftEditorDragHandler.js.flow
+<PROJECT_ROOT>/node_modules/draft-js/lib/DraftEditorLeaf.react.js.flow
+<PROJECT_ROOT>/node_modules/draft-js-plugins-editor/lib/Editor/index.js.flow
 <PROJECT_ROOT>/node_modules/config-chain
 <PROJECT_ROOT>/node_modules/npm/node_modules/config-chain
 <PROJECT_ROOT>/node_modules/stylelint

--- a/assembl/static2/flow/object_types.js
+++ b/assembl/static2/flow/object_types.js
@@ -1,6 +1,6 @@
 /* @flow */
 /* eslint-disable */
-import { type RawContentState } from 'draft-js';
+import { type EditorState } from 'draft-js';
 
 export type IdeaMessageColumns = Array<IdeaMessageColumnFragment>;
 
@@ -47,7 +47,7 @@ type LangstringEntries = Array<LangstringEntry>;
 
 type RichTextLangstringEntry = {
   localeCode: string,
-  value: RawContentState
+  value: EditorState
 };
 type RichTextLangstringEntries = Array<RichTextLangstringEntry>;
 

--- a/assembl/static2/js/app/components/administration/brightMirror/load.js
+++ b/assembl/static2/js/app/components/administration/brightMirror/load.js
@@ -4,8 +4,7 @@ import type { ApolloClient } from 'react-apollo';
 import { PHASES } from '../../../constants';
 
 import ThematicsQuery from '../../../graphql/ThematicsQuery.graphql';
-import { convertEntries } from '../../form/utils';
-import { convertEntriesToRawContentState } from '../../../utils/draftjs';
+import { convertEntriesToI18nValue, convertEntriesToI18nRichText } from '../../form/utils';
 import type { BrightMirrorAdminValues } from './types.flow';
 
 export const load = async (client: ApolloClient, fetchPolicy: FetchPolicy) => {
@@ -22,11 +21,11 @@ export function postLoadFormat(data: ThematicsQueryQuery): BrightMirrorAdminValu
     themes: sortBy(data.thematics, 'order').map(t => ({
       id: t.id,
       img: t.img,
-      title: convertEntries(t.titleEntries),
-      description: convertEntries(t.descriptionEntries),
+      title: convertEntriesToI18nValue(t.titleEntries),
+      description: convertEntriesToI18nValue(t.descriptionEntries),
       announcement: {
-        title: convertEntries(t.announcement.titleEntries),
-        body: convertEntries(convertEntriesToRawContentState(t.announcement.bodyEntries))
+        title: convertEntriesToI18nValue(t.announcement.titleEntries),
+        body: convertEntriesToI18nRichText(t.announcement.bodyEntries)
       }
     }))
   };

--- a/assembl/static2/js/app/components/administration/brightMirror/save.js
+++ b/assembl/static2/js/app/components/administration/brightMirror/save.js
@@ -8,8 +8,7 @@ import { PHASES } from '../../../constants';
 import createThematicMutation from '../../../graphql/mutations/createThematic.graphql';
 import deleteThematicMutation from '../../../graphql/mutations/deleteThematic.graphql';
 import updateThematicMutation from '../../../graphql/mutations/updateThematic.graphql';
-import { createSave, convertToEntries, getFileVariable } from '../../form/utils';
-import { convertEntriesToHTML } from '../../../utils/draftjs';
+import { createSave, convertRichTextToEntries, convertToEntries, getFileVariable } from '../../form/utils';
 
 function getVariables(theme, initialTheme, order) {
   const initialImg = initialTheme ? initialTheme.img : null;
@@ -21,7 +20,7 @@ function getVariables(theme, initialTheme, order) {
     image: getFileVariable(theme.img, initialImg),
     announcement: {
       titleEntries: convertToEntries(theme.announcement.title),
-      bodyEntries: convertEntriesToHTML(convertToEntries(theme.announcement.body))
+      bodyEntries: convertRichTextToEntries(theme.announcement.body)
     },
     order: order
   };

--- a/assembl/static2/js/app/components/administration/brightMirror/types.flow.js
+++ b/assembl/static2/js/app/components/administration/brightMirror/types.flow.js
@@ -1,5 +1,5 @@
 // @flow
-import type { FileValue, I18nValue } from '../../form/types.flow';
+import type { FileValue, I18nValue, I18nRichTextValue } from '../../form/types.flow';
 
 type ThemeValue = {
   id: string,
@@ -9,7 +9,7 @@ type ThemeValue = {
   identifier: string,
   announcement: {
     title: I18nValue,
-    body: I18nValue
+    body: I18nRichTextValue
   }
 };
 

--- a/assembl/static2/js/app/components/administration/discussion/personalizeInterface/load.js
+++ b/assembl/static2/js/app/components/administration/discussion/personalizeInterface/load.js
@@ -16,6 +16,6 @@ export function postLoadFormat(data: DiscussionPreferencesQuery): PersonalizeInt
   const { discussionPreferences } = data;
   return {
     title: discussionPreferences && discussionPreferences.tabTitle,
-    favicon: discussionPreferences ? discussionPreferences.favicon : null
+    favicon: (discussionPreferences && discussionPreferences.favicon) || null
   };
 }

--- a/assembl/static2/js/app/components/administration/legalContents/load.js
+++ b/assembl/static2/js/app/components/administration/legalContents/load.js
@@ -1,8 +1,7 @@
 // @flow
 import type { ApolloClient } from 'react-apollo';
 import LegalContentsQuery from '../../../graphql/LegalContents.graphql';
-import { convertEntriesToRawContentState } from '../../../utils/draftjs';
-import { convertEntries } from '../../form/utils';
+import { convertEntriesToI18nRichText } from '../../form/utils';
 
 import type { LegalContentsFormValues } from './types.flow';
 
@@ -24,12 +23,10 @@ export const postLoadFormat = (data: LegalContentsQuery): LegalContentsFormValue
     userGuidelinesEntries
   } = data.legalContents;
   return {
-    legalNotice: legalNoticeEntries ? convertEntries(convertEntriesToRawContentState(legalNoticeEntries)) : {},
-    termsAndConditions: termsAndConditionsEntries
-      ? convertEntries(convertEntriesToRawContentState(termsAndConditionsEntries))
-      : {},
-    cookiesPolicy: cookiesPolicyEntries ? convertEntries(convertEntriesToRawContentState(cookiesPolicyEntries)) : {},
-    privacyPolicy: privacyPolicyEntries ? convertEntries(convertEntriesToRawContentState(privacyPolicyEntries)) : {},
-    userGuidelines: userGuidelinesEntries ? convertEntries(convertEntriesToRawContentState(userGuidelinesEntries)) : {}
+    legalNotice: legalNoticeEntries ? convertEntriesToI18nRichText(legalNoticeEntries) : {},
+    termsAndConditions: termsAndConditionsEntries ? convertEntriesToI18nRichText(termsAndConditionsEntries) : {},
+    cookiesPolicy: cookiesPolicyEntries ? convertEntriesToI18nRichText(cookiesPolicyEntries) : {},
+    privacyPolicy: privacyPolicyEntries ? convertEntriesToI18nRichText(privacyPolicyEntries) : {},
+    userGuidelines: userGuidelinesEntries ? convertEntriesToI18nRichText(userGuidelinesEntries) : {}
   };
 };

--- a/assembl/static2/js/app/components/administration/legalContents/save.js
+++ b/assembl/static2/js/app/components/administration/legalContents/save.js
@@ -1,21 +1,18 @@
 // @flow
 import type { ApolloClient } from 'react-apollo';
-import { convertEntriesToHTML } from '../../../utils/draftjs';
 import updateLegalContents from '../../../graphql/mutations/updateLegalContents.graphql';
 import type { LegalContentsFormValues } from './types.flow';
-import { createSave, convertToEntries } from '../../form/utils';
+import { createSave, convertRichTextToEntries } from '../../form/utils';
 
 const getVariables = values => ({
-  legalNoticeEntries: convertEntriesToHTML(convertToEntries(values.legalNotice)),
-  termsAndConditionsEntries: convertEntriesToHTML(convertToEntries(values.termsAndConditions)),
-  privacyPolicyEntries: convertEntriesToHTML(convertToEntries(values.privacyPolicy)),
-  cookiesPolicyEntries: convertEntriesToHTML(convertToEntries(values.cookiesPolicy)),
-  userGuidelinesEntries: convertEntriesToHTML(convertToEntries(values.userGuidelines))
+  legalNoticeEntries: convertRichTextToEntries(values.legalNotice),
+  termsAndConditionsEntries: convertRichTextToEntries(values.termsAndConditions),
+  privacyPolicyEntries: convertRichTextToEntries(values.privacyPolicy),
+  cookiesPolicyEntries: convertRichTextToEntries(values.cookiesPolicy),
+  userGuidelinesEntries: convertRichTextToEntries(values.userGuidelines)
 });
 
-export const createMutationsPromises = (client: ApolloClient, locale: string) => (
-  values: LegalContentsFormValues
-) => {
+export const createMutationsPromises = (client: ApolloClient, locale: string) => (values: LegalContentsFormValues) => {
   const allMutations = [];
   const variables = getVariables(values);
 
@@ -26,7 +23,8 @@ export const createMutationsPromises = (client: ApolloClient, locale: string) =>
         locale: locale,
         ...variables
       }
-    }));
+    })
+  );
 
   return allMutations;
 };

--- a/assembl/static2/js/app/components/administration/legalContents/types.flow.js
+++ b/assembl/static2/js/app/components/administration/legalContents/types.flow.js
@@ -1,10 +1,10 @@
 // @flow
-import type { I18nValue } from '../../form/types.flow';
+import type { I18nRichTextValue } from '../../form/types.flow';
 
 export type LegalContentsFormValues = {
-  legalNotice: I18nValue,
-  termsAndConditions: I18nValue,
-  cookiesPolicy: I18nValue,
-  privacyPolicy: I18nValue,
-  userGuidelines: I18nValue
+  legalNotice: I18nRichTextValue,
+  termsAndConditions: I18nRichTextValue,
+  cookiesPolicy: I18nRichTextValue,
+  privacyPolicy: I18nRichTextValue,
+  userGuidelines: I18nRichTextValue
 };

--- a/assembl/static2/js/app/components/administration/legalContents/validate.js
+++ b/assembl/static2/js/app/components/administration/legalContents/validate.js
@@ -1,5 +1,4 @@
 // @flow
-
 const validate = () => ({});
 
 export default validate;

--- a/assembl/static2/js/app/components/administration/resourcesCenter/load.js
+++ b/assembl/static2/js/app/components/administration/resourcesCenter/load.js
@@ -4,8 +4,7 @@ import type { ApolloClient } from 'react-apollo';
 import type { ResourcesValues } from './types.flow';
 import ResourcesCenterPageQuery from '../../../graphql/ResourcesCenterPage.graphql';
 import ResourcesQuery from '../../../graphql/ResourcesQuery.graphql';
-import { convertEntries } from '../../form/utils';
-import { convertEntriesToRawContentState } from '../../../utils/draftjs';
+import { convertEntriesToI18nValue, convertEntriesToI18nRichText } from '../../form/utils';
 
 export const load = async (client: ApolloClient, fetchPolicy: FetchPolicy) => {
   const { data: resourcesCenterData } = await client.query({
@@ -28,15 +27,15 @@ type Data = ResourcesCenterPageQuery & ResourcesQueryQuery;
 
 export function postLoadFormat(data: Data): ResourcesValues {
   return {
-    pageTitle: convertEntries(data.resourcesCenter.titleEntries),
+    pageTitle: convertEntriesToI18nValue(data.resourcesCenter.titleEntries),
     pageHeader: data.resourcesCenter.headerImage,
     resources: data.resources.map(r => ({
       doc: r.doc,
       embedCode: r.embedCode,
       id: r.id,
       img: r.image,
-      text: convertEntries(convertEntriesToRawContentState(r.textEntries)),
-      title: convertEntries(r.titleEntries)
+      text: convertEntriesToI18nRichText(r.textEntries),
+      title: convertEntriesToI18nValue(r.titleEntries)
     }))
   };
 }

--- a/assembl/static2/js/app/components/administration/resourcesCenter/save.js
+++ b/assembl/static2/js/app/components/administration/resourcesCenter/save.js
@@ -3,9 +3,8 @@ import difference from 'lodash/difference';
 import isEqual from 'lodash/isEqual';
 import type { ApolloClient } from 'react-apollo';
 
-import { convertEntriesToHTML } from '../../../utils/draftjs';
 import type { ResourcesValues } from './types.flow';
-import { createSave, convertToEntries, getFileVariable } from '../../form/utils';
+import { createSave, convertRichTextToEntries, convertToEntries, getFileVariable } from '../../form/utils';
 import createResourceMutation from '../../../graphql/mutations/createResource.graphql';
 import updateResourceMutation from '../../../graphql/mutations/updateResource.graphql';
 import deleteResourceMutation from '../../../graphql/mutations/deleteResource.graphql';
@@ -25,7 +24,7 @@ function getResourceVariables(resource, initialResource, order) {
     doc: getFileVariable(resource.doc, initialDoc),
     embedCode: resource.embedCode,
     image: getFileVariable(resource.img, initialImg),
-    textEntries: convertEntriesToHTML(convertToEntries(resource.text)),
+    textEntries: convertRichTextToEntries(resource.text),
     titleEntries: convertToEntries(resource.title),
     order: order
   };

--- a/assembl/static2/js/app/components/administration/resourcesCenter/types.flow.js
+++ b/assembl/static2/js/app/components/administration/resourcesCenter/types.flow.js
@@ -1,5 +1,5 @@
 // @flow
-import type { FileValue, I18nValue } from '../../form/types.flow';
+import type { FileValue, I18nValue, I18nRichTextValue } from '../../form/types.flow';
 
 export type ResourceValue = {
   doc: FileValue,
@@ -7,7 +7,7 @@ export type ResourceValue = {
   id: string,
   img: FileValue,
   title: I18nValue,
-  text: I18nValue
+  text: I18nRichTextValue
 };
 
 export type ResourcesValues = {

--- a/assembl/static2/js/app/components/administration/survey/load.js
+++ b/assembl/static2/js/app/components/administration/survey/load.js
@@ -3,9 +3,8 @@ import sortBy from 'lodash/sortBy';
 import type { ApolloClient } from 'react-apollo';
 
 import ThematicsQuery from '../../../graphql/ThematicsQuery.graphql';
-import { convertEntries } from '../../form/utils';
+import { convertEntriesToI18nValue, convertEntriesToI18nRichText } from '../../form/utils';
 import type { FileValue } from '../../form/types.flow';
-import { convertEntriesToRawContentState } from '../../../utils/draftjs';
 import { createRandomId } from '../../../utils/globalFunctions';
 import type { MediaValue, SurveyAdminValues, ThemeValue } from './types.flow';
 
@@ -59,15 +58,15 @@ export function postLoadFormat(data: ThematicsQueryQuery): SurveyAdminValues {
       questions:
         t.questions.map(q => ({
           id: q.id,
-          title: convertEntries(q.titleEntries)
+          title: convertEntriesToI18nValue(q.titleEntries)
         })) || [],
-      title: convertEntries(t.titleEntries),
+      title: convertEntriesToI18nValue(t.titleEntries),
       video: {
         media: t.video ? convertMedia(t.video) : null,
-        title: t.video ? convertEntries(t.video.titleEntries) : {},
-        descriptionBottom: t.video ? convertEntries(convertEntriesToRawContentState(t.video.descriptionEntriesBottom)) : {},
-        descriptionSide: t.video ? convertEntries(convertEntriesToRawContentState(t.video.descriptionEntriesSide)) : {},
-        descriptionTop: t.video ? convertEntries(convertEntriesToRawContentState(t.video.descriptionEntriesTop)) : {}
+        title: t.video ? convertEntriesToI18nValue(t.video.titleEntries) : {},
+        descriptionBottom: t.video ? convertEntriesToI18nRichText(t.video.descriptionEntriesBottom) : {},
+        descriptionSide: t.video ? convertEntriesToI18nRichText(t.video.descriptionEntriesSide) : {},
+        descriptionTop: t.video ? convertEntriesToI18nRichText(t.video.descriptionEntriesTop) : {}
       }
     }))
   };

--- a/assembl/static2/js/app/components/administration/survey/save.js
+++ b/assembl/static2/js/app/components/administration/survey/save.js
@@ -3,12 +3,11 @@ import difference from 'lodash/difference';
 import isEqual from 'lodash/isEqual';
 import type { ApolloClient } from 'react-apollo';
 
-import { convertEntriesToHTML } from '../../../utils/draftjs';
 import type { SurveyAdminValues } from './types.flow';
 import createThematicMutation from '../../../graphql/mutations/createThematic.graphql';
 import deleteThematicMutation from '../../../graphql/mutations/deleteThematic.graphql';
 import updateThematicMutation from '../../../graphql/mutations/updateThematic.graphql';
-import { createSave, convertToEntries, getFileVariable } from '../../form/utils';
+import { createSave, convertToEntries, convertRichTextToEntries, getFileVariable } from '../../form/utils';
 
 function getVideoVariable(video, initialVideo) {
   if (!video) {
@@ -24,9 +23,9 @@ function getVideoVariable(video, initialVideo) {
     htmlCode: video.media ? video.media.htmlCode : '',
     mediaFile: mediaFile,
     titleEntries: video.title ? convertToEntries(video.title) : null,
-    descriptionEntriesBottom: video.descriptionBottom ? convertEntriesToHTML(convertToEntries(video.descriptionBottom)) : null,
-    descriptionEntriesSide: video.descriptionSide ? convertEntriesToHTML(convertToEntries(video.descriptionSide)) : null,
-    descriptionEntriesTop: video.descriptionTop ? convertEntriesToHTML(convertToEntries(video.descriptionTop)) : null
+    descriptionEntriesBottom: video.descriptionBottom ? convertRichTextToEntries(video.descriptionBottom) : null,
+    descriptionEntriesSide: video.descriptionSide ? convertRichTextToEntries(video.descriptionSide) : null,
+    descriptionEntriesTop: video.descriptionTop ? convertRichTextToEntries(video.descriptionTop) : null
   };
   return videoV;
 }

--- a/assembl/static2/js/app/components/administration/survey/types.flow.js
+++ b/assembl/static2/js/app/components/administration/survey/types.flow.js
@@ -1,5 +1,5 @@
 // @flow
-import type { FileValue, I18nValue } from '../../form/types.flow';
+import type { FileValue, I18nValue, I18nRichTextValue } from '../../form/types.flow';
 
 type QuestionValue = {
   id: string,
@@ -14,9 +14,9 @@ export type MediaValue = {|
 type VideoValue = {
   media: ?MediaValue,
   title: I18nValue,
-  descriptionBottom: I18nValue,
-  descriptionSide: I18nValue,
-  descriptionTop: I18nValue
+  descriptionBottom: I18nRichTextValue,
+  descriptionSide: I18nRichTextValue,
+  descriptionTop: I18nRichTextValue
 };
 
 export type ThemeValue = {

--- a/assembl/static2/js/app/components/administration/voteSession/numberGaugeForm.jsx
+++ b/assembl/static2/js/app/components/administration/voteSession/numberGaugeForm.jsx
@@ -25,14 +25,14 @@ const DumbNumberGaugeForm = ({
     <FormGroup>
       <FormControlWithLabel
         onChange={handleMinChange}
-        value={minimum}
+        value={minimum ? minimum.toString() : ''}
         label={I18n.t('administration.minValue')}
         required
         type="number"
       />
       <FormControlWithLabel
         onChange={handleMaxChange}
-        value={maximum}
+        value={maximum ? maximum.toString() : ''}
         label={I18n.t('administration.maxValue')}
         required
         type="number"

--- a/assembl/static2/js/app/components/administration/voteSession/pageForm.jsx
+++ b/assembl/static2/js/app/components/administration/voteSession/pageForm.jsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { Link } from 'react-router';
 import { I18n, Translate } from 'react-redux-i18n';
 import { FormGroup } from 'react-bootstrap';
-import { type RawContentState } from 'draft-js';
+import { type EditorState } from 'draft-js';
 
 import SectionTitle from '../sectionTitle';
 import FormControlWithLabel from '../../common/formControlWithLabel';
@@ -28,7 +28,7 @@ type Props = {
   headerImgUrl: string,
   headerImgMimeType: string,
   instructionsTitle: string,
-  instructionsContent: RawContentState,
+  instructionsContent: EditorState,
   propositionSectionTitle: string,
   editLocale: string,
   handleHeaderTitleChange: Function,
@@ -160,7 +160,7 @@ const mapStateToProps = (state, { editLocale }) => {
     headerTitle: getEntryValueForLocale(voteSession.get('titleEntries'), editLocale),
     headerSubtitle: getEntryValueForLocale(voteSession.get('subTitleEntries'), editLocale),
     instructionsTitle: getEntryValueForLocale(voteSession.get('instructionsSectionTitleEntries'), editLocale),
-    instructionsContent: instructionsContent && typeof instructionsContent !== 'string' ? instructionsContent.toJS() : null,
+    instructionsContent: instructionsContent,
     propositionSectionTitle: getEntryValueForLocale(voteSession.get('propositionsSectionTitleEntries'), editLocale),
     headerImgUrl: voteSession.getIn(['headerImage', 'externalUrl']),
     headerImgMimeType: voteSession.getIn(['headerImage', 'mimeType'])

--- a/assembl/static2/js/app/components/administration/voteSession/pageForm.jsx
+++ b/assembl/static2/js/app/components/administration/voteSession/pageForm.jsx
@@ -22,7 +22,7 @@ import {
 import { getDiscussionSlug } from '../../../utils/globalFunctions';
 import { get } from '../../../utils/routeMap';
 
-type PageFormProps = {
+type Props = {
   headerTitle: string,
   headerSubtitle: string,
   headerImgUrl: string,
@@ -54,7 +54,7 @@ const DumbPageForm = ({
   handleInstructionsTitleChange,
   handleInstructionsContentChange,
   handlePropositionSectionTitleChange
-}: PageFormProps) => {
+}: Props) => {
   const editLocaleInUppercase = editLocale.toUpperCase();
   const headerTitlePh = `${I18n.t('administration.ph.headerTitle')} ${editLocaleInUppercase}`;
   const headerSubtitlePh = `${I18n.t('administration.ph.headerSubtitle')} ${editLocaleInUppercase}`;

--- a/assembl/static2/js/app/components/administration/voteSession/tokenCategoryForm.jsx
+++ b/assembl/static2/js/app/components/administration/voteSession/tokenCategoryForm.jsx
@@ -50,7 +50,7 @@ const DumbTokenCategoryForm = ({
         required
         type="number"
         onChange={handleNumberChange}
-        value={totalNumber}
+        value={totalNumber.toString()}
         formControlProps={{
           min: '1'
         }}

--- a/assembl/static2/js/app/components/administration/voteSession/voteProposalForm.jsx
+++ b/assembl/static2/js/app/components/administration/voteSession/voteProposalForm.jsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { I18n, Translate } from 'react-redux-i18n';
 import { OverlayTrigger, Button, Checkbox, FormGroup, HelpBlock } from 'react-bootstrap';
-import { type RawContentState } from 'draft-js';
+import { EditorState } from 'draft-js';
 
 import FormControlWithLabel from '../../common/formControlWithLabel';
 import { getEntryValueForLocale } from '../../../utils/i18n';
@@ -20,14 +20,14 @@ import {
   undeleteModule
 } from '../../../actions/adminActions/voteSession';
 import { displayCustomModal, displayModal, closeModal } from '../../../utils/utilityManager';
-import { rawContentStateIsEmpty } from '../../../utils/draftjs';
+import { editorStateIsEmpty } from '../../../utils/draftjs';
 import { createRandomId } from '../../../utils/globalFunctions';
 import CustomizeGaugeForm from './customizeGaugeForm';
 
 type VoteProposalFormProps = {
   index: number,
   title: string,
-  description: RawContentState,
+  description: EditorState,
   _toDelete: boolean,
   markAsToDelete: Function,
   updateTitle: Function,
@@ -115,7 +115,7 @@ const DumbVoteProposalForm = ({
 
   const isTitleEmpty = title === '' || title === null;
 
-  const isDescriptionEmpty = description === null || rawContentStateIsEmpty(description);
+  const isDescriptionEmpty = description === null || editorStateIsEmpty(description);
   const areFieldsEmpty = isDescriptionEmpty && isTitleEmpty;
 
   return (
@@ -250,7 +250,7 @@ const mapStateToProps = ({ admin }, { id, editLocale }) => {
     _toDelete: proposal.get('_toDelete', false),
     validationErrors: proposal.get('_validationErrors'),
     title: getEntryValueForLocale(proposal.get('titleEntries'), editLocale),
-    description: description && typeof description !== 'string' ? description.toJS() : null,
+    description: description || EditorState.createEmpty(),
     order: proposal.get('order'),
     proposalModules: proposal.get('modules').map(moduleId => modulesById.get(moduleId)),
     tokenModules: modulesInOrder.filter(

--- a/assembl/static2/js/app/components/common/formControlWithLabel.jsx
+++ b/assembl/static2/js/app/components/common/formControlWithLabel.jsx
@@ -8,14 +8,14 @@
 import * as React from 'react';
 import { ControlLabel, FormGroup, FormControl, HelpBlock } from 'react-bootstrap';
 import { I18n } from 'react-redux-i18n';
-import { type RawContentState } from 'draft-js';
+import { EditorState } from 'draft-js';
 
 import RichTextEditor from './richTextEditor';
 import { getValidationState } from '../administration/voteSession/voteProposalForm';
 import Helper from './helper';
 
 type FormControlWithLabelProps = {
-  value: ?(string | RawContentState),
+  value: ?(string | EditorState),
   required: boolean,
   onChange: Function,
   type: string,
@@ -82,7 +82,14 @@ class FormControlWithLabel extends React.Component<FormControlWithLabelProps, Fo
     const { value, required } = this.props;
     let errorMessage = '';
     let validationState = null;
-    const valueSize = value ? value.length : 0;
+    let valueSize = 0;
+    if (value) {
+      if (typeof value === 'string') {
+        valueSize = value.length;
+      } else {
+        valueSize = value.getCurrentContent().getPlainText().length;
+      }
+    }
     if (required && valueSize === 0) {
       errorMessage = I18n.t('error.required');
       validationState = 'error';
@@ -98,14 +105,13 @@ class FormControlWithLabel extends React.Component<FormControlWithLabelProps, Fo
 
   renderRichTextEditor = () => {
     const { onChange, value } = this.props;
-    const key = value ? 'notEmpty' : 'empty';
+    const editorState = (typeof value !== 'string' && value) || EditorState.createEmpty();
     return (
       <RichTextEditor
-        key={key}
-        rawContentState={value}
+        editorState={editorState}
         placeholder={this.getLabel()}
         toolbarPosition="bottom"
-        updateContentState={cs => onChange(cs)}
+        onChange={onChange}
         withAttachmentButton={false}
       />
     );

--- a/assembl/static2/js/app/components/common/formControlWithLabel.jsx
+++ b/assembl/static2/js/app/components/common/formControlWithLabel.jsx
@@ -105,16 +105,21 @@ class FormControlWithLabel extends React.Component<FormControlWithLabelProps, Fo
 
   renderRichTextEditor = () => {
     const { onChange, value } = this.props;
-    const editorState = (typeof value !== 'string' && value) || EditorState.createEmpty();
-    return (
-      <RichTextEditor
-        editorState={editorState}
-        placeholder={this.getLabel()}
-        toolbarPosition="bottom"
-        onChange={onChange}
-        withAttachmentButton={false}
-      />
-    );
+    if (typeof value !== 'string') {
+      const editorState = value || EditorState.createEmpty();
+      return (
+        <RichTextEditor
+          editorState={editorState}
+          placeholder={this.getLabel()}
+          toolbarPosition="bottom"
+          onChange={onChange}
+          withAttachmentButton={false}
+        />
+      );
+    }
+
+    // don't render a RichTextEditor if value is a string
+    return null;
   };
 
   renderFormControl = () => {

--- a/assembl/static2/js/app/components/common/richTextEditor/atomicBlockRenderer.jsx
+++ b/assembl/static2/js/app/components/common/richTextEditor/atomicBlockRenderer.jsx
@@ -20,7 +20,7 @@ const AtomicBlockRenderer = ({ block, contentState }: { block: ContentBlock, con
     }
 
     return (
-      <div className="atomic-block" data-blockType="atomic">
+      <div className="atomic-block" data-blocktype="atomic">
         {innerContent}
       </div>
     );

--- a/assembl/static2/js/app/components/common/richTextEditor/buttonConfigType.jsx
+++ b/assembl/static2/js/app/components/common/richTextEditor/buttonConfigType.jsx
@@ -1,10 +1,8 @@
 // @flow
-import { DraftBlockType, DraftInlineStyle } from 'draft-js';
-
 export type ButtonConfigType = {
   icon: string,
   id: string,
   label: string,
-  style?: DraftBlockType | DraftInlineStyle,
+  style?: string,
   type: 'block-type' | 'style' | 'insert-component'
 };

--- a/assembl/static2/js/app/components/common/richTextEditor/index.jsx
+++ b/assembl/static2/js/app/components/common/richTextEditor/index.jsx
@@ -9,10 +9,9 @@
 
 import * as React from 'react';
 import { Translate, I18n } from 'react-redux-i18n';
-import { convertFromRaw, convertToRaw, Editor, EditorState, RawContentState, RichUtils } from 'draft-js';
+import { Editor, EditorState, RichUtils } from 'draft-js';
 import classNames from 'classnames';
 import punycode from 'punycode';
-import throttle from 'lodash/throttle';
 
 import AtomicBlockRenderer from './atomicBlockRenderer';
 import Toolbar from './toolbar';
@@ -20,20 +19,18 @@ import type { ButtonConfigType } from './buttonConfigType';
 import EditAttachments from '../editAttachments';
 import attachmentsPlugin from './attachmentsPlugin';
 
-type RichTextEditorProps = {
-  rawContentState: RawContentState,
+type Props = {
+  editorState: EditorState,
   handleInputFocus?: Function,
   maxLength: number,
+  onChange: Function,
   placeholder?: string,
   textareaRef?: Function,
   toolbarPosition: string,
-  updateContentState: Function,
-  withAttachmentButton: boolean,
-  handleCharCountChange: Function
+  withAttachmentButton: boolean
 };
 
 type RichTextEditorState = {
-  editorState: EditorState,
   editorHasFocus: boolean
 };
 
@@ -48,53 +45,22 @@ function customBlockRenderer(block) {
   return null;
 }
 
-export default class RichTextEditor extends React.Component<RichTextEditorProps, RichTextEditorState> {
-  editor: ?HTMLDivElement;
+export default class RichTextEditor extends React.Component<Props, RichTextEditorState> {
+  editor: ?Editor;
 
   static defaultProps = {
     handleInputFocus: undefined,
     maxLength: 0,
     toolbarPosition: 'top',
-    withAttachmentButton: false,
-    handleCharCountChange: () => {}
+    withAttachmentButton: false
   };
 
-  constructor(props: RichTextEditorProps): void {
+  constructor(props: Props): void {
     super(props);
-    const editorState = props.rawContentState
-      ? EditorState.createWithContent(convertFromRaw(props.rawContentState))
-      : EditorState.createEmpty();
     this.state = {
-      editorState: editorState,
       editorHasFocus: false
     };
   }
-
-  getCurrentRawContentState = () => convertToRaw(this.state.editorState.getCurrentContent());
-
-  onBlur = () => {
-    this.setState(
-      {
-        editorHasFocus: false
-      },
-      () => {
-        this.props.updateContentState(this.getCurrentRawContentState());
-      }
-    );
-  };
-
-  onChange = (newEditorState: EditorState): void => {
-    this.setState(
-      {
-        editorState: newEditorState
-      },
-      throttle(() => {
-        this.props.updateContentState(this.getCurrentRawContentState());
-        const charCount = this.getCharCount(newEditorState);
-        this.props.handleCharCountChange(charCount);
-      }, 300)
-    );
-  };
 
   handleEditorFocus = (): void => {
     const { handleInputFocus } = this.props;
@@ -143,7 +109,7 @@ export default class RichTextEditor extends React.Component<RichTextEditorProps,
 
   shouldHidePlaceholder(): boolean {
     // don't display placeholder if user changes the block type (to bullet list) before to type anything
-    const contentState = this.state.editorState.getCurrentContent();
+    const contentState = this.props.editorState.getCurrentContent();
     if (!contentState.hasText()) {
       if (
         contentState
@@ -168,8 +134,7 @@ export default class RichTextEditor extends React.Component<RichTextEditorProps,
   };
 
   renderRemainingChars = (): React.Element<any> => {
-    const { maxLength } = this.props;
-    const editorState = this.state.editorState;
+    const { editorState, maxLength } = this.props;
     const charCount = this.getCharCount(editorState);
     const remainingChars = maxLength - charCount;
     return (
@@ -179,55 +144,46 @@ export default class RichTextEditor extends React.Component<RichTextEditorProps,
     );
   };
 
-  handleReturn = (e: KeyboardEvent): string => {
+  handleReturn = (e: SyntheticKeyboardEvent<*>): 'handled' | 'not-handled' => {
     // Pressing shift-enter keys creates a new line (<br/>) instead of an new paragraph (<p>)
     // See https://github.com/HubSpot/draft-convert/issues/83
     // For example, this enables to create line returns inside a list item.
-    const { editorState } = this.state;
+    const { editorState, onChange } = this.props;
     if (e.shiftKey) {
-      this.setState({ editorState: RichUtils.insertSoftNewline(editorState) });
+      onChange(RichUtils.insertSoftNewline(editorState));
       return 'handled';
     }
     return 'not-handled';
   };
 
   deleteAttachment = (documentId: string): void => {
-    const contentState = this.state.editorState.getCurrentContent();
+    const { editorState, onChange } = this.props;
+    const contentState = editorState.getCurrentContent();
     const newContentState = attachmentsPlugin.removeAttachment(contentState, documentId);
-    this.setState(
-      {
-        editorState: EditorState.createWithContent(newContentState)
-      },
-      () => {
-        this.props.updateContentState(convertToRaw(newContentState));
-      }
-    );
+    onChange(EditorState.createWithContent(newContentState));
   };
 
   renderToolbar = () => {
-    const withAttachmentButton = this.props.withAttachmentButton;
+    const { editorState, onChange, withAttachmentButton } = this.props;
     return (
       <Toolbar
         buttonsConfig={this.getToolbarButtons()}
-        editorState={this.state.editorState}
+        editorState={editorState}
         focusEditor={this.focusEditor}
-        onChange={this.onChange}
+        onChange={onChange}
         withAttachmentButton={withAttachmentButton}
       />
     );
   };
 
   render() {
-    const { maxLength, placeholder, textareaRef, toolbarPosition } = this.props;
-    const { editorState } = this.state;
+    const { editorState, maxLength, onChange, placeholder, textareaRef, toolbarPosition } = this.props;
     const divClassName = classNames('rich-text-editor', { hidePlaceholder: this.shouldHidePlaceholder() });
-    const attachments = attachmentsPlugin.getAttachments(this.getCurrentRawContentState());
+    const attachments = attachmentsPlugin.getAttachments(editorState);
     return (
       <div className={divClassName} ref={textareaRef}>
         <div className="editor-header">
-          {this.state.editorState.getCurrentContent().hasText() ? (
-            <div className="editor-label form-label">{placeholder}</div>
-          ) : null}
+          {editorState.getCurrentContent().hasText() ? <div className="editor-label form-label">{placeholder}</div> : null}
           {toolbarPosition === 'top' ? this.renderToolbar() : null}
           <div className="clear" />
         </div>
@@ -235,8 +191,7 @@ export default class RichTextEditor extends React.Component<RichTextEditorProps,
           <Editor
             blockRendererFn={customBlockRenderer}
             editorState={editorState}
-            onBlur={this.onBlur}
-            onChange={this.onChange}
+            onChange={onChange}
             onFocus={this.handleEditorFocus}
             placeholder={placeholder}
             ref={(e) => {

--- a/assembl/static2/js/app/components/common/richTextEditor/toolbar.jsx
+++ b/assembl/static2/js/app/components/common/richTextEditor/toolbar.jsx
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react';
 import { graphql } from 'react-apollo';
-import { AtomicBlockUtils, DraftBlockType, DraftInlineStyle, RichUtils } from 'draft-js';
+import { AtomicBlockUtils, RichUtils } from 'draft-js';
 import { I18n } from 'react-redux-i18n';
 
 import uploadDocumentMutation from '../../../graphql/mutations/uploadDocument.graphql';
@@ -25,9 +25,9 @@ type ToolbarState = {
 };
 
 class Toolbar extends React.Component<ToolbarProps, ToolbarState> {
-  currentStyle: DraftInlineStyle;
+  currentStyle: string;
 
-  currentBlockType: DraftBlockType;
+  currentBlockType: string;
 
   constructor() {
     super();
@@ -43,7 +43,7 @@ class Toolbar extends React.Component<ToolbarProps, ToolbarState> {
     });
   };
 
-  getCurrentBlockType(): DraftBlockType {
+  getCurrentBlockType(): string {
     const { editorState } = this.props;
     const selection = editorState.getSelection();
     return editorState
@@ -52,7 +52,7 @@ class Toolbar extends React.Component<ToolbarProps, ToolbarState> {
       .getType();
   }
 
-  toggleBlockType(blockType: DraftBlockType): void {
+  toggleBlockType(blockType: string): void {
     const { editorState, focusEditor, onChange } = this.props;
     onChange(RichUtils.toggleBlockType(editorState, blockType));
     focusEditor();
@@ -69,6 +69,7 @@ class Toolbar extends React.Component<ToolbarProps, ToolbarState> {
     let onToggle;
     switch (config.type) {
     case 'style': {
+      // $FlowFixMe
       isActive = this.currentStyle.contains(config.style);
       onToggle = () => {
         if (config.style) {
@@ -81,7 +82,7 @@ class Toolbar extends React.Component<ToolbarProps, ToolbarState> {
     }
     case 'block-type': {
       isActive = config.style === this.currentBlockType;
-      onToggle = () => this.toggleBlockType(config.style);
+      onToggle = () => this.toggleBlockType(config.style || '');
       break;
     }
     default:

--- a/assembl/static2/js/app/components/debate/common/editPostForm.jsx
+++ b/assembl/static2/js/app/components/debate/common/editPostForm.jsx
@@ -3,13 +3,13 @@ import * as React from 'react';
 import { compose, graphql, withApollo } from 'react-apollo';
 import { Row, Col, FormGroup, Button } from 'react-bootstrap';
 import { Translate, I18n } from 'react-redux-i18n';
-import { RawContentState } from 'draft-js';
+import { EditorState } from 'draft-js';
 
 import uploadDocumentMutation from '../../../graphql/mutations/uploadDocument.graphql';
 import updatePostMutation from '../../../graphql/mutations/updatePost.graphql';
 import { displayAlert, inviteUserToLogin } from '../../../utils/utilityManager';
 import { getConnectedUserId } from '../../../utils/globalFunctions';
-import { convertToRawContentState, convertRawContentStateToHTML, rawContentStateIsEmpty } from '../../../utils/draftjs';
+import { convertToEditorState, convertContentStateToHTML, editorStateIsEmpty } from '../../../utils/draftjs';
 import RichTextEditor from '../../common/richTextEditor';
 import attachmentsPlugin from '../../common/richTextEditor/attachmentsPlugin';
 import type { UploadNewAttachmentsPromiseResult } from '../../common/richTextEditor/attachmentsPlugin';
@@ -31,7 +31,7 @@ type EditPostFormProps = {
 
 type EditPostFormState = {
   subject: string,
-  body: RawContentState
+  body: EditorState
 };
 
 class EditPostForm extends React.PureComponent<EditPostFormProps, EditPostFormState> {
@@ -40,7 +40,7 @@ class EditPostForm extends React.PureComponent<EditPostFormProps, EditPostFormSt
     const { subject } = props;
     const body = props.body || '';
     this.state = {
-      body: convertToRawContentState(body),
+      body: convertToEditorState(body),
       subject: subject
     };
   }
@@ -49,7 +49,7 @@ class EditPostForm extends React.PureComponent<EditPostFormProps, EditPostFormSt
     this.setState({ subject: e.target.value });
   };
 
-  updateBody = (rawBody: RawContentState): void => {
+  updateBody = (rawBody: EditorState): void => {
     this.setState({ body: rawBody });
   };
 
@@ -68,7 +68,7 @@ class EditPostForm extends React.PureComponent<EditPostFormProps, EditPostFormSt
     const { uploadDocument, updatePost } = this.props;
     const { body } = this.state;
     const subjectIsEmpty = this.state.subject && this.state.subject.length === 0;
-    const bodyIsEmpty = rawContentStateIsEmpty(body);
+    const bodyIsEmpty = editorStateIsEmpty(body);
     if (!subjectIsEmpty && !bodyIsEmpty) {
       // first we upload the new documents
       const uploadDocumentsPromise = attachmentsPlugin.uploadNewAttachments(body, uploadDocument);
@@ -81,7 +81,7 @@ class EditPostForm extends React.PureComponent<EditPostFormProps, EditPostFormSt
           contentLocale: this.props.originalLocale,
           postId: this.props.id,
           subject: this.state.subject || '',
-          body: convertRawContentStateToHTML(result.contentState),
+          body: convertContentStateToHTML(result.contentState),
           attachments: result.documentIds
         };
         displayAlert('success', I18n.t('loading.wait'));
@@ -139,9 +139,9 @@ class EditPostForm extends React.PureComponent<EditPostFormProps, EditPostFormSt
               ))}
             <FormGroup>
               <RichTextEditor
-                rawContentState={this.state.body}
+                editorState={this.state.body}
                 placeholder={I18n.t('debate.edit.body')}
-                updateContentState={this.updateBody}
+                onChange={this.updateBody}
                 maxLength={TEXT_AREA_MAX_LENGTH}
                 withAttachmentButton
               />

--- a/assembl/static2/js/app/components/debate/survey/question.jsx
+++ b/assembl/static2/js/app/components/debate/survey/question.jsx
@@ -83,8 +83,9 @@ class Question extends React.Component<QuestionProps, QuestionState> {
   };
 
   getPostBodyCharCount = () => {
-    if (this.state.postBody) {
-      return this.state.postBody.getCurrentContent().getPlainText().length;
+    const { postBody } = this.state;
+    if (postBody) {
+      return postBody.getCurrentContent().getPlainText().length;
     }
 
     return 0;

--- a/assembl/static2/js/app/components/debate/survey/question.jsx
+++ b/assembl/static2/js/app/components/debate/survey/question.jsx
@@ -4,6 +4,7 @@ import { graphql, compose } from 'react-apollo';
 import { connect } from 'react-redux';
 import { Translate, I18n } from 'react-redux-i18n';
 import { Grid, Col, Button } from 'react-bootstrap';
+import { EditorState } from 'draft-js';
 
 import { getConnectedUserId } from '../../../utils/globalFunctions';
 import { getIfPhaseCompletedByIdentifier } from '../../../utils/timeline';
@@ -12,7 +13,7 @@ import createPostMutation from '../../../graphql/mutations/createPost.graphql';
 import { SMALL_SCREEN_WIDTH, MINIMUM_BODY_LENGTH } from '../../../constants';
 import { withScreenDimensions } from '../../common/screenDimensions';
 import RichTextEditor from '../../common/richTextEditor';
-import { convertRawContentStateToHTML } from '../../../utils/draftjs';
+import { convertEditorStateToHTML } from '../../../utils/draftjs';
 
 type QuestionProps = {
   title: string,
@@ -29,8 +30,7 @@ type QuestionProps = {
 
 type QuestionState = {
   buttonDisabled: boolean,
-  postBody: ?string,
-  charCount: number
+  postBody: EditorState
 };
 
 class Question extends React.Component<QuestionProps, QuestionState> {
@@ -38,8 +38,7 @@ class Question extends React.Component<QuestionProps, QuestionState> {
     super(props);
     this.state = {
       buttonDisabled: false,
-      postBody: '',
-      charCount: 0
+      postBody: EditorState.createEmpty()
     };
   }
 
@@ -48,13 +47,13 @@ class Question extends React.Component<QuestionProps, QuestionState> {
     const body = this.state.postBody;
     this.setState({ buttonDisabled: true }, () =>
       this.props
-        .mutate({ variables: { contentLocale: contentLocale, ideaId: questionId, body: convertRawContentStateToHTML(body) } })
+        .mutate({ variables: { contentLocale: contentLocale, ideaId: questionId, body: convertEditorStateToHTML(body) } })
         .then(() => {
           scrollToQuestion(true, index + 1);
           displayAlert('success', I18n.t('debate.survey.postSuccess'));
           refetchTheme();
           this.setState({
-            postBody: null,
+            postBody: EditorState.createEmpty(),
             buttonDisabled: false
           });
         })
@@ -83,8 +82,12 @@ class Question extends React.Component<QuestionProps, QuestionState> {
     }
   };
 
-  updateCharCount = (newValue) => {
-    this.setState({ charCount: newValue });
+  getPostBodyCharCount = () => {
+    if (this.state.postBody) {
+      return this.state.postBody.getCurrentContent().getPlainText().length;
+    }
+
+    return 0;
   };
 
   render() {
@@ -111,14 +114,13 @@ class Question extends React.Component<QuestionProps, QuestionState> {
             </div>
             <Col xs={12} md={9} className="col-centered">
               <RichTextEditor
-                rawContentState={this.state.postBody}
+                editorState={this.state.postBody}
                 maxLength={1000}
+                onChange={this.updateBody}
                 placeHolder={I18n.t('debate.survey.txtAreaPh')}
-                updateContentState={this.updateBody}
                 handleInputFocus={this.redirectToLogin}
-                handleCharCountChange={this.updateCharCount}
               />
-              {this.state.charCount > MINIMUM_BODY_LENGTH && (
+              {this.getPostBodyCharCount() > MINIMUM_BODY_LENGTH && (
                 <Button
                   onClick={this.createPost}
                   disabled={this.state.buttonDisabled}

--- a/assembl/static2/js/app/components/form/multilingualRichTextFieldAdapter.jsx
+++ b/assembl/static2/js/app/components/form/multilingualRichTextFieldAdapter.jsx
@@ -1,4 +1,5 @@
 // @flow
+import { EditorState } from 'draft-js';
 import React from 'react';
 import { type FieldRenderProps } from 'react-final-form';
 import { ControlLabel, FormGroup } from 'react-bootstrap';
@@ -7,7 +8,7 @@ import RichTextEditor from '../common/richTextEditor';
 import Error from './error';
 import { getValidationState } from './utils';
 
-type multilingualValue = { [string]: string };
+type multilingualValue = { [string]: EditorState };
 
 type Props = {
   editLocale: string,
@@ -23,24 +24,22 @@ type Props = {
 
 const RichTextFieldAdapter = ({
   editLocale,
-  input: { name, onChange, value, ...otherListeners },
+  input: { name, onBlur, onChange, value, ...otherListeners },
   label,
   meta: { error, touched },
   ...rest
 }: Props) => {
-  const valueInLocale = value[editLocale] || null;
-  const key = valueInLocale ? 'notEmpty' : 'empty';
+  const valueInLocale = value[editLocale] || EditorState.createEmpty();
   return (
     <FormGroup controlId={name} validationState={getValidationState(error, touched)}>
       {valueInLocale ? <ControlLabel>{label}</ControlLabel> : null}
       <RichTextEditor
         {...otherListeners}
         {...rest}
-        key={key}
-        rawContentState={valueInLocale}
+        editorState={valueInLocale}
         placeholder={label}
         toolbarPosition="bottom"
-        updateContentState={cs => onChange({ ...value, [editLocale]: cs })}
+        onChange={es => onChange({ ...value, [editLocale]: es })}
         withAttachmentButton={false}
       />
       <Error name={name} />

--- a/assembl/static2/js/app/components/form/types.flow.js
+++ b/assembl/static2/js/app/components/form/types.flow.js
@@ -1,13 +1,26 @@
 // @flow
+import { EditorState } from 'draft-js';
+
 export type I18nValue = { [string]: string };
+export type I18nRichTextValue = { [string]: EditorState };
 
-export type FileValue = ?{
-  externalUrl: ?string,
-  mimeType: ?string,
-  title: ?string
-};
+// file value for storage in react-final-form state
+export type FileValue =
+  | null
+  | string
+  | {
+      externalUrl: ?File,
+      mimeType: ?string,
+      title: ?string
+    }
+  | {
+      externalUrl: ?string,
+      mimeType: ?string,
+      title: ?string
+    };
 
-export type FileVariable = string | FileValue | null;
+// file variable sent to mutations
+export type FileVariable = null | 'TO_DELETE' | File;
 
 export type MutationsPromises = Array<() => Promise<*>>;
 

--- a/assembl/static2/js/app/pages/administration.jsx
+++ b/assembl/static2/js/app/pages/administration.jsx
@@ -21,7 +21,7 @@ import LegalContentsQuery from '../graphql/LegalContents.graphql';
 import VoteSessionQuery from '../graphql/VoteSession.graphql';
 import LandingPageQuery from '../graphql/LandingPage.graphql';
 import TimelineQuery from '../graphql/Timeline.graphql';
-import { convertEntriesToRawContentState } from '../utils/draftjs';
+import { convertEntriesToEditorState } from '../utils/draftjs';
 import { getPhaseId } from '../utils/timeline';
 import landingPagePlugin from '../utils/administration/landingPage';
 
@@ -108,7 +108,7 @@ class Administration extends React.Component {
     const voteSessionForStore = {
       ...filteredVoteSession.voteSession,
       instructionsSectionContentEntries: filteredVoteSession.voteSession.instructionsSectionContentEntries
-        ? convertEntriesToRawContentState(filteredVoteSession.voteSession.instructionsSectionContentEntries)
+        ? convertEntriesToEditorState(filteredVoteSession.voteSession.instructionsSectionContentEntries)
         : null
     };
     this.props.updateVoteSessionPage(voteSessionForStore);
@@ -137,7 +137,7 @@ class Administration extends React.Component {
     const proposals = voteSession ? filter(VoteSessionQuery, { voteSession: voteSession }).voteSession.proposals : [];
     const proposalsForStore = proposals.map(proposal => ({
       ...proposal,
-      descriptionEntries: proposal.descriptionEntries ? convertEntriesToRawContentState(proposal.descriptionEntries) : null
+      descriptionEntries: proposal.descriptionEntries ? convertEntriesToEditorState(proposal.descriptionEntries) : null
     }));
     this.props.updateVoteProposals(proposalsForStore);
   }
@@ -171,7 +171,7 @@ class Administration extends React.Component {
       const dataForStore = {
         ...filtered.discussion,
         subtitleEntries: filtered.discussion.subtitleEntries
-          ? convertEntriesToRawContentState(filtered.discussion.subtitleEntries)
+          ? convertEntriesToEditorState(filtered.discussion.subtitleEntries)
           : null
       };
       this.props.updateLandingPage(dataForStore);

--- a/assembl/static2/js/app/pages/voteSessionAdmin.jsx
+++ b/assembl/static2/js/app/pages/voteSessionAdmin.jsx
@@ -157,7 +157,7 @@ export const createVariablesForProposalsMutation = (proposal: VoteProposal): Var
   descriptionEntries: convertEntriesToHTML(proposal.descriptionEntries)
 });
 
-type VoteSessionAdminProps = {
+type Props = {
   editLocale: string,
   i18n: {
     locale: string
@@ -187,7 +187,7 @@ type VoteSessionAdminProps = {
   router: Router
 };
 
-type VoteSessionAdminState = {
+type State = {
   firstWarningDisplayed: boolean,
   secondWarningDisplayed: boolean,
   refetching: boolean
@@ -216,8 +216,8 @@ export const getProposalValidationErrors = (p: VoteProposalMap, editLocale: stri
   return errors;
 };
 
-class VoteSessionAdmin extends React.Component<VoteSessionAdminProps, VoteSessionAdminState> {
-  constructor(props: VoteSessionAdminProps) {
+class VoteSessionAdmin extends React.Component<Props, State> {
+  constructor(props: Props) {
     super(props);
     this.state = {
       firstWarningDisplayed: false,

--- a/assembl/static2/js/app/pages/voteSessionAdmin.jsx
+++ b/assembl/static2/js/app/pages/voteSessionAdmin.jsx
@@ -26,7 +26,7 @@ import updateNumberGaugeVoteSpecificationMutation from '../graphql/mutations/upd
 import createProposalMutation from '../graphql/mutations/createProposal.graphql';
 import updateProposalMutation from '../graphql/mutations/updateProposal.graphql';
 import deleteProposalMutation from '../graphql/mutations/deleteProposal.graphql';
-import { convertEntriesToHTML } from '../utils/draftjs';
+import { convertEntriesToHTML, convertImmutableEntriesToJS } from '../utils/draftjs';
 import { getPhaseId } from '../utils/timeline';
 import { get } from '../utils/routeMap';
 import { displayAlert, displayCustomModal, closeModal } from '../utils/utilityManager';
@@ -341,7 +341,9 @@ class VoteSessionAdmin extends React.Component<Props, State> {
       const titleEntries = voteSessionPage.get('titleEntries').toJS();
       const subTitleEntries = voteSessionPage.get('subTitleEntries').toJS();
       const instructionsSectionTitleEntries = voteSessionPage.get('instructionsSectionTitleEntries').toJS();
-      const instructionsSectionContentEntries = voteSessionPage.get('instructionsSectionContentEntries').toJS();
+      const instructionsSectionContentEntries = convertImmutableEntriesToJS(
+        voteSessionPage.get('instructionsSectionContentEntries')
+      );
       const propositionsSectionTitleEntries = voteSessionPage.get('propositionsSectionTitleEntries').toJS();
       const pageHeaderImage = voteSessionPage.get('headerImage').toJS();
       const headerImage = typeof pageHeaderImage.externalUrl === 'object' ? pageHeaderImage.externalUrl : null;
@@ -434,8 +436,12 @@ class VoteSessionAdmin extends React.Component<Props, State> {
         }
 
         const items = [];
-        voteProposals.forEach((t) => {
-          items.push({ ...t.toJS(), voteSessionId: voteSessionPageId });
+        voteProposals.forEach((vp) => {
+          items.push({
+            ...vp.toJS(),
+            descriptionEntries: convertImmutableEntriesToJS(vp.get('descriptionEntries')),
+            voteSessionId: voteSessionPageId
+          });
         });
         const proposalsToDeleteOrUpdate = items.filter(item => !item._isNew);
         let mutationsPromises: Array<() => Promise<*>> = [];
@@ -569,7 +575,7 @@ const mapStateToProps = ({ admin: { editLocale, voteSession }, i18n, context, ti
     voteModules: voteModules,
     voteSessionPage: voteSession.page,
     debateId: context.debateId,
-    voteSessionId: page.toJS().id,
+    voteSessionId: page.get('id'),
     voteProposals: voteProposalsById
       .map((proposal) => {
         const pModules = proposal

--- a/assembl/static2/js/app/reducers/adminReducer/landingPage.js
+++ b/assembl/static2/js/app/reducers/adminReducer/landingPage.js
@@ -185,7 +185,7 @@ export const page: LandingPageReducer = (state = initialPage, action) => {
     }
     newState = newState
       .set('titleEntries', fromJS(action.page.titleEntries))
-      .set('subtitleEntries', fromJS(action.page.subtitleEntries))
+      .set('subtitleEntries', List(action.page.subtitleEntries.map(entry => Map(entry))))
       .set('buttonLabelEntries', fromJS(action.page.buttonLabelEntries));
     return newState.set('_hasChanged', false);
   }
@@ -194,9 +194,7 @@ export const page: LandingPageReducer = (state = initialPage, action) => {
       .update('titleEntries', updateInLangstringEntries(action.locale, fromJS(action.value)))
       .set('_hasChanged', true);
   case UPDATE_LANDING_PAGE_HEADER_SUBTITLE:
-    return state
-      .update('subtitleEntries', updateInLangstringEntries(action.locale, fromJS(action.value)))
-      .set('_hasChanged', true);
+    return state.update('subtitleEntries', updateInLangstringEntries(action.locale, action.value)).set('_hasChanged', true);
   case UPDATE_LANDING_PAGE_HEADER_BUTTON_LABEL:
     return state
       .update('buttonLabelEntries', updateInLangstringEntries(action.locale, fromJS(action.value)))

--- a/assembl/static2/js/app/reducers/adminReducer/voteSession.js
+++ b/assembl/static2/js/app/reducers/adminReducer/voteSession.js
@@ -85,7 +85,7 @@ export const voteSessionPage: VoteSessionPageReducer = (state = initialPage, act
       .set('_hasChanged', true);
   case UPDATE_VOTE_SESSION_PAGE_INSTRUCTIONS_CONTENT:
     return state
-      .update('instructionsSectionContentEntries', updateInLangstringEntries(action.locale, fromJS(action.value)))
+      .update('instructionsSectionContentEntries', updateInLangstringEntries(action.locale, action.value))
       .set('_hasChanged', true);
   case UPDATE_VOTE_SESSION_PAGE_PROPOSITIONS_TITLE:
     return state
@@ -112,7 +112,7 @@ export const voteSessionPage: VoteSessionPageReducer = (state = initialPage, act
       seeCurrentVotes: action.seeCurrentVotes,
       subTitleEntries: fromJS(action.subTitleEntries),
       instructionsSectionTitleEntries: fromJS(action.instructionsSectionTitleEntries),
-      instructionsSectionContentEntries: fromJS(action.instructionsSectionContentEntries),
+      instructionsSectionContentEntries: List(action.instructionsSectionContentEntries.map(entry => Map(entry))),
       propositionsSectionTitleEntries: fromJS(action.propositionsSectionTitleEntries),
       headerImage: headerImage
     });
@@ -506,16 +506,18 @@ export const voteProposalsById = (state: Map<string, Map> = Map(), action: Redux
   case UPDATE_VOTE_PROPOSALS: {
     let newState = Map();
     action.voteProposals.forEach((proposal) => {
-      const proposalInfo = fromJS({
+      const proposalInfo = Map({
         _isNew: false,
         _toDelete: false,
         _hasChanged: false,
-        _validationErrors: [],
+        _validationErrors: List(),
         order: proposal.order,
         id: proposal.id,
-        titleEntries: proposal.titleEntries,
-        descriptionEntries: proposal.descriptionEntries,
-        modules: proposal.modules ? proposal.modules.map(m => m.id) : []
+        titleEntries: fromJS(proposal.titleEntries),
+        descriptionEntries: List(proposal.descriptionEntries.map(
+          entry => Map(entry)
+        )),
+        modules: fromJS(proposal.modules ? proposal.modules.map(m => m.id) : [])
       });
       newState = newState.set(proposal.id, proposalInfo);
     });
@@ -541,7 +543,7 @@ export const voteProposalsById = (state: Map<string, Map> = Map(), action: Redux
       .setIn([action.id, '_hasChanged'], true);
   case UPDATE_VOTE_PROPOSAL_DESCRIPTION:
     return state
-      .updateIn([action.id, 'descriptionEntries'], updateInLangstringEntries(action.locale, fromJS(action.value)))
+      .updateIn([action.id, 'descriptionEntries'], updateInLangstringEntries(action.locale, action.value))
       .setIn([action.id, '_hasChanged'], true);
   case ADD_MODULE_TO_PROPOSAL:
     return state

--- a/assembl/static2/js/app/utils/i18n.js
+++ b/assembl/static2/js/app/utils/i18n.js
@@ -93,8 +93,8 @@ export const getAvailableLocales = (locale: string, translations: { [string]: an
     @returns {function} Updater function (see immutable-js) that updates the value of the
     entry with given locale by the given value
 */
-// Map<string, any> in case of rich text (raw content state converted to immutable)
-type LangstringValue = string | Map<string, any>;
+// EditorState in case of rich text
+type LangstringValue = string | EditorState;
 type LangstringEntriesList = List<Map<string, LangstringValue>>;
 export const updateInLangstringEntries = (locale: string, value: LangstringValue) => (
   entries: LangstringEntriesList = List()

--- a/assembl/static2/package.json
+++ b/assembl/static2/package.json
@@ -92,7 +92,7 @@
     "bootstrap": "^3.3.7",
     "classnames": "^2.2.5",
     "draft-convert": "^2",
-    "draft-js": "^0.10.1",
+    "draft-js": "^0.10.5",
     "final-form": "^4.8.2",
     "final-form-arrays": "^1.0.4",
     "graphql": "^0.10.5",

--- a/assembl/static2/tests/helpers/draftjs.js
+++ b/assembl/static2/tests/helpers/draftjs.js
@@ -1,0 +1,6 @@
+// @flow
+import { ContentState, EditorState } from 'draft-js';
+
+export function createEditorStateFromText(text: string): EditorState {
+  return EditorState.createWithContent(ContentState.createFromText(text));
+}

--- a/assembl/static2/tests/unit/components/administration/voteSession/__snapshots__/numberGaugeForm.spec.jsx.snap
+++ b/assembl/static2/tests/unit/components/administration/voteSession/__snapshots__/numberGaugeForm.spec.jsx.snap
@@ -19,7 +19,7 @@ exports[`DumbNumberGaugeForm component should render a form to set up a numeral 
       required={true}
       type="number"
       validationErrors={undefined}
-      value={2}
+      value="2"
     />
     <FormControlWithLabel
       componentClass={undefined}
@@ -35,7 +35,7 @@ exports[`DumbNumberGaugeForm component should render a form to set up a numeral 
       required={true}
       type="number"
       validationErrors={undefined}
-      value={11}
+      value="11"
     />
     <FormControlWithLabel
       componentClass={undefined}

--- a/assembl/static2/tests/unit/components/administration/voteSession/__snapshots__/tokenCategoryForm.spec.jsx.snap
+++ b/assembl/static2/tests/unit/components/administration/voteSession/__snapshots__/tokenCategoryForm.spec.jsx.snap
@@ -46,7 +46,7 @@ exports[`tokenTypeForm component should render a TokenCategoryForm component 1`]
       required={true}
       type="number"
       validationErrors={undefined}
-      value={12}
+      value="12"
     />
     <label
       htmlFor="color-picker-1"

--- a/assembl/static2/tests/unit/components/common/richTextEditor/__snapshots__/atomicBlockRenderer.spec.jsx.snap
+++ b/assembl/static2/tests/unit/components/common/richTextEditor/__snapshots__/atomicBlockRenderer.spec.jsx.snap
@@ -3,7 +3,7 @@
 exports[`AtomicBlockRenderer component should render an image block 1`] = `
 <div
   className="atomic-block"
-  data-blockType="atomic"
+  data-blocktype="atomic"
 >
   <img
     alt=""

--- a/assembl/static2/tests/unit/components/common/richTextEditor/attachmentsPlugin.spec.jsx
+++ b/assembl/static2/tests/unit/components/common/richTextEditor/attachmentsPlugin.spec.jsx
@@ -1,4 +1,4 @@
-import { convertFromRaw, convertToRaw, ContentState, Entity } from 'draft-js';
+import { convertFromRaw, convertToRaw, ContentState, EditorState, Entity } from 'draft-js';
 
 import plugin from '../../../../../js/app/components/common/richTextEditor/attachmentsPlugin';
 
@@ -74,6 +74,8 @@ const rcs = {
     }
   }
 };
+
+const es = EditorState.createWithContent(convertFromRaw(rcs));
 
 describe('attachmentsPlugin', () => {
   describe('blockToHTML function', () => {
@@ -214,7 +216,7 @@ describe('attachmentsPlugin', () => {
         }
       };
       const result = htmlToEntity(nodeName, node, createEntity);
-      const expected = '1';
+      const expected = '3';
       expect(result).toEqual(expected);
     });
   });
@@ -222,7 +224,7 @@ describe('attachmentsPlugin', () => {
   describe('getAttachments function', () => {
     const { getAttachments } = plugin;
     it('should return the list of all attachments ids', () => {
-      const result = getAttachments(rcs);
+      const result = getAttachments(es);
       // FIXME: entityKey values is quite unstable here. It seems that there is a side effect
       const expected = [
         { entityKey: '2', document: { id: '1234', title: 'Foobar', mimeType: 'application/pdf' } },
@@ -236,7 +238,7 @@ describe('attachmentsPlugin', () => {
   describe('getAttachmentsDocumentIds function', () => {
     const { getAttachmentsDocumentIds } = plugin;
     it('should return the list of all attachments ids', () => {
-      const result = getAttachmentsDocumentIds(rcs);
+      const result = getAttachmentsDocumentIds(es);
       const expected = ['1234', '1236'];
       expect(result).toEqual(expected);
     });

--- a/assembl/static2/tests/unit/components/common/richTextEditor/index.spec.jsx
+++ b/assembl/static2/tests/unit/components/common/richTextEditor/index.spec.jsx
@@ -1,15 +1,20 @@
 import React from 'react';
 import ShallowRenderer from 'react-test-renderer/shallow';
-import { ContentState, convertToRaw, RichUtils } from 'draft-js';
+import { ContentState, EditorState, RichUtils } from 'draft-js';
+import { configure, mount } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
 
 import RichTextEditor from '../../../../../js/app/components/common/richTextEditor';
 
+configure({ adapter: new Adapter() });
+
 describe('RichTextEditor component', () => {
   it.skip('should render a rich text editor', () => {
-    const rawContentState = convertToRaw(ContentState.createFromText('foobar'));
+    const contentState = ContentState.createFromText('foobar');
+    const editorState = EditorState.createWithContent(contentState);
     const updateEditorStateSpy = jest.fn(newState => newState);
     const props = {
-      rawContentState: rawContentState,
+      editorState: editorState,
       maxLength: 2000,
       placeholder: 'Write here',
       updateEditorState: updateEditorStateSpy
@@ -22,49 +27,30 @@ describe('RichTextEditor component', () => {
   });
 
   describe('getCharCount method', () => {
-    it('should return 0 if the editorState content is empty', () => {
-      const rawContentState = convertToRaw(ContentState.createFromText(''));
-      const rte = new RichTextEditor({ rawContentState: rawContentState });
-      const actual = rte.getCharCount(rte.state.editorState);
-      expect(actual).toEqual(0);
-    });
-
-    it('should return the number of characters in the editorState', () => {
-      const rawContentState = convertToRaw(ContentState.createFromText('Hello world'));
-      // const editorState = EditorState.createWithContent(ContentState.createFromText('Hello world'));
-      const rte = new RichTextEditor({ rawContentState: rawContentState });
-      const actual = rte.getCharCount(rte.state.editorState);
-      expect(actual).toEqual(11);
-    });
+    it('should return 0 if the editorState content is empty');
+    it('should return the number of characters in the editorState');
   });
 
   describe('shouldHidePlaceholder method', () => {
     it('should return true if the content is empty and the block type is not unstyled', () => {
-      const rawContentState = convertToRaw(ContentState.createFromText(''));
-      const rte = new RichTextEditor({
-        rawContentState: rawContentState
-      });
-      const newEditorState = RichUtils.toggleBlockType(rte.state.editorState, 'unordered-list-item');
-      rte.state.editorState = newEditorState;
-      const actual = rte.shouldHidePlaceholder();
+      let editorState = EditorState.createWithContent(ContentState.createFromText(''));
+      editorState = RichUtils.toggleBlockType(editorState, 'unordered-list-item');
+      const wrapper = mount(<RichTextEditor editorState={editorState} />);
+      const actual = wrapper.instance().shouldHidePlaceholder();
       expect(actual).toBeTruthy();
     });
 
     it('should return false if the content is not empty', () => {
-      const rawContentState = convertToRaw(ContentState.createFromText('Hello world'));
-      const rte = new RichTextEditor({
-        rawContentState: rawContentState
-      });
-      const actual = rte.shouldHidePlaceholder();
+      const editorState = EditorState.createWithContent(ContentState.createFromText('Hello world'));
+      const wrapper = mount(<RichTextEditor editorState={editorState} />);
+      const actual = wrapper.instance().shouldHidePlaceholder();
       expect(actual).toBeFalsy();
     });
 
     it('should return false if the block type is unstyled', () => {
-      const rawContentState = convertToRaw(ContentState.createFromText(''));
-      const rte = new RichTextEditor({
-        rawContentState: rawContentState
-      });
-      const actual = rte.shouldHidePlaceholder();
+      const editorState = EditorState.createWithContent(ContentState.createFromText(''));
+      const wrapper = mount(<RichTextEditor editorState={editorState} />);
+      const actual = wrapper.instance().shouldHidePlaceholder();
       expect(actual).toBeFalsy();
     });
   });

--- a/assembl/static2/tests/unit/reducers/adminReducer/landingPage.spec.js
+++ b/assembl/static2/tests/unit/reducers/adminReducer/landingPage.spec.js
@@ -1,5 +1,6 @@
 import { fromJS, List, Map } from 'immutable';
 
+import { createEditorStateFromText } from '../../../helpers/draftjs';
 import * as actionTypes from '../../../../js/app/actions/actionTypes';
 import * as reducers from '../../../../js/app/reducers/adminReducer/landingPage';
 import { modulesById } from '../../components/administration/landingPage/fakeData';
@@ -192,38 +193,47 @@ describe('Landing page modulesHasChanged reducer', () => {
 
 describe('page reducer', () => {
   const reducer = reducers.page;
-  it('should handle UPDATE_LANDING_PAGE_HEADER_TITLE action type', () => {
-    const oldState = fromJS({
+  let oldState;
+  const enSubtitle = createEditorStateFromText('in english');
+  const frSubtitle = createEditorStateFromText('en français');
+  beforeEach(() => {
+    oldState = Map({
       _hasChanged: false,
-      titleEntries: [{ localeCode: 'fr', value: 'en français' }, { localeCode: 'en', value: 'in english' }],
-      subtitleEntries: [{ localeCode: 'fr', value: 'en français' }, { localeCode: 'en', value: 'in english' }],
-      buttonLabelEntries: [{ localeCode: 'fr', value: 'en français' }, { localeCode: 'en', value: 'in english' }],
-      headerImage: {
+      titleEntries: fromJS([{ localeCode: 'fr', value: 'en français' }, { localeCode: 'en', value: 'in english' }]),
+      subtitleEntries: List.of(Map({ localeCode: 'fr', value: frSubtitle }), Map({ localeCode: 'en', value: enSubtitle })),
+      buttonLabelEntries: fromJS([{ localeCode: 'fr', value: 'en français' }, { localeCode: 'en', value: 'in english' }]),
+      headerImage: fromJS({
         externalUrl: '',
         mimeType: '',
         title: ''
-      },
-      logoImage: {
+      }),
+      logoImage: fromJS({
         externalUrl: '',
         mimeType: '',
         title: ''
-      }
+      })
     });
-    const expected = fromJS({
+  });
+
+  it('should handle UPDATE_LANDING_PAGE_HEADER_TITLE action type', () => {
+    const expected = Map({
       _hasChanged: true,
-      titleEntries: [{ localeCode: 'fr', value: 'nouvelle valeur en français' }, { localeCode: 'en', value: 'in english' }],
-      subtitleEntries: [{ localeCode: 'fr', value: 'en français' }, { localeCode: 'en', value: 'in english' }],
-      buttonLabelEntries: [{ localeCode: 'fr', value: 'en français' }, { localeCode: 'en', value: 'in english' }],
-      headerImage: {
+      titleEntries: fromJS([
+        { localeCode: 'fr', value: 'nouvelle valeur en français' },
+        { localeCode: 'en', value: 'in english' }
+      ]),
+      subtitleEntries: List.of(Map({ localeCode: 'fr', value: frSubtitle }), Map({ localeCode: 'en', value: enSubtitle })),
+      buttonLabelEntries: fromJS([{ localeCode: 'fr', value: 'en français' }, { localeCode: 'en', value: 'in english' }]),
+      headerImage: fromJS({
         externalUrl: '',
         mimeType: '',
         title: ''
-      },
-      logoImage: {
+      }),
+      logoImage: fromJS({
         externalUrl: '',
         mimeType: '',
         title: ''
-      }
+      })
     });
     const action = {
       locale: 'fr',
@@ -234,78 +244,59 @@ describe('page reducer', () => {
   });
 
   it('should handle UPDATE_LANDING_PAGE_HEADER_SUBTITLE action type', () => {
-    const oldState = fromJS({
-      _hasChanged: false,
-      titleEntries: [{ localeCode: 'fr', value: 'en français' }, { localeCode: 'en', value: 'in english' }],
-      subtitleEntries: [{ localeCode: 'fr', value: 'en français' }, { localeCode: 'en', value: 'in english' }],
-      buttonLabelEntries: [{ localeCode: 'fr', value: 'en français' }, { localeCode: 'en', value: 'in english' }],
-      headerImage: {
-        externalUrl: '',
-        mimeType: '',
-        title: ''
-      },
-      logoImage: {
-        externalUrl: '',
-        mimeType: '',
-        title: ''
-      }
-    });
-    const expected = fromJS({
+    const newFrSubtitle = createEditorStateFromText('nouvelle valeur en français');
+    const expected = Map({
       _hasChanged: true,
-      titleEntries: [{ localeCode: 'fr', value: 'en français' }, { localeCode: 'en', value: 'in english' }],
-      subtitleEntries: [{ localeCode: 'fr', value: 'nouvelle valeur en français' }, { localeCode: 'en', value: 'in english' }],
-      buttonLabelEntries: [{ localeCode: 'fr', value: 'en français' }, { localeCode: 'en', value: 'in english' }],
-      headerImage: {
+      titleEntries: fromJS([{ localeCode: 'fr', value: 'en français' }, { localeCode: 'en', value: 'in english' }]),
+      subtitleEntries: List.of(
+        Map({
+          localeCode: 'fr',
+          value: newFrSubtitle
+        }),
+        Map({ localeCode: 'en', value: enSubtitle })
+      ),
+      buttonLabelEntries: fromJS([{ localeCode: 'fr', value: 'en français' }, { localeCode: 'en', value: 'in english' }]),
+      headerImage: fromJS({
         externalUrl: '',
         mimeType: '',
         title: ''
-      },
-      logoImage: {
+      }),
+      logoImage: fromJS({
         externalUrl: '',
         mimeType: '',
         title: ''
-      }
+      })
     });
     const action = {
       locale: 'fr',
-      value: 'nouvelle valeur en français',
+      value: newFrSubtitle,
       type: actionTypes.UPDATE_LANDING_PAGE_HEADER_SUBTITLE
     };
     expect(reducer(oldState, action)).toEqual(expected);
   });
 
   it('should handle UPDATE_LANDING_PAGE_HEADER_BUTTON_LABEL action type', () => {
-    const oldState = fromJS({
-      _hasChanged: false,
-      titleEntries: [{ localeCode: 'fr', value: 'en français' }, { localeCode: 'en', value: 'in english' }],
-      subtitleEntries: [{ localeCode: 'fr', value: 'en français' }, { localeCode: 'en', value: 'in english' }],
-      buttonLabelEntries: [{ localeCode: 'fr', value: 'en français' }, { localeCode: 'en', value: 'in english' }],
-      headerImage: {
-        externalUrl: '',
-        mimeType: '',
-        title: ''
-      },
-      logoImage: {
-        externalUrl: '',
-        mimeType: '',
-        title: ''
-      }
-    });
-    const expected = fromJS({
+    const expected = Map({
       _hasChanged: true,
-      titleEntries: [{ localeCode: 'fr', value: 'en français' }, { localeCode: 'en', value: 'in english' }],
-      subtitleEntries: [{ localeCode: 'fr', value: 'en français' }, { localeCode: 'en', value: 'in english' }],
-      buttonLabelEntries: [{ localeCode: 'fr', value: 'nouvelle valeur en français' }, { localeCode: 'en', value: 'in english' }],
-      headerImage: {
+      titleEntries: fromJS([
+        { localeCode: 'fr', value: 'en français' },
+        { localeCode: 'en', value: 'in english' }
+      ]),
+      subtitleEntries: List.of(Map({ localeCode: 'fr', value: frSubtitle }), Map({ localeCode: 'en', value: enSubtitle })),
+      buttonLabelEntries: fromJS([
+        { localeCode: 'fr', value: 'nouvelle valeur en français' },
+        { localeCode: 'en', value: 'in english' }
+      ]),
+      headerImage: fromJS({
         externalUrl: '',
         mimeType: '',
         title: ''
-      },
-      logoImage: {
+      }),
+      logoImage: fromJS({
         externalUrl: '',
         mimeType: '',
         title: ''
-      }
+      })
     });
     const action = {
       locale: 'fr',
@@ -316,86 +307,60 @@ describe('page reducer', () => {
   });
 
   it('should handle UPDATE_LANDING_PAGE_HEADER_IMAGE action type', () => {
-    const oldState = fromJS({
-      _hasChanged: true,
-      titleEntries: [],
-      subtitleEntries: [],
-      buttonLabelEntries: [],
-      headerImage: {
-        externalUrl: '',
-        mimeType: '',
-        title: ''
-      },
-      logoImage: {
-        externalUrl: '',
-        mimeType: '',
-        title: ''
-      }
-    });
     const file = new File([''], 'foo.jpg', { name: 'foo.jpg', type: 'image/jpeg' });
-    const expected = {
+    const expected = Map({
       _hasChanged: true,
-      titleEntries: [],
-      subtitleEntries: [],
-      buttonLabelEntries: [],
-      headerImage: {
-        title: '',
+      titleEntries: fromJS([
+        { localeCode: 'fr', value: 'en français' },
+        { localeCode: 'en', value: 'in english' }
+      ]),
+      subtitleEntries: List.of(Map({ localeCode: 'fr', value: frSubtitle }), Map({ localeCode: 'en', value: enSubtitle })),
+      buttonLabelEntries: fromJS([{ localeCode: 'fr', value: 'en français' }, { localeCode: 'en', value: 'in english' }]),
+      headerImage: Map({
         externalUrl: file,
-        mimeType: 'image/jpeg'
-      },
-      logoImage: {
+        mimeType: 'image/jpeg',
+        title: ''
+      }),
+      logoImage: Map({
         externalUrl: '',
         mimeType: '',
         title: ''
-      }
-    };
+      })
+    });
     const action = {
       value: file,
       type: actionTypes.UPDATE_LANDING_PAGE_HEADER_IMAGE
     };
     const actual = reducer(oldState, action);
-    expect(actual.toJS()).toEqual(expected);
+    expect(actual).toEqual(expected);
   });
 
   it('should handle UPDATE_LANDING_PAGE_HEADER_LOGO action type', () => {
-    const oldState = fromJS({
-      _hasChanged: true,
-      titleEntries: [],
-      subtitleEntries: [],
-      buttonLabelEntries: [],
-      headerImage: {
-        externalUrl: '',
-        mimeType: '',
-        title: ''
-      },
-      logoImage: {
-        externalUrl: '',
-        mimeType: '',
-        title: ''
-      }
-    });
     const file = new File([''], 'foo.jpg', { name: 'foo.jpg', type: 'image/jpeg' });
-    const expected = {
+    const expected = Map({
       _hasChanged: true,
-      titleEntries: [],
-      subtitleEntries: [],
-      buttonLabelEntries: [],
-      headerImage: {
-        title: '',
+      titleEntries: fromJS([
+        { localeCode: 'fr', value: 'en français' },
+        { localeCode: 'en', value: 'in english' }
+      ]),
+      subtitleEntries: List.of(Map({ localeCode: 'fr', value: frSubtitle }), Map({ localeCode: 'en', value: enSubtitle })),
+      buttonLabelEntries: fromJS([{ localeCode: 'fr', value: 'en français' }, { localeCode: 'en', value: 'in english' }]),
+      headerImage: Map({
         externalUrl: '',
-        mimeType: ''
-      },
-      logoImage: {
+        mimeType: '',
+        title: ''
+      }),
+      logoImage: Map({
         externalUrl: file,
         mimeType: 'image/jpeg',
         title: ''
-      }
-    };
+      })
+    });
     const action = {
       value: file,
       type: actionTypes.UPDATE_LANDING_PAGE_HEADER_LOGO
     };
     const actual = reducer(oldState, action);
-    expect(actual.toJS()).toEqual(expected);
+    expect(actual).toEqual(expected);
   });
 });

--- a/assembl/static2/tests/unit/utils/draftjs.spec.js
+++ b/assembl/static2/tests/unit/utils/draftjs.spec.js
@@ -1,37 +1,61 @@
-import { convertFromRaw } from 'draft-js';
+import { ContentState, EditorState } from 'draft-js';
+import { List, Map } from 'immutable';
 
+import { createEditorStateFromText } from '../../helpers/draftjs';
 import * as draftjs from '../../../js/app/utils/draftjs';
 
 describe('draftjs utils', () => {
-  describe('createEmptyEditorState function', () => {
-    const { createEmptyEditorState } = draftjs;
-    it('should create an empty editor state', () => {
-      const actual = createEmptyEditorState();
-      expect(actual.getCurrentContent().getPlainText()).toEqual('');
+  // describe('convertEntries function');
+  describe('convertToEditorState function', () => {
+    const { convertToEditorState } = draftjs;
+    it('should convert empty string to editor state', () => {
+      const actual = convertToEditorState('');
+      expect(actual.getCurrentContent().hasText()).toBeFalsy();
+    });
+
+    it('should convert html to editor state', () => {
+      const actual = convertToEditorState('<p>We need to hack the auxiliary PCI driver!</p>');
+      const expected = EditorState.createWithContent(ContentState.createFromText('We need to hack the auxiliary PCI driver!'));
+      expect(actual.getCurrentContent().getPlainText()).toEqual(expected.getCurrentContent().getPlainText());
     });
   });
 
-  describe('textToRawContentState function', () => {
-    const { textToRawContentState } = draftjs;
-    it('should convert a string to an EditorState record', () => {
-      const actual = textToRawContentState('foobar');
-      const expected = {
-        entityMap: {},
-        blocks: [
-          {
-            text: 'foobar',
-            type: 'unstyled'
-          }
-        ]
-      };
-      expect(actual.entityMap).toEqual(expected.entityMap);
-      expect(actual.blocks[0].text).toEqual(expected.blocks[0].text);
-      expect(actual.blocks[0].type).toEqual(expected.blocks[0].type);
+  describe('convertContentStateToHTML function', () => {
+    const { convertContentStateToHTML } = draftjs;
+    it('should convert an empty editor state to html', () => {
+      const cs = ContentState.createFromText('');
+      const actual = convertContentStateToHTML(cs);
+      const expected = '<p></p>';
+      expect(actual).toEqual(expected);
+    });
+
+    it('should convert an editor state with text to html', () => {
+      const cs = ContentState.createFromText('Use the redundant USB alarm!');
+      const actual = convertContentStateToHTML(cs);
+      const expected = '<p>Use the redundant USB alarm!</p>';
+      expect(actual).toEqual(expected);
     });
   });
 
-  describe('convertEntriesToRawContentState function', () => {
-    const { convertEntriesToRawContentState, textToRawContentState } = draftjs;
+  describe('convertEditorStateToHTML function', () => {
+    const { convertEditorStateToHTML } = draftjs;
+    it('should convert an empty editor state to html', () => {
+      const es = EditorState.createEmpty();
+      const actual = convertEditorStateToHTML(es);
+      const expected = '<p></p>';
+      expect(actual).toEqual(expected);
+    });
+
+    it('should convert an editor state with text to html', () => {
+      const es = createEditorStateFromText('Use the redundant USB alarm!');
+      const actual = convertEditorStateToHTML(es);
+      const expected = '<p>Use the redundant USB alarm!</p>';
+      expect(actual).toEqual(expected);
+    });
+  });
+
+  describe('convertEntriesToEditorState function', () => {
+    const { convertEntriesToEditorState } = draftjs;
     it('should convert entries values to EditorState', () => {
       const entries = [
         {
@@ -43,35 +67,35 @@ describe('draftjs utils', () => {
           value: '<p>toto</p>'
         }
       ];
-      const actual = convertEntriesToRawContentState(entries);
-      const expected = [
-        {
-          localeCode: 'en',
-          value: textToRawContentState('foo')
-        },
-        {
-          localeCode: 'fr',
-          value: textToRawContentState('toto')
-        }
-      ];
-      expect(actual.length).toEqual(expected.length);
-      expect(convertFromRaw(actual[0].value).getPlainText()).toEqual(convertFromRaw(expected[0].value).getPlainText());
-      expect(convertFromRaw(actual[1].value).getPlainText()).toEqual(convertFromRaw(expected[1].value).getPlainText());
+      const actual = convertEntriesToEditorState(entries);
+      let en;
+      let fr;
+      if (actual[0].localeCode === 'en') {
+        en = actual[0];
+        fr = actual[1];
+      } else {
+        en = actual[1];
+        fr = actual[0];
+      }
+      expect(en.value.getCurrentContent().getPlainText()).toEqual('foo');
+      expect(fr.value.getCurrentContent().getPlainText()).toEqual('toto');
     });
   });
 
-  describe('convertRawContentStateToHTML function', () => {
-    const { convertRawContentStateToHTML, textToRawContentState } = draftjs;
-    it('should convert a raw content state to HTML', () => {
-      const rcs = textToRawContentState('foobar');
-      const actual = convertRawContentStateToHTML(rcs);
-      const expected = '<p>foobar</p>';
+  describe('convertImmutableEntriesToJS', () => {
+    const { convertImmutableEntriesToJS } = draftjs;
+    it('should convert immutable entries to an array of objects', () => {
+      const enValue = createEditorStateFromText('hello');
+      const frValue = createEditorStateFromText('salut');
+      const input = List.of(Map({ localeCode: 'en', value: enValue }), Map({ localeCode: 'fr', value: frValue }));
+      const actual = convertImmutableEntriesToJS(input);
+      const expected = [{ localeCode: 'en', value: enValue }, { localeCode: 'fr', value: frValue }];
       expect(actual).toEqual(expected);
     });
   });
 
   describe('convertEntriesToHTML function', () => {
-    const { convertEntriesToHTML, textToRawContentState } = draftjs;
+    const { convertEntriesToHTML } = draftjs;
     it('should do nothing with empty entries', () => {
       const actual = convertEntriesToHTML([]);
       const expected = [];
@@ -82,11 +106,11 @@ describe('draftjs utils', () => {
       const entries = [
         {
           localeCode: 'en',
-          value: textToRawContentState('foo')
+          value: EditorState.createWithContent(ContentState.createFromText('foo'))
         },
         {
           localeCode: 'fr',
-          value: textToRawContentState('toto')
+          value: EditorState.createWithContent(ContentState.createFromText('toto'))
         }
       ];
       const actual = convertEntriesToHTML(entries);
@@ -104,16 +128,21 @@ describe('draftjs utils', () => {
     });
   });
 
-  describe('rawContentStateIsEmpty function', () => {
-    const { textToRawContentState, rawContentStateIsEmpty } = draftjs;
-    it('should return true if rawContentState is empty', () => {
-      const rcs = textToRawContentState('');
-      expect(rawContentStateIsEmpty(rcs)).toBeTruthy();
+  describe('editorStateIsEmpty function', () => {
+    const { editorStateIsEmpty } = draftjs;
+    it('should return true if editor state is empty', () => {
+      const es = EditorState.createEmpty('');
+      expect(editorStateIsEmpty(es)).toBeTruthy();
+    });
+
+    it('should return true if editor state is empty', () => {
+      const es = createEditorStateFromText('');
+      expect(editorStateIsEmpty(es)).toBeTruthy();
     });
 
     it('should return false if rawContentState is not empty', () => {
-      const rcs = textToRawContentState('foo');
-      expect(rawContentStateIsEmpty(rcs)).toBeFalsy();
+      const es = createEditorStateFromText('foo');
+      expect(editorStateIsEmpty(es)).toBeFalsy();
     });
   });
 });

--- a/assembl/static2/yarn.lock
+++ b/assembl/static2/yarn.lock
@@ -3111,10 +3111,10 @@ draft-convert@^2:
     invariant "^2.2.1"
 
 draft-js@^0.10.1:
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/draft-js/-/draft-js-0.10.1.tgz#6f1219d8095729691429ca6fd7a58d2a8be5cb67"
+  version "0.10.5"
+  resolved "https://registry.yarnpkg.com/draft-js/-/draft-js-0.10.5.tgz#bfa9beb018fe0533dbb08d6675c371a6b08fa742"
   dependencies:
-    fbjs "^0.8.7"
+    fbjs "^0.8.15"
     immutable "~3.7.4"
     object-assign "^4.1.0"
 
@@ -3834,7 +3834,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.12, fbjs@^0.8.16, fbjs@^0.8.7, fbjs@^0.8.9:
+fbjs@^0.8.12, fbjs@^0.8.16, fbjs@^0.8.9:
   version "0.8.16"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
   dependencies:
@@ -3846,7 +3846,7 @@ fbjs@^0.8.12, fbjs@^0.8.16, fbjs@^0.8.7, fbjs@^0.8.9:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
 
-fbjs@^0.8.4:
+fbjs@^0.8.15, fbjs@^0.8.4:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   dependencies:
@@ -4804,11 +4804,17 @@ iconv-lite@0.4.19:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
-iconv-lite@^0.4.17, iconv-lite@^0.4.5, iconv-lite@~0.4.13:
+iconv-lite@^0.4.17, iconv-lite@^0.4.5:
   version "0.4.21"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.21.tgz#c47f8733d02171189ebc4a400f3218d348094798"
   dependencies:
     safer-buffer "^2.1.0"
+
+iconv-lite@~0.4.13:
+  version "0.4.24"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3"
 
 icss-replace-symbols@^1.1.0:
   version "1.1.0"
@@ -5644,6 +5650,10 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
+"js-tokens@^3.0.0 || ^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+
 js-yaml@^3.4.3:
   version "3.11.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.11.0.tgz#597c1a8bd57152f26d622ce4117851a51f5ebaef"
@@ -6060,7 +6070,13 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.0, loose-envify@^1.3.1:
+loose-envify@^1.0.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
+  dependencies:
+    js-tokens "^3.0.0 || ^4.0.0"
+
+loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -8716,7 +8732,7 @@ safe-buffer@5.1.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, s
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
-safer-buffer@^2.1.0:
+"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
 
@@ -9624,13 +9640,9 @@ typescript@^2.5.1:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.2.tgz#3c5b6fd7f6de0914269027f03c0946758f7673a4"
 
-ua-parser-js@^0.7.18:
+ua-parser-js@^0.7.18, ua-parser-js@^0.7.9:
   version "0.7.18"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.18.tgz#a7bfd92f56edfb117083b69e31d2aa8882d4b1ed"
-
-ua-parser-js@^0.7.9:
-  version "0.7.17"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.17.tgz#e9ec5f9498b9ec910e7ae3ac626a805c4d09ecac"
 
 uglify-es@^3.3.4:
   version "3.3.9"

--- a/assembl/static2/yarn.lock
+++ b/assembl/static2/yarn.lock
@@ -3110,7 +3110,7 @@ draft-convert@^2:
     immutable "~3.7.4"
     invariant "^2.2.1"
 
-draft-js@^0.10.1:
+draft-js@^0.10.5:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/draft-js/-/draft-js-0.10.5.tgz#bfa9beb018fe0533dbb08d6675c371a6b08fa742"
   dependencies:
@@ -3834,19 +3834,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.12, fbjs@^0.8.16, fbjs@^0.8.9:
-  version "0.8.16"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
-  dependencies:
-    core-js "^1.0.0"
-    isomorphic-fetch "^2.1.1"
-    loose-envify "^1.0.0"
-    object-assign "^4.1.0"
-    promise "^7.1.1"
-    setimmediate "^1.0.5"
-    ua-parser-js "^0.7.9"
-
-fbjs@^0.8.15, fbjs@^0.8.4:
+fbjs@^0.8.12, fbjs@^0.8.15, fbjs@^0.8.16, fbjs@^0.8.4, fbjs@^0.8.9:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   dependencies:
@@ -4804,13 +4792,7 @@ iconv-lite@0.4.19:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
-iconv-lite@^0.4.17, iconv-lite@^0.4.5:
-  version "0.4.21"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.21.tgz#c47f8733d02171189ebc4a400f3218d348094798"
-  dependencies:
-    safer-buffer "^2.1.0"
-
-iconv-lite@~0.4.13:
+iconv-lite@^0.4.17, iconv-lite@^0.4.5, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   dependencies:
@@ -6070,17 +6052,11 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.0, loose-envify@^1.3.1:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
-
-loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.0, loose-envify@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
-  dependencies:
-    js-tokens "^3.0.0"
 
 loud-rejection@^1.0.0:
   version "1.6.0"
@@ -8732,7 +8708,7 @@ safe-buffer@5.1.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, s
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
-"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.1.0:
+"safer-buffer@>= 2.1.2 < 3":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
 
@@ -9640,7 +9616,7 @@ typescript@^2.5.1:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.2.tgz#3c5b6fd7f6de0914269027f03c0946758f7673a4"
 
-ua-parser-js@^0.7.18, ua-parser-js@^0.7.9:
+ua-parser-js@^0.7.18:
   version "0.7.18"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.18.tgz#a7bfd92f56edfb117083b69e31d2aa8882d4b1ed"
 


### PR DESCRIPTION
We no more use `editorState` in `RichTextEditor` local state, it creates too many errors / difficulties. Now editorState belongs to the parent component local state or `redux` store or `react-final-form` internal state. We only convert `editorState` to send our mutations.