### PR TITLE
Translation activation control

### DIFF
--- a/assembl/graphql/discussion.py
+++ b/assembl/graphql/discussion.py
@@ -312,6 +312,7 @@ class DiscussionPreferences(graphene.ObjectType):
     favicon = graphene.Field(Document, description=docs.DiscussionPreferences.favicon)
     logo = graphene.Field(Document, description=docs.DiscussionPreferences.logo)
     with_moderation = graphene.Boolean(description=docs.DiscussionPreferences.with_moderation)
+    with_translation = graphene.Boolean(description=docs.DiscussionPreferences.with_translation)
     slug = graphene.String(required=True, description=docs.DiscussionPreferences.slug)
     old_slugs = graphene.List(graphene.String, required=True, description=docs.DiscussionPreferences.old_slugs)
 
@@ -338,6 +339,9 @@ class DiscussionPreferences(graphene.ObjectType):
 
     def resolve_with_moderation(self, args, context, info):
         return self.get('with_moderation')
+
+    def resolve_with_translation(self, args, context, info):
+        return self.get('with_translation')
 
     def resolve_slug(self, args, context, info):
         discussion_id = context.matchdict['discussion_id']
@@ -574,6 +578,7 @@ class UpdateDiscussionPreferences(graphene.Mutation):
         favicon = graphene.String(description=docs.UpdateDiscussionPreferences.favicon)
         logo = graphene.String(description=docs.UpdateDiscussionPreferences.logo)
         with_moderation = graphene.Boolean(description=docs.UpdateDiscussionPreferences.with_moderation)
+        with_translation = graphene.Boolean(description=docs.UpdateDiscussionPreferences.with_translation)
         slug = graphene.String(description=docs.UpdateDiscussionPreferences.slug)
 
     preferences = graphene.Field(lambda: DiscussionPreferences)
@@ -590,6 +595,7 @@ class UpdateDiscussionPreferences(graphene.Mutation):
         favicon = args.get('favicon', None)
         logo = args.get('logo', None)
         with_moderation = args.get('with_moderation', None)
+        with_translation = args.get('with_translation', None)
         slug = args.get('slug', None)
         with cls.default_db.no_autoflush as db:
             if languages is not None:
@@ -626,6 +632,9 @@ class UpdateDiscussionPreferences(graphene.Mutation):
 
             if with_moderation is not None:
                 discussion.preferences['with_moderation'] = with_moderation
+
+            if with_translation is not None:
+                discussion.preferences['with_translation'] = with_translation
 
             if slug is not None:
                 if slug != discussion.slug:

--- a/assembl/graphql/discussion.py
+++ b/assembl/graphql/discussion.py
@@ -341,7 +341,13 @@ class DiscussionPreferences(graphene.ObjectType):
         return self.get('with_moderation')
 
     def resolve_with_translation(self, args, context, info):
-        return self.get('with_translation')
+        discussion_id = context.matchdict['discussion_id']
+        discussion = models.Discussion.get(discussion_id)
+        translation_service = discussion.preferences['translation_service']
+        if translation_service == 'assembl.nlp.translation_service.GoogleTranslationService':
+            return True
+        else:
+            return False
 
     def resolve_slug(self, args, context, info):
         discussion_id = context.matchdict['discussion_id']
@@ -633,8 +639,10 @@ class UpdateDiscussionPreferences(graphene.Mutation):
             if with_moderation is not None:
                 discussion.preferences['with_moderation'] = with_moderation
 
-            if with_translation is not None:
-                discussion.preferences['with_translation'] = with_translation
+            if with_translation is True:
+                discussion.preferences['translation_service'] = "assembl.nlp.translation_service.GoogleTranslationService"
+            else:
+                discussion.preferences['translation_service'] = ""
 
             if slug is not None:
                 if slug != discussion.slug:

--- a/assembl/graphql/docstrings.py
+++ b/assembl/graphql/docstrings.py
@@ -119,6 +119,7 @@ class DiscussionPreferences:
     favicon = Default.document % ("""The site favicon.""",)
     logo = Default.document % ("""The site logo.""",)
     with_moderation = """A Boolean flag indicating whether the moderation is activated or not."""
+    with_translation = """A Boolean flag indicating wheter the users have the possibility to translate the messages or not."""
     slug = Discussion.slug
     old_slugs = """List of previous used slugs for this discussion"""
 
@@ -164,6 +165,7 @@ class UpdateDiscussionPreferences:
     favicon = DiscussionPreferences.favicon
     logo = DiscussionPreferences.logo
     with_moderation = DiscussionPreferences.with_moderation
+    with_translation = DiscussionPreferences.with_translation
     slug = DiscussionPreferences.slug
 
 

--- a/assembl/models/preferences.py
+++ b/assembl/models/preferences.py
@@ -1087,6 +1087,15 @@ class Preferences(MutableMapping, Base, NamedClassMixin):
             "modification_permission": P_ADMIN_DISC,
             "default": False,
         },
