### PR TITLE
Votes on landing page stats

### DIFF
--- a/assembl/graphql/docstrings.py
+++ b/assembl/graphql/docstrings.py
@@ -33,6 +33,7 @@ class Schema:
     default_preferences = """The default discussion preferences. These are server wide settings, independent of the debate."""
     locales = """The list of locales supported on the debate. These are the languages of the debate."""
     total_sentiments = """The total count of sentiments on the debate, regardless of chosen type. Deleted users' sentiments are not counted."""
+    total_vote_session_participations = """The total of all participations on all the vote sessions"""
     has_syntheses = """A boolean flag indicating if the debate has yet released a synthesis or not."""
     vote_session = """A vote session's meta data, if a vote session exists."""
     resources = """A list of Resource meta data on the debate."""

--- a/assembl/static2/js/app/components/administration/voteSession/gaugeForm.jsx
+++ b/assembl/static2/js/app/components/administration/voteSession/gaugeForm.jsx
@@ -198,9 +198,9 @@ const DumbGaugeForm = ({
         minimum={minimum}
         maximum={maximum}
         unit={unit}
-        handleMinChange={e => handleMinChange(e.target.value)}
-        handleMaxChange={e => handleMaxChange(e.target.value)}
-        handleUnitChange={e => handleUnitChange(e.target.value)}
+        handleMinChange={() => handleMinChange}
+        handleMaxChange={() => handleMaxChange}
+        handleUnitChange={() => handleUnitChange}
       />
     )}
     {!isNumberGauge && <TextGaugeForm choices={choices} handleGaugeChoiceLabelChange={handleGaugeChoiceLabelChange} />}
