### PR TITLE
debug the sso modal

### DIFF
--- a/assembl/static2/js/app/components/cookies/acceptCookiesModal.spec.jsx
+++ b/assembl/static2/js/app/components/cookies/acceptCookiesModal.spec.jsx
@@ -12,7 +12,7 @@ const updateAcceptedCookiesSpy = jest.fn(() => {});
 
 const defaultAcceptCookiesModalProps = {
   pathname: 'fakeSlug/home',
-  userId: '1234',
+  id: '1234',
   hasTermsAndConditions: true,
   hasPrivacyPolicy: true,
   hasUserGuidelines: true,


### PR DESCRIPTION
We had to add a manageErrorAndLoading right after the tabsconditionQuery. Without the manageErrorAndLoading, the component was rendering before the end of the query. Vincent give me a cleaner solution but I was not able to make this solution works. 

We have to put this.showModal in componentDidMount and ComponentDidUpdate because when we go to an authorized route like the CGU page and then go back to an unauthorized route, the modal was not rendering again. It works with this.showModal in ComponentDidUpdate. 