### PR TITLE
SUPPORT 30: the links to a post in the announcement do not scroll down to the post

### DIFF
--- a/assembl/static2/js/app/components/common/tree/tree.jsx
+++ b/assembl/static2/js/app/components/common/tree/tree.jsx
@@ -50,8 +50,11 @@ class Tree extends React.Component<Props> {
     }
   }
 
-  componentDidUpdate() {
-    this.triggerScrollToRow(this.props.initialRowIndex);
+  componentDidUpdate(prevProps: Props) {
+    const { initialRowIndex } = this.props;
+    if (prevProps.initialRowIndex !== initialRowIndex) {
+      this.triggerScrollToRow(initialRowIndex);
+    }
   }
 
   triggerScrollToRow = (rowIndex: ?number) => {

--- a/assembl/static2/js/app/components/common/tree/tree.jsx
+++ b/assembl/static2/js/app/components/common/tree/tree.jsx
@@ -31,10 +31,7 @@ class Tree extends React.Component<Props> {
     // or to avoid recreating all dom nodes if we go back to the same idea.
     this.cache.clearAll();
     this.prevStopIndex = 0;
-    const { initialRowIndex } = this.props;
-    if (this.listRef && initialRowIndex !== null) {
-      this.listRef.scrollToRow(initialRowIndex);
-    }
+    this.triggerScrollToRow(this.props.initialRowIndex);
   }
 
   componentWillReceiveProps(nextProps: Props) {
@@ -52,6 +49,16 @@ class Tree extends React.Component<Props> {
       this.prevStopIndex = 0;
     }
   }
+
+  componentDidUpdate() {
+    this.triggerScrollToRow(this.props.initialRowIndex);
+  }
+
+  triggerScrollToRow = (rowIndex: ?number) => {
+    if (this.listRef && rowIndex !== null) {
+      this.listRef.scrollToRow(rowIndex);
+    }
+  };
 
   nuggetsManager: NuggetsManager = new NuggetsManager();
 


### PR DESCRIPTION
This PR is linked to [this support ticket](https://bluenove.atlassian.net/browse/SUPPORT-30)

The issue was that the function that scrolls down to the post was only run in componentDidMount and we did not go through this lifecycle method of the Tree component when clicking on a link. It is now run in componentDidUpdate as well, which solves the issue.