### PR TITLE
Fix: post translation in survey and thread exports

### DIFF
--- a/assembl/models/generic.py
+++ b/assembl/models/generic.py
@@ -454,15 +454,17 @@ class Content(TombstonableMixin, DiscussionBoundBase):
             log.error("What is this mimetype?" + mimetype)
             return body
 
-    def maybe_translate(self, pref_collection=None):
+    def maybe_translate(self, pref_collection=None, target_locales=None):
         from assembl.tasks.translate import (
-            translate_content, PrefCollectionTranslationTable)
+            translate_content, PrefCollectionTranslationTable, LanguagesTranslationTable)
         service = self.discussion.translation_service()
         if service.canTranslate is not None:
             translations = None
             if pref_collection:
                 translations = PrefCollectionTranslationTable(
                     service, pref_collection)
+            elif target_locales:
+                translations = LanguagesTranslationTable(service, target_locales)
 
             translate_content(
                 self, translation_table=translations, service=service)

--- a/assembl/models/generic.py
+++ b/assembl/models/generic.py
@@ -454,13 +454,16 @@ class Content(TombstonableMixin, DiscussionBoundBase):
             log.error("What is this mimetype?" + mimetype)
             return body
 
-    def maybe_translate(self, pref_collection):
+    def maybe_translate(self, pref_collection=None):
         from assembl.tasks.translate import (
             translate_content, PrefCollectionTranslationTable)
         service = self.discussion.translation_service()
         if service.canTranslate is not None:
-            translations = PrefCollectionTranslationTable(
-                service, pref_collection)
+            translations = None
+            if pref_collection:
+                translations = PrefCollectionTranslationTable(
+                    service, pref_collection)
+
             translate_content(
                 self, translation_table=translations, service=service)
 

--- a/assembl/tasks/translate.py
+++ b/assembl/tasks/translate.py
@@ -37,7 +37,7 @@ class DiscussionPreloadTranslationTable(TranslationTable):
         self.base_languages.discard(None)
 
     def languages_for(self, locale_code, db=None):
-        locale_code = self.service.asKnownLocale(locale_code)
+        locale_code = self.service.asKnownLocale(locale_code) or []
         return self.base_languages - set(locale_code)
 
 

--- a/assembl/tasks/translate.py
+++ b/assembl/tasks/translate.py
@@ -37,8 +37,12 @@ class DiscussionPreloadTranslationTable(TranslationTable):
         self.base_languages.discard(None)
 
     def languages_for(self, locale_code, db=None):
-        locale_code = self.service.asKnownLocale(locale_code) or []
-        return self.base_languages - set(locale_code)
+        content_locale = set()
+        locale_code = self.service.asKnownLocale(locale_code)
+        if locale_code:
+            content_locale = set([locale_code])
+
+        return self.base_languages - content_locale
 
 
 def translate_content(

--- a/assembl/tasks/translate.py
+++ b/assembl/tasks/translate.py
@@ -14,7 +14,26 @@ class TranslationTable(object):
         return ()
 
 
+class LanguagesTranslationTable(TranslationTable):
+    """Translation table that uses the given target languages."""
+    def __init__(self, service, target_locales):
+        self.service = service
+        self.base_languages = {
+            service.asKnownLocale(lang)
+            for lang in target_locales}
+        self.base_languages.discard(None)
+
+    def languages_for(self, locale_code, db=None):
+        content_locale = set()
+        locale_code = self.service.asKnownLocale(locale_code)
+        if locale_code:
+            content_locale = set([locale_code])
+
+        return self.base_languages - content_locale
+
+
 class PrefCollectionTranslationTable(TranslationTable):
+    """Translation table that uses the languages of the given LanguagePreferenceCollection."""
     def __init__(self, service, prefCollection):
         self.service = service
         self.prefCollection = prefCollection
@@ -29,6 +48,7 @@ class PrefCollectionTranslationTable(TranslationTable):
 
 
 class DiscussionPreloadTranslationTable(TranslationTable):
+    """Translation table that uses the languages of given discussion."""
     def __init__(self, service, discussion):
         self.service = service
         self.base_languages = {

--- a/assembl/views/api2/discussion.py
+++ b/assembl/views/api2/discussion.py
@@ -1501,6 +1501,9 @@ def phase1_csv_export(request):
             row[QUESTION_TITLE] = get_entries_locale_original(question.title).get('entry')
             posts = get_published_posts(question)
             for post in posts:
+                if has_lang:
+                    post.maybe_translate()
+
                 post_entries = get_entries_locale_original(post.body)
                 row[POST_BODY] = sanitize_text(post_entries.get('entry'))
                 row[POST_ID] = post.id
@@ -1628,6 +1631,9 @@ def phase2_csv_export(request):
         row[IDEA_NAME] = get_entries_locale_original(idea.title).get('entry')
         posts = get_published_posts(idea)
         for post in posts:
+            if has_lang:
+                post.maybe_translate()
+
             subject = get_entries_locale_original(post.subject)
             body = get_entries_locale_original(post.body)
 

--- a/assembl/views/api2/discussion.py
+++ b/assembl/views/api2/discussion.py
@@ -1502,7 +1502,7 @@ def phase1_csv_export(request):
             posts = get_published_posts(question)
             for post in posts:
                 if has_lang:
-                    post.maybe_translate()
+                    post.maybe_translate(target_locales=[language])
 
                 post_entries = get_entries_locale_original(post.body)
                 row[POST_BODY] = sanitize_text(post_entries.get('entry'))
@@ -1632,7 +1632,7 @@ def phase2_csv_export(request):
         posts = get_published_posts(idea)
         for post in posts:
             if has_lang:
-                post.maybe_translate()
+                post.maybe_translate(target_locales=[language])
 
             subject = get_entries_locale_original(post.subject)
             body = get_entries_locale_original(post.body)


### PR DESCRIPTION
I would prefer to add a new `TranslationTable` type and specify the locale to which we want to translate to avoid unnecessary translations (here we translate the post to each language of the discussion but we only need the target locale that have been chosen by the user). What do you think about it?

Also, I'm not sure about the change in `assembl/tasks/translate.py`