### PR TITLE
Persistent alerts DEVAS-1823

### DIFF
--- a/assembl/static2/js/app/pages/discussionAdmin.jsx
+++ b/assembl/static2/js/app/pages/discussionAdmin.jsx
@@ -169,7 +169,7 @@ class DiscussionAdmin extends React.Component<Props, State> {
       deleteDiscussionPhase,
       editLocale
     } = this.props;
-    displayAlert('success', `${I18n.t('loading.wait')}...`);
+    displayAlert('success', `${I18n.t('loading.wait')}...`, false, -1);
 
     if (languagePreferenceHasChanged) {
       const payload = {

--- a/assembl/static2/js/app/pages/landingPageAdmin.jsx
+++ b/assembl/static2/js/app/pages/landingPageAdmin.jsx
@@ -125,7 +125,7 @@ class LandingPageAdmin extends React.Component<Props, State> {
       updateDiscussionPhase,
       refetchTimeline
     } = this.props;
-    displayAlert('success', `${I18n.t('loading.wait')}...`);
+    displayAlert('success', `${I18n.t('loading.wait')}...`, false, -1);
     if (landingPageModulesHasChanged) {
       const mutationsPromises = getMutationsPromises({
         items: landingPageModules,

--- a/assembl/static2/js/app/utils/utilityManager.jsx
+++ b/assembl/static2/js/app/utils/utilityManager.jsx
@@ -26,19 +26,31 @@ export const displayAlert = (style, msg, topPosition = false, time = 4000) => {
     alertMsg:String => the message displayed in the alert
     showAlert:Boolean => to show/hide the alert
     topPosition:Boolean => if true, the top attribute should be 0
+    time => the duration of the alert. If time === -1, it is persistent
   */
-  alertManager.component.setState({
-    base: false,
-    alertStyle: style,
-    alertMsg: msg,
-    showAlert: true,
-    topPosition: topPosition
-  });
-  setTimeout(() => {
-    alertManager.component.setState({
+  alertManager.component.setState(
+    // ensure that we hide the old alert if it was persistent
+    {
       showAlert: false
-    });
-  }, time);
+    },
+    () => {
+      alertManager.component.setState({
+        base: false,
+        alertStyle: style,
+        alertMsg: msg,
+        showAlert: true,
+        topPosition: topPosition
+      });
+    }
+  );
+
+  if (time !== -1) {
+    setTimeout(() => {
+      alertManager.component.setState({
+        showAlert: false
+      });
+    }, time);
+  }
 };
 
 export const displayModal = (title, body, footer, footerTxt, button = null, showModal = true, bsSize = null) => {

--- a/assembl/static2/js/app/utils/utilityManager.jsx
+++ b/assembl/static2/js/app/utils/utilityManager.jsx
@@ -118,7 +118,10 @@ export const openShareModal = (options) => {
 export const inviteUserToLogin = () => {
   const body = (
     <div>
-      <p><Translate value="login.loginModalBody" /></p><br />
+      <p>
+        <Translate value="login.loginModalBody" />
+      </p>
+      <br />
       <LoginButton label={I18n.t('login.loginModalFooter')} />
     </div>
   );
@@ -134,7 +137,6 @@ export const promptForLoginOr = action => () => {
     action();
   }
 };
-
 
 export const defaultAnchorAttributes = {
   rel: 'noopener no-referrer',
@@ -153,7 +155,15 @@ export const localAwareLink = AnchorComponent => ({ urlData, anchorAttributes, p
   const attrs = anchorAttributes || null;
   const componentProps = props || null;
   if (!urlData.local) {
-    return (<a href={urlData.url} {...attrs} ><AnchorComponent {...componentProps} /></a>);
+    return (
+      <a href={urlData.url} {...attrs}>
+        <AnchorComponent {...componentProps} />
+      </a>
+    );
   }
-  return (<Link to={urlData.url} {...attrs}><AnchorComponent {...componentProps} /></Link>);
+  return (
+    <Link to={urlData.url} {...attrs}>
+      <AnchorComponent {...componentProps} />
+    </Link>
+  );
 };


### PR DESCRIPTION
Add possibility to set time to `-1` to make an alert message persistent (until another message is displayed). Fixes DEVAS-1823

(I tried to add a test for `displayAlert` util but this code is not easy to test, I gave up)