### PR TITLE
Devas1841: fix visual bug on author for fiction preview

### DIFF
--- a/assembl/static2/css/components/fictionPreview.scss
+++ b/assembl/static2/css/components/fictionPreview.scss
@@ -93,7 +93,7 @@
 
         .author {
           font-size: $font-size-xxs;
-          width: 70px;
+          max-width: 70px;
           display: inline-block;
           line-height: 8px;
         }
@@ -120,7 +120,7 @@
       .inner-box {
         .info {
           .author {
-            width: 120px;
+            max-width: 120px;
           }
         }
       }
@@ -165,7 +165,7 @@
 
           .author {
             font-size: $font-size-xs;
-            width: 230px;
+            max-width: 230px;
           }
 
           .published-date {
@@ -214,7 +214,7 @@
           margin-bottom: 41px;
 
           .author {
-            width: 260px;
+            max-width: 260px;
           }
         }
       }


### PR DESCRIPTION
If author name is short, it doesn"t take whole preview space