### PR TITLE
bugherd-72 keep the same idea width during the transition

### DIFF
--- a/assembl/static2/css/components/ideas.scss
+++ b/assembl/static2/css/components/ideas.scss
@@ -209,7 +209,6 @@
 
 @media screen and (min-width: 768px) {
   .theme-inline {
-    min-width: 280px;
-    max-width: 350px;
+    min-width: 350px;
   }
 }


### PR DESCRIPTION
https://www.bugherd.com/projects/158157/tasks/72

"J'ai un effet bizarre lorsque je clique sur "Voir les 2 sous-thémes", l'image se rétrécie avant de prendre sa taille normale. Il n'y a un effet de bord suite à la modification liée à l'absence d'un module pour une thématique ?"