### PR TITLE
Add hsts header to the nginx template

### DIFF
--- a/assembl/templates/system/nginx_default.jinja2
+++ b/assembl/templates/system/nginx_default.jinja2
@@ -18,6 +18,7 @@ upstream urlmetadata {
 server {
   {% if accept_secure_connection %}
     listen 443 ssl http2;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     {% if nginx_ipv6 %}
     listen   [::]:443 ssl http2;
     {% endif %}

--- a/assembl/templates/system/nginx_default.jinja2
+++ b/assembl/templates/system/nginx_default.jinja2
@@ -18,7 +18,9 @@ upstream urlmetadata {
 server {
   {% if accept_secure_connection %}
     listen 443 ssl http2;
+    {% if hsts_header %}
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    {% endif %}
     {% if nginx_ipv6 %}
     listen   [::]:443 ssl http2;
     {% endif %}


### PR DESCRIPTION
Without HSTS, a client may ask an unencrypted connection and be served by the server a 301 redirection. An hacker can intercept this redirection. To enforce HTTPS in the first exchange, HSTS header must be present.

This was implemented based on:
https://www.nginx.com/blog/http-strict-transport-security-hsts-and-nginx/