@@ -250,11 +250,11 @@ const mapDispatchToProps = (dispatch, { id, editLocale }) => ({
   // for number gauge
   handleMinChange: (value) => {
     dispatch(markAllDependenciesAsChanged(id));
-    dispatch(updateGaugeMinimum(id, value));
+    dispatch(updateGaugeMinimum(id, parseInt(value, 10)));
   },
   handleMaxChange: (value) => {
     dispatch(markAllDependenciesAsChanged(id));
-    dispatch(updateGaugeMaximum(id, value));
+    dispatch(updateGaugeMaximum(id, parseInt(value, 10)));
   },
   handleUnitChange: (value) => {
     dispatch(markAllDependenciesAsChanged(id));

--- a/assembl/static2/js/app/components/administration/voteSession/gaugeForm.jsx
+++ b/assembl/static2/js/app/components/administration/voteSession/gaugeForm.jsx
@@ -198,9 +198,9 @@ const DumbGaugeForm = ({
         minimum={minimum}
         maximum={maximum}
         unit={unit}
-        handleMinChange={() => handleMinChange}
-        handleMaxChange={() => handleMaxChange}
-        handleUnitChange={() => handleUnitChange}
+        handleMinChange={(value: number) => handleMinChange(value)}
+        handleMaxChange={(value: number) => handleMaxChange(value)}
+        handleUnitChange={(value: number) => handleUnitChange(value)}
       />
     )}
     {!isNumberGauge && <TextGaugeForm choices={choices} handleGaugeChoiceLabelChange={handleGaugeChoiceLabelChange} />}

--- a/assembl/static2/js/app/components/administration/voteSession/gaugeForm.jsx
+++ b/assembl/static2/js/app/components/administration/voteSession/gaugeForm.jsx
@@ -200,7 +200,7 @@ const DumbGaugeForm = ({
         unit={unit}
         handleMinChange={(value: number) => handleMinChange(value)}
         handleMaxChange={(value: number) => handleMaxChange(value)}
-        handleUnitChange={(value: number) => handleUnitChange(value)}
+        handleUnitChange={(value: string) => handleUnitChange(value)}
       />
     )}
     {!isNumberGauge && <TextGaugeForm choices={choices} handleGaugeChoiceLabelChange={handleGaugeChoiceLabelChange} />}

--- a/assembl/static2/js/app/components/administration/voteSession/numberGaugeForm.jsx
+++ b/assembl/static2/js/app/components/administration/voteSession/numberGaugeForm.jsx
@@ -20,44 +20,32 @@ const DumbNumberGaugeForm = ({
   handleMinChange,
   handleMaxChange,
   handleUnitChange
-}: NumberGaugeFormProps) => {
-  const onMinChange = (value: number) => {
-    if (value > 0) {
-      handleMinChange(value);
-    }
-  };
-  const onMaxChange = (value: number) => {
-    if (value > 0) {
-      handleMaxChange(value);
-    }
-  };
-  return (
-    <div>
-      <FormGroup>
-        <FormControlWithLabel
-          onChange={e => onMinChange(parseInt(e.target.value, 10))}
-          value={minimum ? minimum.toString() : ''}
-          label={I18n.t('administration.minValue')}
-          required
-          type="number"
-        />
-        <FormControlWithLabel
-          onChange={e => onMaxChange(parseInt(e.target.value, 10))}
-          value={maximum ? maximum.toString() : ''}
-          label={I18n.t('administration.maxValue')}
-          required
-          type="number"
-        />
-        <FormControlWithLabel
-          onChange={e => handleUnitChange(e.target.value)}
-          value={unit}
-          label={I18n.t('administration.unit')}
-          required
-          type="text"
-        />
-      </FormGroup>
-    </div>
-  );
-};
+}: NumberGaugeFormProps) => (
+  <React.Fragment>
+    <FormGroup>
+      <FormControlWithLabel
+        onChange={e => handleMinChange(parseInt(e.target.value, 10))}
+        value={minimum ? minimum.toString() : ''}
+        label={I18n.t('administration.minValue')}
+        required
+        type="number"
+      />
+      <FormControlWithLabel
+        onChange={e => handleMaxChange(parseInt(e.target.value, 10))}
+        value={maximum ? maximum.toString() : ''}
+        label={I18n.t('administration.maxValue')}
+        required
+        type="number"
+      />
+      <FormControlWithLabel
+        onChange={e => handleUnitChange(e.target.value)}
+        value={unit}
+        label={I18n.t('administration.unit')}
+        required
+        type="text"
+      />
+    </FormGroup>
+  </React.Fragment>
+);
 
 export default DumbNumberGaugeForm;

--- a/assembl/static2/js/app/components/administration/voteSession/numberGaugeForm.jsx
+++ b/assembl/static2/js/app/components/administration/voteSession/numberGaugeForm.jsx
@@ -20,26 +20,44 @@ const DumbNumberGaugeForm = ({
   handleMinChange,
   handleMaxChange,
   handleUnitChange
-}: NumberGaugeFormProps) => (
-  <div>
-    <FormGroup>
-      <FormControlWithLabel
-        onChange={value => handleMinChange(parseInt(value, 10))}
-        value={minimum ? minimum.toString() : ''}
-        label={I18n.t('administration.minValue')}
-        required
-        type="number"
-      />
-      <FormControlWithLabel
-        onChange={value => handleMaxChange(parseInt(value, 10))}
-        value={maximum ? maximum.toString() : ''}
-        label={I18n.t('administration.maxValue')}
-        required
-        type="number"
-      />
-      <FormControlWithLabel onChange={handleUnitChange} value={unit} label={I18n.t('administration.unit')} required type="text" />
-    </FormGroup>
-  </div>
-);
+}: NumberGaugeFormProps) => {
+  const onMinChange = (value: number) => {
+    if (value > 0) {
+      handleMinChange(value);
+    }
+  };
+  const onMaxChange = (value: number) => {
+    if (value > 0) {
+      handleMaxChange(value);
+    }
+  };
+  return (
+    <div>
+      <FormGroup>
+        <FormControlWithLabel
+          onChange={e => onMinChange(parseInt(e.target.value, 10))}
+          value={minimum ? minimum.toString() : ''}
+          label={I18n.t('administration.minValue')}
+          required
+          type="number"
+        />
+        <FormControlWithLabel
+          onChange={e => onMaxChange(parseInt(e.target.value, 10))}
+          value={maximum ? maximum.toString() : ''}
+          label={I18n.t('administration.maxValue')}
+          required
+          type="number"
+        />
+        <FormControlWithLabel
+          onChange={e => handleUnitChange(e.target.value)}
+          value={unit}
+          label={I18n.t('administration.unit')}
+          required
+          type="text"
+        />
+      </FormGroup>
+    </div>
+  );
+};
 
 export default DumbNumberGaugeForm;

