### PR TITLE
Show the display name in the navbar

### DIFF
--- a/assembl/static2/js/app/components/common/avatar.jsx
+++ b/assembl/static2/js/app/components/common/avatar.jsx
@@ -11,18 +11,28 @@ import manageErrorAndLoading from './manageErrorAndLoading';
 import { browserHistory } from '../../router';
 import { localAwareLink } from '../../utils/utilityManager';
 
-type Props = {
+export type Props = {
   // used by getDerivedStateFromProps
   location: string, // eslint-disable-line
   slug: string,
   connectedUserId: string,
   loginData: {
     url: string,
-    local: string
-  }
+    local: boolean
+  },
+  displayName: string,
+  split: ?boolean
 };
 
 type State = { next: string };
+
+const LoginAnchor = () => (
+  <div className="connection">
+    <Translate value="navbar.connection" />
+  </div>
+);
+
+export const LocalAwareAnchor = localAwareLink(LoginAnchor);
 
 class Avatar extends React.Component<Props, State> {
   static getDerivedStateFromProps(props: Props) {
@@ -35,7 +45,7 @@ class Avatar extends React.Component<Props, State> {
   state = { next: '' };
 
   render() {
-    const { slug, connectedUserId, loginData } = this.props;
+    const { slug, connectedUserId, loginData, displayName, split } = this.props;
     let loginUrl = `${getContextual('login', { slug: slug })}?next=${this.state.next}`;
     if (loginData && loginData.url) {
       loginUrl = loginData.url.includes('?')
@@ -46,16 +56,11 @@ class Avatar extends React.Component<Props, State> {
       <div className="inline">
         <span className="assembl-icon-profil grey" />
         <span className="user-account">
-          <Translate value="profile.panelTitle" />
+          {displayName && displayName.length >= 17 && split ? `${displayName.substring(0, 17)}...` : displayName}
         </span>
       </div>
     );
-    const LoginAnchor = () => (
-      <div className="connection">
-        <Translate value="navbar.connection" />
-      </div>
-    );
-    const LocalAwareAnchor = localAwareLink(LoginAnchor);
+
     const urlData = { url: loginUrl, local: loginData.local };
     return (
       <div className="right avatar">
@@ -89,6 +94,8 @@ const mapStateToProps = ({ context, debate }) => ({
   connectedUserId: context.connectedUserId,
   id: context.connectedUserIdBase64
 });
+
+export { Avatar };
 
 export default compose(
   connect(mapStateToProps),

--- a/assembl/static2/js/app/components/navbar/UserMenu.jsx
+++ b/assembl/static2/js/app/components/navbar/UserMenu.jsx
@@ -28,7 +28,7 @@ const UserMenu = ({ location, helpUrl, loginData }: UserMenuProps) => (
           <span className="assembl-icon-faq grey" />
         </Link>
       )}
-    <Avatar location={location} loginData={loginData} />
+    <Avatar location={location} loginData={loginData} split />
   </div>
 );
 

--- a/assembl/static2/tests/unit/components/common/avatar.spec.jsx
+++ b/assembl/static2/tests/unit/components/common/avatar.spec.jsx
@@ -1,0 +1,73 @@
+// @flow
+import React from 'react';
+import Adapter from 'enzyme-adapter-react-16';
+import { configure, shallow, mount } from 'enzyme';
+import { NavDropdown } from 'react-bootstrap';
+
+import { Avatar, LocalAwareAnchor } from '../../../../js/app/components/common/avatar';
+import type { Props } from '../../../../js/app/components/common/avatar';
+
+configure({ adapter: new Adapter() });
+
+const props: Props = {
+  location: '/ai-consultation/profile/1234',
+  slug: 'ai-consultation',
+  connectedUserId: '1234',
+  loginData: {
+    url: '/ai-consultation/login',
+    local: true
+  },
+  displayName: 'Johnny',
+  split: true
+};
+
+describe('<Avatar /> - with shallow', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = shallow(<Avatar {...props} />);
+  });
+
+  it('Should not render LocalAwareAnchor component when the user is connected', () => {
+    expect(wrapper.find(LocalAwareAnchor)).toHaveLength(0);
+  });
+
+  it('Should render LocalAwareAnchor component when the user is disconnected', () => {
+    wrapper.setProps({ connectedUserId: null });
+    expect(wrapper.find(LocalAwareAnchor)).toHaveLength(1);
+  });
+
+  it('Should render NavDropdown component when the user is connected', () => {
+    expect(wrapper.find(NavDropdown)).toHaveLength(1);
+  });
+
+  it('Should not render NavDropdown component when the user is disconnected', () => {
+    wrapper.setProps({ connectedUserId: null });
+    expect(wrapper.find(NavDropdown)).toHaveLength(0);
+  });
+});
+
+describe('<Avatar /> - with mount', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = mount(<Avatar {...props} />);
+  });
+
+  it('Should split the display name if is longer than or equal to 17 length', () => {
+    wrapper.setProps({ displayName: 'Johnny the king of kings' });
+    const span = wrapper.find('span [className="user-account"]');
+    expect(span.text()).toEqual('Johnny the king o...');
+  });
+
+  it('Should not split the display name if is smaller than 17 length', () => {
+    const span = wrapper.find('span [className="user-account"]');
+    expect(span.text()).toEqual('Johnny');
+  });
+
+  it('Should not split the display name if split prop is false', () => {
+    wrapper.setProps({ displayName: 'Johnny the king of kings', split: false });
+    const span = wrapper.find('span [className="user-account"]');
+    expect(span.text()).toEqual('Johnny the king of kings');
+  });
+});


### PR DESCRIPTION
- Show the display name instead of « my account »
- Split the display name if it’s too long
- Split the display name according to the context
- Improve the test coverage
