### PR TITLE
Make sure that passwordChangeResponse exists, else bail out

### DIFF
--- a/assembl/static2/js/app/pages/requestPasswordChange.jsx
+++ b/assembl/static2/js/app/pages/requestPasswordChange.jsx
@@ -24,7 +24,7 @@ export class DumbRequestPasswordChange extends React.Component<Props> {
       <Grid fluid className="login-container">
         <Row className="max-container center">
           <Col xs={12} md={6} className="col-centered">
-            {passwordChangeResponse.success ? (
+            {passwordChangeResponse && passwordChangeResponse.success ? (
               <SendPwdConfirm />
             ) : (
               <RequestNewPasswordForm


### PR DESCRIPTION
I'm not sure if this is the best behaviour that we want. If there `passwordChangeResponse` is null (for whatever reason), do we want to show the form again, or display proper error?

Fix after crash became visible at:

https://sentry.bluenove.com/sentry/sg-maroc/issues/529/?query=transaction:%22app/pages/requestPasswordChange%20in%20value%22