--- a/assembl/static2/js/app/components/administration/voteSession/tokenCategoryForm.jsx
+++ b/assembl/static2/js/app/components/administration/voteSession/tokenCategoryForm.jsx
@@ -49,7 +49,9 @@ const DumbTokenCategoryForm = ({
         label={I18n.t('administration.tokenNumber')}
         required
         type="number"
-        onChange={v => handleNumberChange(parseInt(v, 10))}
+        onChange={(v) => {
+          handleNumberChange(parseInt(v, 10));
+        }}
         value={totalNumber.toString()}
         formControlProps={{
           min: '1'
@@ -83,9 +85,9 @@ const mapStateToProps = (state, { id, editLocale }) => {
 
 const mapDispatchToProps = (dispatch, { moduleId, id, editLocale }) => ({
   handleTitleChange: e => dispatch(updateTokenVoteCategoryTitle(id, editLocale, e.target.value, moduleId)),
-  handleNumberChange: (e) => {
-    if (e.target.value > 0) {
-      dispatch(updateTokenTotalNumber(id, e.target.value, moduleId));
+  handleNumberChange: (value) => {
+    if (value > 0) {
+      dispatch(updateTokenTotalNumber(id, value, moduleId));
     }
   },
   handleColorChange: color => dispatch(updateTokenVoteCategoryColor(id, color.hex, moduleId))

--- a/assembl/static2/js/app/components/administration/voteSession/tokenCategoryForm.jsx
+++ b/assembl/static2/js/app/components/administration/voteSession/tokenCategoryForm.jsx
@@ -49,9 +49,7 @@ const DumbTokenCategoryForm = ({
         label={I18n.t('administration.tokenNumber')}
         required
         type="number"
-        onChange={(v) => {
-          handleNumberChange(parseInt(v, 10));
-        }}
+        onChange={v => handleNumberChange(parseInt(v, 10))}
         value={totalNumber.toString()}
         formControlProps={{
           min: '1'

--- a/assembl/static2/js/app/components/administration/voteSession/tokenCategoryForm.jsx
+++ b/assembl/static2/js/app/components/administration/voteSession/tokenCategoryForm.jsx
@@ -49,7 +49,7 @@ const DumbTokenCategoryForm = ({
         label={I18n.t('administration.tokenNumber')}
         required
         type="number"
-        onChange={v => handleNumberChange(parseInt(v, 10))}
+        onChange={e => handleNumberChange(parseInt(e.target.value, 10))}
         value={totalNumber.toString()}
         formControlProps={{
           min: '1'

--- a/assembl/static2/js/app/components/common/formControlWithLabel.jsx
+++ b/assembl/static2/js/app/components/common/formControlWithLabel.jsx
@@ -17,7 +17,7 @@ import Helper from './helper';
 type FormControlWithLabelProps = {
   value: ?(string | EditorState),
   required: boolean,
-  onChange: (string | EditorState | number) => void,
+  onChange: Function,
   type: string,
   disabled?: boolean,
   name?: string,

--- a/assembl/static2/js/app/components/common/formControlWithLabel.jsx
+++ b/assembl/static2/js/app/components/common/formControlWithLabel.jsx
@@ -17,7 +17,7 @@ import Helper from './helper';
 type FormControlWithLabelProps = {
   value: ?(string | EditorState),
   required: boolean,
-  onChange: Function,
+  onChange: (string | EditorState | number) => void,
   type: string,
   disabled?: boolean,
   name?: string,

--- a/assembl/static2/js/app/components/common/formControlWithLabel.jsx
+++ b/assembl/static2/js/app/components/common/formControlWithLabel.jsx
@@ -148,7 +148,7 @@ class FormControlWithLabel extends React.Component<FormControlWithLabelProps, Fo
         name={name}
         type={type}
         placeholder={this.getLabel()}
-        onChange={event => onChange(event.target.value)}
+        onChange={onChange}
         value={valueToShow}
         onBlur={this.setValidationState}
         {...additionalProps}

--- a/assembl/static2/js/app/components/common/formControlWithLabel.jsx
+++ b/assembl/static2/js/app/components/common/formControlWithLabel.jsx
@@ -148,7 +148,7 @@ class FormControlWithLabel extends React.Component<FormControlWithLabelProps, Fo
         name={name}
         type={type}
         placeholder={this.getLabel()}
-        onChange={onChange}
+        onChange={event => onChange(event.target.value)}
         value={valueToShow}
         onBlur={this.setValidationState}
         {...additionalProps}

--- a/assembl/static2/js/app/components/home/header/statistic.jsx
+++ b/assembl/static2/js/app/components/home/header/statistic.jsx
@@ -19,14 +19,15 @@ type Props = {
   rootIdea: Idea,
   numParticipants: number,
   totalSentiments: number,
+  totalVoteSessionParticipations: number,
   visitsAnalytics: VisitsAnalytics
 };
 
 class Statistic extends React.PureComponent<Props> {
   render() {
-    const { rootIdea, numParticipants, totalSentiments, visitsAnalytics } = this.props;
+    const { rootIdea, numParticipants, totalSentiments, totalVoteSessionParticipations, visitsAnalytics } = this.props;
     const { sumVisitsLength, nbPageviews } = visitsAnalytics;
-    const statElements = [statSentiments(totalSentiments), statParticipants(numParticipants)];
+    const statElements = [statSentiments(totalSentiments + totalVoteSessionParticipations), statParticipants(numParticipants)];
     if (rootIdea) {
       statElements.push(statMessages(rootIdea.numPosts));
     }
@@ -60,7 +61,9 @@ class Statistic extends React.PureComponent<Props> {
 
 export default compose(
   graphql(RootIdeaStatsQuery, {
-    props: ({ data: { rootIdea, numParticipants, totalSentiments, visitsAnalytics, loading, error } }) => {
+    props: ({
+      data: { rootIdea, numParticipants, totalSentiments, visitsAnalytics, loading, error, totalVoteSessionParticipations }
+    }) => {
       if (error || loading) {
         return {
           error: error,
@@ -71,7 +74,8 @@ export default compose(
         rootIdea: rootIdea,
         numParticipants: numParticipants,
         totalSentiments: totalSentiments,
-        visitsAnalytics: visitsAnalytics
+        visitsAnalytics: visitsAnalytics,
+        totalVoteSessionParticipations: totalVoteSessionParticipations
       };
     }
   }),

--- a/assembl/static2/js/app/components/home/header/statistic.jsx
+++ b/assembl/static2/js/app/components/home/header/statistic.jsx
@@ -1,24 +1,39 @@
-// @noflow
+// @flow
 import * as React from 'react';
 import { compose, graphql } from 'react-apollo';
 import { I18n } from 'react-redux-i18n';
 import moment from 'moment';
 import 'moment-duration-format'; // needed for momentDuration.format()
-import RootIdeaStats from '../../../graphql/RootIdeaStats.graphql';
+import RootIdeaStatsQuery from '../../../graphql/RootIdeaStats.graphql';
 import manageErrorAndLoading from '../../../components/common/manageErrorAndLoading';
 import HeaderStatistics, { statMessages, statParticipants, statSentiments } from '../../../components/common/headerStatistics';
 
-class Statistic extends React.Component<$FlowFixMeProps> {
+export type VisitsAnalytics = {
+  nbPageviews: ?number,
+  npUniqPageviews: ?number,
+  sumVisitsLength: ?number,
+  __typename?: 'VisitsAnalytics'
+};
+
+type Props = {
+  rootIdea: Idea,
+  numParticipants: number,
+  totalSentiments: number,
+  visitsAnalytics: VisitsAnalytics
+};
+
+class Statistic extends React.PureComponent<Props> {
   render() {
-    const { rootIdea, numParticipants, totalSentiments, visitsAnalytics } = this.props.data;
+    const { rootIdea, numParticipants, totalSentiments, visitsAnalytics } = this.props;
+    const { sumVisitsLength, nbPageviews } = visitsAnalytics;
     const statElements = [statSentiments(totalSentiments), statParticipants(numParticipants)];
     if (rootIdea) {
       statElements.push(statMessages(rootIdea.numPosts));
     }
 
     if (visitsAnalytics) {
-      if ('sumVisitsLength' in visitsAnalytics && visitsAnalytics.sumVisitsLength > 0) {
-        const totalSeconds = visitsAnalytics.sumVisitsLength;
+      if (sumVisitsLength && sumVisitsLength > 0) {
+        const totalSeconds = sumVisitsLength;
         // Second parameter of parseInt() is mandatory, see
         // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt
         const secondsAsNumber = parseInt(totalSeconds, 10);
@@ -31,10 +46,10 @@ class Statistic extends React.Component<$FlowFixMeProps> {
           metricNameTranslateKey: 'home.sumVisitsLength'
         });
       }
-      if ('nbPageviews' in visitsAnalytics && visitsAnalytics.nbPageviews > 0) {
+      if (nbPageviews && nbPageviews > 0) {
         statElements.push({
           iconName: 'double-page',
-          metricValue: visitsAnalytics.nbPageviews,
+          metricValue: nbPageviews,
           metricNameTranslateKey: 'home.pageViews'
         });
       }
@@ -43,4 +58,22 @@ class Statistic extends React.Component<$FlowFixMeProps> {
   }
 }
 
-export default compose(graphql(RootIdeaStats), manageErrorAndLoading({ textHidden: true, color: 'white' }))(Statistic);
+export default compose(
+  graphql(RootIdeaStatsQuery, {
+    props: ({ data: { rootIdea, numParticipants, totalSentiments, visitsAnalytics, loading, error } }) => {
+      if (error || loading) {
+        return {
+          error: error,
+          loading: loading
+        };
+      }
+      return {
+        rootIdea: rootIdea,
+        numParticipants: numParticipants,
+        totalSentiments: totalSentiments,
+        visitsAnalytics: visitsAnalytics
+      };
+    }
+  }),
+  manageErrorAndLoading({ displayLoader: false, textHidden: true, color: 'white' })
+)(Statistic);

--- a/assembl/static2/js/app/graphql/RootIdeaStats.graphql
+++ b/assembl/static2/js/app/graphql/RootIdeaStats.graphql
@@ -8,6 +8,7 @@ query RootIdeaStats {
     }
   }
   totalSentiments
+  totalVoteSessionParticipations
   numParticipants
   visitsAnalytics {
     sumVisitsLength

--- a/assembl/static2/js/app/pages/voteSession.jsx
+++ b/assembl/static2/js/app/pages/voteSession.jsx
@@ -267,8 +267,9 @@ class DumbVoteSession extends React.Component<Props, State> {
 
   submitVotes = () => {
     const { addTokenVote, addGaugeVote, refetchVoteSession } = this.props;
+    const { userTokenVotes, userGaugeVotes } = this.state;
     this.setState({ submitting: true });
-    this.state.userTokenVotes.forEach((voteSpecs, proposalId) => {
+    userTokenVotes.forEach((voteSpecs, proposalId) => {
       voteSpecs.forEach((tokenCategories, voteSpecId) => {
         tokenCategories.forEach((voteValue, tokenCategoryId) => {
           addTokenVote({
@@ -289,7 +290,7 @@ class DumbVoteSession extends React.Component<Props, State> {
         });
       });
     });
-    this.state.userGaugeVotes.forEach((voteSpecs, proposalId) => {
+    userGaugeVotes.forEach((voteSpecs, proposalId) => {
       voteSpecs.forEach((voteValue, voteSpecId) => {
         addGaugeVote({
           variables: {
@@ -311,7 +312,7 @@ class DumbVoteSession extends React.Component<Props, State> {
   getStatElements = () => {
     let numParticipations = 0;
     let participantsIds = [];
-    this.props.proposals.forEach((p) => {
+    this.props.proposals.forEach((p: Proposal) => {
       participantsIds = participantsIds
         .concat(
           p.voteResults.participants.map((participant) => {

--- a/assembl/static2/tests/unit/components/administration/voteSession/__snapshots__/numberGaugeForm.spec.jsx.snap
+++ b/assembl/static2/tests/unit/components/administration/voteSession/__snapshots__/numberGaugeForm.spec.jsx.snap
@@ -30,7 +30,7 @@ exports[`DumbNumberGaugeForm component should render a form to set up a numeral 
       helperUrl=""
       label="Unit"
       labelAlwaysVisible={false}
-      onChange={[MockFunction]}
+      onChange={[Function]}
       required={true}
       type="text"
       value="kms"

--- a/assembl/static2/tests/unit/components/administration/voteSession/__snapshots__/numberGaugeForm.spec.jsx.snap
+++ b/assembl/static2/tests/unit/components/administration/voteSession/__snapshots__/numberGaugeForm.spec.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DumbNumberGaugeForm component should render a form to set up a numeral gauge 1`] = `
-<div>
+<React.Fragment>
   <FormGroup
     bsClass="form-group"
   >
@@ -36,5 +36,5 @@ exports[`DumbNumberGaugeForm component should render a form to set up a numeral 
       value="kms"
     />
   </FormGroup>
-</div>
+</React.Fragment>
 `;

--- a/assembl/tests/views_tests/test_graphql_ideas.py
+++ b/assembl/tests/views_tests/test_graphql_ideas.py
@@ -473,6 +473,23 @@ def test_graphql_discussion_counters_all_phases(graphql_request, proposals, top_
     assert res.data['rootIdea']['numPosts'] == 16  # phase 1+2 posts counted because all posts come from discussion.root_idea
     assert res.data['numParticipants'] == 1
 
+def test_graphql_total_vote_session_participations_zero_vote(graphql_request, proposals, phases):
+    res = schema.execute(
+        u"""query RootIdeaStats {
+              totalVoteSessionParticipations
+            }
+        """, context_value=graphql_request)
+    assert res.errors is None
+    assert res.data['totalVoteSessionParticipations'] == 0
+
+def test_graphql_total_vote_session_participations_4_votes(graphql_request, phases, graphql_participant1_request, vote_session, vote_proposal, token_vote_spec_with_votes, gauge_vote_specification_with_votes, graphql_registry):
+    res = schema.execute(
+        u"""query RootIdeaStats {
+              totalVoteSessionParticipations
+            }
+        """, context_value=graphql_request)
+    assert res.errors is None
+    assert res.data['totalVoteSessionParticipations'] == 4
 
 def test_get_long_title_on_idea(graphql_request, idea_in_thread_phase):
     # This is the "What you need to know"


### PR DESCRIPTION
This PR is linked to [this ticket](https://bluenove.atlassian.net/browse/DEVAS-1727).

What we do here is that we now add both vote sessions' participations and sentiments on posts as the new "participations" metric on the landing page stats