+        {
+            "id": "with_translation",
+            "value_type": "bool",
+            "name": _("Translation option"),
+            "description": _("Is the translation of messages activated or not"),
+            "allow_user_override": None,
+            "modification_permission": P_ADMIN_DISC,
+            "default": True,
+        },
     ]
 
     # Precompute, this is not mutable.

--- a/assembl/models/preferences.py
+++ b/assembl/models/preferences.py
@@ -1086,16 +1086,7 @@ class Preferences(MutableMapping, Base, NamedClassMixin):
             "allow_user_override": None,
             "modification_permission": P_ADMIN_DISC,
             "default": False,
-        },
-        {
-            "id": "with_translation",
-            "value_type": "bool",
-            "name": _("Translation option"),
-            "description": _("Is the translation of messages activated or not"),
-            "allow_user_override": None,
-            "modification_permission": P_ADMIN_DISC,
-            "default": True,
-        },
+        }
     ]
 
     # Precompute, this is not mutable.

--- a/assembl/static2/js/app/components/administration/discussion/preferences/index.jsx
+++ b/assembl/static2/js/app/components/administration/discussion/preferences/index.jsx
@@ -95,6 +95,17 @@ class DiscussionPreferencesForm extends React.Component<Props, State> {
                     label={I18n.t('administration.activateModeration')}
                     type="checkbox"
                   />
+                  <div className="separator" />
+                  <div className="title">
+                    <Translate value="administration.translation" />
+                  </div>
+                  <Field
+                    component={CheckboxFieldAdapter}
+                    name="withTranslation"
+                    isChecked
+                    label={I18n.t('administration.activateTranslation')}
+                    type="checkbox"
+                  />
                 </div>
               </AdminForm>
             </div>

--- a/assembl/static2/js/app/components/administration/discussion/preferences/load.js
+++ b/assembl/static2/js/app/components/administration/discussion/preferences/load.js
@@ -39,9 +39,11 @@ export function postLoadFormat(data: Data): DiscussionPreferencesFormValues {
     label: language.label,
     value: language.localeCode
   }));
+  const { withModeration, withTranslation, slug } = discussionPreferences;
   return {
     languages: languages,
-    withModeration: discussionPreferences.withModeration,
-    slug: discussionPreferences.slug
+    withModeration: withModeration,
+    withTranslation: withTranslation,
+    slug: slug
   };
 }

--- a/assembl/static2/js/app/components/administration/discussion/preferences/save.js
+++ b/assembl/static2/js/app/components/administration/discussion/preferences/save.js
@@ -9,6 +9,7 @@ import { SECTION_DISCUSSION_PREFERENCES } from '../../../../constants';
 const getVariables = async (client: ApolloClient, values: DiscussionPreferencesFormValues) => ({
   languages: convertCheckboxListValueToVariable(values.languages),
   withModeration: values.withModeration,
+  withTranslation: values.withTranslation,
   slug: values.slug
 });
 

--- a/assembl/static2/js/app/components/administration/discussion/preferences/types.flow.js
+++ b/assembl/static2/js/app/components/administration/discussion/preferences/types.flow.js
@@ -4,5 +4,6 @@ import { type CheckboxListValue } from '../../../form/types.flow';
 export type DiscussionPreferencesFormValues = {
   languages: CheckboxListValue,
   withModeration: boolean,
+  withTranslation: Boolean,
   slug: string
 };

--- a/assembl/static2/js/app/graphql/DiscussionPreferences.graphql
+++ b/assembl/static2/js/app/graphql/DiscussionPreferences.graphql
@@ -6,6 +6,7 @@ query DiscussionPreferences($inLocale: String!) {
       nativeName
     }
     withModeration
+    withTranslation
     slug
   }
 }

