### PR TITLE
Bugfix: diamond showing in the announcement even when there is no content

### DIFF
--- a/assembl/static2/js/app/components/common/textAndMedia.jsx
+++ b/assembl/static2/js/app/components/common/textAndMedia.jsx
@@ -22,15 +22,7 @@ type TitleProps = {
   value: ?string
 };
 
-type SideDescriptionProps = {
-  content: string
-};
-
-type TopDescriptionProps = {
-  content: string
-};
-
-type BottomDescriptionProps = {
+type DescriptionProps = {
   content: string
 };
 
@@ -40,7 +32,7 @@ type ContentProps = {
 };
 
 class TextAndMedia extends React.Component<Props> {
-  static isValidDescription = (description: ?string): boolean => description !== '<p></p>';
+  static isValidDescription = (description: ?string): boolean => (description ? description !== '<p></p>' : false);
 
   static Title = ({ value }: TitleProps) => (
     <div className="media-title-section">
@@ -49,7 +41,7 @@ class TextAndMedia extends React.Component<Props> {
     </div>
   );
 
-  static SideDescription = ({ content }: SideDescriptionProps) => (
+  static SideDescription = ({ content }: DescriptionProps) => (
     <div className="media-description">
       <div className="media-description-icon">
         <span className="assembl-icon-pepite color2">&nbsp;</span>
@@ -59,11 +51,11 @@ class TextAndMedia extends React.Component<Props> {
     </div>
   );
 
-  static TopDescription = ({ content }: TopDescriptionProps) => (
+  static TopDescription = ({ content }: DescriptionProps) => (
     <div className="media-description-layer media-description-top" dangerouslySetInnerHTML={{ __html: content }} />
   );
 
-  static BottomDescription = ({ content }: BottomDescriptionProps) => (
+  static BottomDescription = ({ content }: DescriptionProps) => (
     <div className="media-description-layer media-description-bottom" dangerouslySetInnerHTML={{ __html: content }} />
   );
 

--- a/assembl/static2/js/app/components/debate/common/__snapshots__/announcement.spec.jsx.snap
+++ b/assembl/static2/js/app/components/debate/common/__snapshots__/announcement.spec.jsx.snap
@@ -36,37 +36,7 @@ exports[`Announcement component <Announcement /> on a multiColumns should render
           className="container-fluid"
         >
           <div
-            className="col-md-4 col-sm-12"
-          >
-            <div
-              className="media-description"
-            >
-              <div
-                className="media-description-icon"
-              >
-                <span
-                  className="assembl-icon-pepite color2"
-                >
-                   
-                </span>
-              </div>
-              <div
-                className="description-txt"
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": undefined,
-                  }
-                }
-              />
-              <div
-                className="box-hyphen left"
-              >
-                 
-              </div>
-            </div>
-          </div>
-          <div
-            className="col-md-8 col-sm-12"
+            className="col-md-12 col-sm-12"
           >
             <div
               className="media-right"
@@ -76,40 +46,6 @@ exports[`Announcement component <Announcement /> on a multiColumns should render
                 dangerouslySetInnerHTML={
                   Object {
                     "__html": "<p>Bonjour à tous</p><p>Nous allons mettre un deuxieme paragraphe</p><p>Et un peu de <strong>texte en gras</strong>",
-                  }
-                }
-              />
-              <div
-                className="media-description"
-              >
-                <div
-                  className="media-description-icon"
-                >
-                  <span
-                    className="assembl-icon-pepite color2"
-                  >
-                     
-                  </span>
-                </div>
-                <div
-                  className="description-txt"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": undefined,
-                    }
-                  }
-                />
-                <div
-                  className="box-hyphen left"
-                >
-                   
-                </div>
-              </div>
-              <div
-                className="media-description-layer media-description-bottom"
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": null,
                   }
                 }
               />
@@ -262,37 +198,7 @@ exports[`Announcement component <Announcement/> on a thread should render an ann
           className="container-fluid"
         >
           <div
-            className="col-md-4 col-sm-12"
-          >
-            <div
-              className="media-description"
-            >
-              <div
-                className="media-description-icon"
-              >
-                <span
-                  className="assembl-icon-pepite color2"
-                >
-                   
-                </span>
-              </div>
-              <div
-                className="description-txt"
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": undefined,
-                  }
-                }
-              />
-              <div
-                className="box-hyphen left"
-              >
-                 
-              </div>
-            </div>
-          </div>
-          <div
-            className="col-md-8 col-sm-12"
+            className="col-md-12 col-sm-12"
           >
             <div
               className="media-right"
@@ -302,40 +208,6 @@ exports[`Announcement component <Announcement/> on a thread should render an ann
                 dangerouslySetInnerHTML={
                   Object {
                     "__html": "<p>Bonjour à tous</p><p>Nous allons mettre un deuxieme paragraphe</p><p>Et un peu de <strong>texte en gras</strong>",
-                  }
-                }
-              />
-              <div
-                className="media-description"
-              >
-                <div
-                  className="media-description-icon"
-                >
-                  <span
-                    className="assembl-icon-pepite color2"
-                  >
-                     
-                  </span>
-                </div>
-                <div
-                  className="description-txt"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": undefined,
-                    }
-                  }
-                />
-                <div
-                  className="box-hyphen left"
-                >
-                   
-                </div>
-              </div>
-              <div
-                className="media-description-layer media-description-bottom"
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": null,
                   }
                 }
               />


### PR DESCRIPTION
Here is the [support ticket associated](https://bluenove.atlassian.net/browse/SUPPORT-44) to this issue

The nugget diamond in the announcement was displayed even when there were no content. The problem was that the isValidDescription method would return true if content is null, it only checked that it's not an empty html paragraph.