### PR TITLE
Automate Uptime Robot

### DIFF
--- a/assembl/configs/base_env.rc
+++ b/assembl/configs/base_env.rc
@@ -114,6 +114,9 @@ _package_install = false
 # bugherd_url
 # bugherd_key
 # wsginame
+#
+# For servers to be monitored by Uptime Robot
+# _uptime_robot_api_key
 
 # Optional - Path to SSL Stapling certificates, must be single file
 # on server

--- a/assembl/fabfile.py
+++ b/assembl/fabfile.py
@@ -3229,6 +3229,9 @@ def remove_server_from_uptime_robot():
         print(red("No Uptime Robot API key has been set for this server. Cannot progress any further..."))
         exit(1)
     location = join(env.projectpath, '.monitor_id')
+    if not exists(location):
+        print(red("The monitor id was not found. Cannot progress any further..."))
+        exit(1)
     monitor_id = run('cat %s' % location)
     if not monitor_id:
         print(red("No monitor id was found for this server. Quitting..."))

--- a/assembl/fabfile.py
+++ b/assembl/fabfile.py
@@ -1677,7 +1677,8 @@ def install_server_deps():
     """
     execute(install_fail2ban)
     execute(install_jq)
-    execute(add_server_to_uptime_robot)
+    if not is_integration_env() or not env.get('wsginame') == 'dev.wsgi':
+        execute(add_server_to_uptime_robot)
 
 
 @task


### PR DESCRIPTION
Ability to quickly and seamlessly add/remove monitors that track the uptime of our production servers. Uptime Robot has been added to the Bluenove Slack channel `server_status`, pending approval by @moutard-bluenove . 

All future server installations will have uptime robot automatically set up to be monitored, and tracking is done via slack. From the existing set of servers, the following have been tracked.

✅ stats.bluenove.com
✅ sentry.bluenove.com
✅ preprod-assembl.bluenove.com
✅ dev-assembl.bluenove.com
❌ client servers