### PR TITLE
Fix votes export

### DIFF
--- a/assembl/views/api2/discussion.py
+++ b/assembl/views/api2/discussion.py
@@ -587,7 +587,7 @@ def extract_taxonomy_csv(request):
     return csv_response(extract_list, CSV_MIMETYPE, fieldnames)
 
 
-def csv_response(results, format, fieldnames=None):
+def csv_response(results, format, fieldnames=None, content_disposition=None):
     output = StringIO()
     # include BOM for Excel to open the file in UTF-8 properly
     output.write(u'\ufeff'.encode('utf-8'))
@@ -621,7 +621,7 @@ def csv_response(results, format, fieldnames=None):
         writer.save('')
 
     output.seek(0)
-    return Response(body_file=output, content_type=format)
+    return Response(body_file=output, content_type=format, content_disposition=content_disposition)
 
 
 @view_config(context=InstanceContext, name="contribution_count",

--- a/assembl/views/api2/discussion.py
+++ b/assembl/views/api2/discussion.py
@@ -584,7 +584,7 @@ def extract_taxonomy_csv(request):
         }
         extract_list.append(extract_info)
 
-    return csv_response(extract_list, CSV_MIMETYPE, fieldnames)
+    return csv_response(extract_list, CSV_MIMETYPE, fieldnames, content_disposition='attachment; filename="extract_taxonomies.csv"')
 
 
 def csv_response(results, format, fieldnames=None, content_disposition=None):

--- a/assembl/views/api2/discussion.py
+++ b/assembl/views/api2/discussion.py
@@ -589,6 +589,8 @@ def extract_taxonomy_csv(request):
 
 def csv_response(results, format, fieldnames=None):
     output = StringIO()
+    # include BOM for Excel to open the file in UTF-8 properly
+    output.write(u'\ufeff'.encode('utf-8'))
 
     if format == CSV_MIMETYPE:
         from csv import writer

--- a/assembl/views/api2/votes.py
+++ b/assembl/views/api2/votes.py
@@ -274,6 +274,8 @@ def global_vote_results_csv(request):
         coltitles.append('Total votes')
 
     output = StringIO()
+    # include BOM for Excel to open the file in UTF-8 properly
+    output.write(u'\ufeff'.encode('utf-8'))
     csvw = csv.writer(output)
     csvw.writerow(coltitles)
     from assembl.graphql.vote_session import get_avg_choice
@@ -337,6 +339,7 @@ def global_vote_results_csv(request):
                     histogram = dict(q_histogram.all())
                     for choice in template_spec.get_choices():
                         row.append(histogram.get(choice.value, 0))
+
             if spec is None:
                 row.append('-')
             else:

--- a/assembl/views/api2/votes.py
+++ b/assembl/views/api2/votes.py
@@ -417,4 +417,4 @@ def extract_voters(request):
 
             extract_votes.append(extract_info)
     extract_votes.sort(key=operator.itemgetter('Nom du contributeur'))
-    return csv_response(extract_votes, CSV_MIMETYPE, fieldnames)
+    return csv_response(extract_votes, CSV_MIMETYPE, fieldnames, content_disposition='attachment; filename="detailed_vote_results.csv"')

--- a/assembl/views/api2/votes.py
+++ b/assembl/views/api2/votes.py
@@ -266,7 +266,7 @@ def global_vote_results_csv(request):
         else:
             coltitles.append(u'{title} - moyenne'.format(title=title).encode('utf-8'))
             if isinstance(template_spec, NumberGaugeVoteSpecification):
-                for choice_value in range_float(template_spec.minimum, spec.maximum, spec.nb_ticks):
+                for choice_value in range_float(template_spec.minimum, template_spec.maximum, template_spec.nb_ticks):
                     coltitles.append(u'{value} {unit}'.format(value=choice_value, unit=template_spec.unit).encode('utf-8'))
             else:
                 for choice in template_spec.get_choices():


### PR DESCRIPTION
Fixes the following in votes export:

- add BOM so that excel knows this is UTF-8 (DEVAS-1792)
- add filename and content disposition for detailed votes export
- fix bug in `global_vote_results_csv` (I had an `AttributeError` because `spec` was used before it was defined (in fact, it was defined in the list comprehension that creates the `template_specs` line 244 so the error was hidden)
- add filename and add BOM for taxonomies extract