### PR TITLE
DEVAS 1940 bugfix survey admin

### DIFF
--- a/assembl/graphql/idea.py
+++ b/assembl/graphql/idea.py
@@ -136,7 +136,8 @@ class IdeaInterface(graphene.Interface):
         if not self.parents:
             return None
 
-        return self.parents[0].graphene_id()
+        parent = self.parents[0]
+        return parent.graphene_id() if parent else None
 
     def resolve_ancestors(self, args, context, info):
         # We use id_only=True and models.Idea.get on purpose, to

--- a/assembl/static2/js/app/components/administration/discussion/phaseForm.jsx
+++ b/assembl/static2/js/app/components/administration/discussion/phaseForm.jsx
@@ -27,7 +27,8 @@ type PhaseFormProps = {
   handleEndDateChange: Function,
   handleIdentifierChange: Function,
   locale: string,
-  hasConflictingDates: boolean
+  hasConflictingDates: boolean,
+  isNew: boolean
 };
 
 export const DumbPhaseForm = ({
@@ -40,7 +41,8 @@ export const DumbPhaseForm = ({
   start,
   end,
   hasConflictingDates,
-  locale
+  locale,
+  isNew
 }: PhaseFormProps) => {
   const startDatePickerPlaceholder = I18n.t('administration.timelineAdmin.selectStart', { count: phaseNumber });
   const endDatePickerPlaceholder = I18n.t('administration.timelineAdmin.selectEnd', { count: phaseNumber });
@@ -111,6 +113,7 @@ export const DumbPhaseForm = ({
       <div className="margin-m">
         <SplitButton
           className="admin-dropdown"
+          disabled={!isNew}
           id={`dropdown-${phaseId}`}
           title={splitButtonTitle}
           onSelect={handleIdentifierChange}
@@ -142,7 +145,8 @@ const mapStateToProps = (state, { phaseId }) => {
     start: phase ? phase.get('start') : null,
     end: phase ? phase.get('end') : null,
     hasConflictingDates: phase ? phase.get('hasConflictingDates') : null,
-    locale: state.i18n.locale
+    locale: state.i18n.locale,
+    isNew: phase.get('_isNew')
   };
 };
 

--- a/assembl/static2/js/app/components/administration/discussion/phaseForm.jsx
+++ b/assembl/static2/js/app/components/administration/discussion/phaseForm.jsx
@@ -10,7 +10,12 @@ import { type moment } from 'moment';
 import { modulesTranslationKeys } from '../../../constants';
 import { getDiscussionSlug } from '../../../utils/globalFunctions';
 import { get } from '../../../utils/routeMap';
-import { updatePhaseIdentifier, updateStartDate, updateEndDate } from '../../../actions/adminActions/timeline';
+import {
+  updatePhaseIdentifier,
+  updateStartDate,
+  updateEndDate,
+  updateIsThematicsTable
+} from '../../../actions/adminActions/timeline';
 
 type PhaseFormProps = {
   phaseId: string,
@@ -142,7 +147,10 @@ const mapStateToProps = (state, { phaseId }) => {
 };
 
 const mapDispatchToProps = (dispatch, { phaseId }) => ({
-  handleIdentifierChange: eventKey => dispatch(updatePhaseIdentifier(phaseId, eventKey)),
+  handleIdentifierChange: (eventKey) => {
+    dispatch(updatePhaseIdentifier(phaseId, eventKey));
+    dispatch(updateIsThematicsTable(phaseId, eventKey === 'survey'));
+  },
   handleStartDateChange: date => dispatch(updateStartDate(phaseId, date)),
   handleEndDateChange: date => dispatch(updateEndDate(phaseId, date))
 });

--- a/assembl/static2/js/app/components/administration/discussion/phaseForm.jsx
+++ b/assembl/static2/js/app/components/administration/discussion/phaseForm.jsx
@@ -146,7 +146,7 @@ const mapStateToProps = (state, { phaseId }) => {
     end: phase ? phase.get('end') : null,
     hasConflictingDates: phase ? phase.get('hasConflictingDates') : null,
     locale: state.i18n.locale,
-    isNew: phase.get('_isNew')
+    isNew: phase && phase.get('_isNew')
   };
 };
 

--- a/assembl/static2/tests/unit/components/administration/timeline/__snapshots__/phaseForm.spec.jsx.snap
+++ b/assembl/static2/tests/unit/components/administration/timeline/__snapshots__/phaseForm.spec.jsx.snap
@@ -120,6 +120,7 @@ exports[`PhaseForm component should render a form to update the dates and module
   >
     <SplitButton
       className="admin-dropdown"
+      disabled={true}
       id="dropdown-1234"
       onSelect={[Function]}
       title="Survey module"

--- a/assembl/static2/tests/unit/components/administration/timeline/phaseForm.spec.jsx
+++ b/assembl/static2/tests/unit/components/administration/timeline/phaseForm.spec.jsx
@@ -17,7 +17,8 @@ describe('PhaseForm component', () => {
       identifier: 'survey',
       start: moment('2014-12-31T09:00:00+00:00'),
       end: moment('2015-12-31T09:00:00+00:00'),
-      locale: 'fr'
+      locale: 'fr',
+      isNew: false
     };
 
     const shallowRenderer = new ShallowRenderer();


### PR DESCRIPTION
Now it’s forbidden to change the module if the phase already exists.

- The select box to set a module is disabled if the phase is marked as _isNew=false
- `isThematicsTable` is set in the frontend, even if it's not yet used in the backend, just to not forget for the future
- The backend don't return orphan ideas