### PR TITLE
Show version number only if connected user is administrator

### DIFF
--- a/assembl/static2/js/app/components/common/footer.jsx
+++ b/assembl/static2/js/app/components/common/footer.jsx
@@ -5,7 +5,7 @@ import { Translate } from 'react-redux-i18n';
 import { Grid } from 'react-bootstrap';
 import { connect } from 'react-redux';
 import { graphql, compose } from 'react-apollo';
-
+import connectedUserIsAdmin from '../../utils/permissions';
 import { get } from '../../utils/routeMap';
 import manageErrorAndLoading from '../../components/common/manageErrorAndLoading';
 import TabsConditionQuery from '../../graphql/TabsConditionQuery.graphql';
@@ -93,7 +93,7 @@ const Footer = ({
             </div>
             <div />
             <div className="legal-pages">{legalPagesInFooter}</div>
-            {assemblVersion && <div className="assembl-version">v{assemblVersion}</div>}
+            {connectedUserIsAdmin() && assemblVersion && <div className="assembl-version">v{assemblVersion}</div>}
           </div>
         </div>
       </div>


### PR DESCRIPTION
As a result of a security audit, It has been reported that it is not desired that the version number of Assembl appears on the bottom right of the landing page. This piece of code makes the version number visible only if the connected user is an administrator.