### PR TITLE
Fix links in rich text editors that are in react-final-form forms

### DIFF
--- a/assembl/static2/js/app/components/form/multilingualRichTextFieldAdapter.jsx
+++ b/assembl/static2/js/app/components/form/multilingualRichTextFieldAdapter.jsx
@@ -2,10 +2,9 @@
 import { EditorState } from 'draft-js';
 import React from 'react';
 import { type FieldRenderProps } from 'react-final-form';
-import { FormGroup } from 'react-bootstrap';
+import { FormGroup, HelpBlock } from 'react-bootstrap';
 
 import RichTextEditor from '../common/richTextEditor';
-import Error from './error';
 import { getValidationState } from './utils';
 
 type multilingualValue = { [string]: EditorState };
@@ -43,7 +42,8 @@ const RichTextFieldAdapter = ({
         onChange={es => onChange({ ...value, [editLocale]: es })}
         withAttachmentButton={withAttachmentButton}
       />
-      <Error name={name} />
+      {/* Warning: we can't use Error component here because having 2 fields with the same name breaks links in Editor */}
+      {touched && error ? <HelpBlock>{error}</HelpBlock> : null}
     </FormGroup>
   );
 };

--- a/assembl/static2/tests/unit/components/form/__snapshots__/multilingualRichTextFieldAdapter.spec.jsx.snap
+++ b/assembl/static2/tests/unit/components/form/__snapshots__/multilingualRichTextFieldAdapter.spec.jsx.snap
@@ -370,6 +370,11 @@ exports[`MultilingualRichTextFieldAdapter component should render a rich text fi
       toolbarPosition="bottom"
       withAttachmentButton={false}
     />
+    <span
+      className="help-block"
+    >
+      This field is required
+    </span>
   </div>
   <button
     disabled={true}


### PR DESCRIPTION
It seems that there is a problem in the rendering of the Draft-js editor when there is two fields that have the same name. It fixes links in rich text in the administration (DEVAS-1698).