--- a/assembl/static2/js/app/graphql/mutations/updateDiscussionPreference.graphql
+++ b/assembl/static2/js/app/graphql/mutations/updateDiscussionPreference.graphql
@@ -1,6 +1,7 @@
 mutation updateDiscussionPreference(
   $languages: [String]
   $withModeration: Boolean
+  $withTranslation: Boolean
   $tabTitle: String
   $favicon: String
   $slug: String
@@ -9,6 +10,7 @@ mutation updateDiscussionPreference(
   updateDiscussionPreferences(
     languages: $languages
     withModeration: $withModeration
+    withTranslation: $withTranslation
     tabTitle: $tabTitle
     favicon: $favicon
     slug: $slug

--- a/assembl/static2/js/app/utils/translations.js
+++ b/assembl/static2/js/app/utils/translations.js
@@ -863,7 +863,7 @@ const Translations = {
       moderation: "Modération à priori",
       activateModeration: "Activer la modération",
       translation: "Option de traduction pour les utilisateurs",
-      activateTranslation: "Ativer l'option pour les utilisateurs de traduire les messages",
+      activateTranslation: "Activer l'option pour les utilisateurs de traduire les messages",
       ph: {
         propositionSectionTitle: "Titre de la section",
         propositionSectionSubtitle: "Sous-titre de la section",

--- a/assembl/static2/js/app/utils/translations.js
+++ b/assembl/static2/js/app/utils/translations.js
@@ -862,6 +862,8 @@ const Translations = {
       languageChoice: "Sélection des langues du débat",
       moderation: "Modération à priori",
       activateModeration: "Activer la modération",
+      translation: "Option de traduction pour les utilisateurs",
+      activateTranslation: "Ativer l'option pour les utilisateurs de traduire les messages",
       ph: {
         propositionSectionTitle: "Titre de la section",
         propositionSectionSubtitle: "Sous-titre de la section",
@@ -1880,6 +1882,8 @@ const Translations = {
       languageChoice: "Select desired languages below",
       moderation: "Post pending for moderation",
       activateModeration: "Activate the moderation",
+      translation: "Option to translate messages",
+      activateTranslation: "Activate the options for user to translate the messages",
       ph: {
         propositionSectionTitle: "Section title",
         propositionSectionSubtitle: "Section subtitle",

--- a/assembl/static2/js/app/utils/translations.js
+++ b/assembl/static2/js/app/utils/translations.js
@@ -1883,7 +1883,7 @@ const Translations = {
       moderation: "Post pending for moderation",
       activateModeration: "Activate the moderation",
       translation: "Option to translate messages",
-      activateTranslation: "Activate the options for user to translate the messages",
+      activateTranslation: "Activate the option for users to translate the messages",
       ph: {
         propositionSectionTitle: "Section title",
         propositionSectionSubtitle: "Section subtitle",

--- a/assembl/tests/fixtures/discussion.py
+++ b/assembl/tests/fixtures/discussion.py
@@ -209,3 +209,9 @@ def discussion_with_moderation(discussion, test_session):
     discussion.preferences['with_moderation'] = True
     test_session.commit()
     return discussion
+
+@pyest.fixture(scope="function")
+def discussion_with_translation(discussion, test_session):
+    discussion.preferences['with_translation'] = True
+    test_session.commit()
+    return discussion

--- a/assembl/tests/fixtures/discussion.py
+++ b/assembl/tests/fixtures/discussion.py
@@ -210,7 +210,7 @@ def discussion_with_moderation(discussion, test_session):
     test_session.commit()
     return discussion
 
-@pyest.fixture(scope="function")
+@pytest.fixture(scope="function")
 def discussion_with_translation(discussion, test_session):
     discussion.preferences['with_translation'] = True
     test_session.commit()

--- a/assembl/tests/views_tests/test_graphql.py
+++ b/assembl/tests/views_tests/test_graphql.py
@@ -1693,7 +1693,7 @@ query { discussionPreferences { languages { locale, name(inLocale:"fr"), nativeN
             u'favicon': None,
             u'logo': None,
             u'tabTitle': '',
-            u'withModeration': False
+            u'withModeration': False,
             u'withTranslation': True
         }
     }
@@ -1709,7 +1709,7 @@ def test_query_discussion_preferences_moderation(graphql_registry, graphql_reque
             u'logo': None,
             u'tabTitle': '',
             u'withModeration': True,
-            u'withTranslation': True
+            u'withTranslation': True,
         }
     }
 

--- a/assembl/tests/views_tests/test_graphql.py
+++ b/assembl/tests/views_tests/test_graphql.py
@@ -1694,6 +1694,7 @@ query { discussionPreferences { languages { locale, name(inLocale:"fr"), nativeN
             u'logo': None,
             u'tabTitle': '',
             u'withModeration': False
+            u'withTranslation': True
         }
     }
 
@@ -1707,7 +1708,8 @@ def test_query_discussion_preferences_moderation(graphql_registry, graphql_reque
             u'favicon': None,
             u'logo': None,
             u'tabTitle': '',
-            u'withModeration': True
+            u'withModeration': True,
+            u'withTranslation': True
         }
     }
 

--- a/assembl/tests/views_tests/test_graphql.py
+++ b/assembl/tests/views_tests/test_graphql.py
@@ -1693,8 +1693,7 @@ query { discussionPreferences { languages { locale, name(inLocale:"fr"), nativeN
             u'favicon': None,
             u'logo': None,
             u'tabTitle': '',
-            u'withModeration': False,
-            u'withTranslation': True
+            u'withModeration': False
         }
     }
 
@@ -1708,8 +1707,7 @@ def test_query_discussion_preferences_moderation(graphql_registry, graphql_reque
             u'favicon': None,
             u'logo': None,
             u'tabTitle': '',
-            u'withModeration': True,
-            u'withTranslation': True,
+            u'withModeration': True
         }
     }
 


### PR DESCRIPTION
This adds an option in discussion preferences to activate or not the option for users to translate messages