### PR TITLE
Add a validation for JSON, and a test

### DIFF
--- a/assembl/models/preferences.py
+++ b/assembl/models/preferences.py
@@ -280,7 +280,8 @@ class Preferences(MutableMapping, Base, NamedClassMixin):
         elif data_type == "int":
             assert isinstance(value, int), "Not an integer"
         elif data_type == "json":
-            pass  # no check
+            # Will raise a JSONDecodeError if not a valid JSON
+            json.loads(value)
         else:
             assert isinstance(value, (str, unicode)), "Not a string"
             if data_type in ("string", "text"):

--- a/assembl/tests/fixtures/preferences.py
+++ b/assembl/tests/fixtures/preferences.py
@@ -37,7 +37,7 @@ def non_standard_preference(request, test_session):
                 "description": "The preference configuration; override only with care",
                 "allow_user_override": None,
                 "modification_permission": P_SYSADMIN,
-                "default": None
+                "default": {}
             },
             {
                 "id": "test_url",

--- a/assembl/tests/model_tests/test_preference.py
+++ b/assembl/tests/model_tests/test_preference.py
@@ -1,3 +1,5 @@
+import pytest
+from simplejson import JSONDecodeError
 
 def test_preference_address_empty(test_session, non_standard_preference):
     try:
@@ -123,3 +125,16 @@ def test_preference_address_good_special_character(test_session, non_standard_pr
         assert True
     except:
         assert False, "An error should NOT have been raised"
+
+
+def test_preferences_extra_json_valid_json(test_session, discussion):
+    preferences = discussion.preferences
+    valid_json = '{"hello": "world"}'
+    preferences['extra_json'] = valid_json
+
+
+def test_preferences_extra_json_invalid_json(test_session, discussion):
+    preferences = discussion.preferences
+    invalid_json = '{"hello: "world"}'
+    with pytest.raises(JSONDecodeError):
+        preferences['extra_json'] = invalid_json


### PR DESCRIPTION
A validation for JSON in the preference. To avoid faulty json to creep past front-end checks / API based calls to Preferences's `extra_json` field. 