### PR TITLE
Invoke setup ctx

### DIFF
--- a/assembl/tasks/common.py
+++ b/assembl/tasks/common.py
@@ -15,6 +15,7 @@ local_code_root = dirname(dirname(realpath(_local_file)))
 
 
 def task(*args, **kwargs):
+    import pdb; pdb.set_trace()
     pre = list(kwargs.pop('pre', args))
     pre.append(base_task(setup_ctx))
     return base_task(pre=pre, **kwargs)
@@ -165,7 +166,6 @@ def setup_ctx(c):
                 target, config_prefix, project_prefix))
         if not data:
             break
-        import pdb; pdb.set_trace()
         target = data.get('_extends', None)
         temp_config = rec_update(data, temp_config)
 

--- a/assembl/tasks/common.py
+++ b/assembl/tasks/common.py
@@ -134,7 +134,6 @@ def is_cloud_env(c):
 
 def setup_ctx(c):
     """Surgically alter the context's config with config inheritance."""
-    import pdb; pdb.set_trace()
     project_prefix = c.config.get('_project_home', c.config._project_prefix[:-1])
     if is_cloud_env(c):
         code_root = os.path.join(os.getcwd(), get_venv_site_packages(c))

--- a/assembl/tasks/common.py
+++ b/assembl/tasks/common.py
@@ -15,7 +15,6 @@ local_code_root = dirname(dirname(realpath(_local_file)))
 
 
 def task(*args, **kwargs):
-    import pdb; pdb.set_trace()
     pre = list(kwargs.pop('pre', args))
     pre.append(base_task(setup_ctx))
     return base_task(pre=pre, **kwargs)
@@ -135,6 +134,7 @@ def is_cloud_env(c):
 
 def setup_ctx(c):
     """Surgically alter the context's config with config inheritance."""
+    import pdb; pdb.set_trace()
     project_prefix = c.config.get('_project_home', c.config._project_prefix[:-1])
     if is_cloud_env(c):
         code_root = os.path.join(os.getcwd(), get_venv_site_packages(c))

--- a/assembl/tasks/common.py
+++ b/assembl/tasks/common.py
@@ -148,8 +148,8 @@ def setup_ctx(c):
     current['_internal'] = c.config.get('_internal') or {}
     current['_internal']['mac'] = sys.platform == 'darwin'
     target = c.config.get('_extends', None)
-    if not target and exists(c, 'invoke.yaml'):
-        target = 'invoke.yaml'
+    #if not target and exists(c, 'invoke.yaml'):
+    target = 'invoke.yaml'
     temp_config = {}
     while target:
         if os.path.isabs(target):

--- a/assembl/tasks/common.py
+++ b/assembl/tasks/common.py
@@ -165,9 +165,10 @@ def setup_ctx(c):
                 target, config_prefix, project_prefix))
         if not data:
             break
+        import pdb; pdb.set_trace()
         target = data.get('_extends', None)
         temp_config = rec_update(data, temp_config)
-    import pdb; pdb.set_trace()
+
     current = rec_update(current, temp_config)
 
     account_id = current.get('aws_client', None)

--- a/assembl/tasks/common.py
+++ b/assembl/tasks/common.py
@@ -149,6 +149,7 @@ def setup_ctx(c):
     target = c.config.get('_extends', None)
     if not target and exists(c, 'invoke.yaml'):
         target = 'invoke.yaml'
+    temp_config = {}
     while target:
         if os.path.isabs(target):
             if exists(c, target):
@@ -165,7 +166,9 @@ def setup_ctx(c):
         if not data:
             break
         target = data.get('_extends', None)
-        current = rec_update(data, current)
+        temp_config = rec_update(data, temp_config)
+    import pdb; pdb.set_trace()
+    current = rec_update(current, temp_config)
 
     account_id = current.get('aws_client', None)
     if not account_id:

--- a/assembl/tasks/common.py
+++ b/assembl/tasks/common.py
@@ -147,9 +147,7 @@ def setup_ctx(c):
     current['projectpath'] = project_prefix
     current['_internal'] = c.config.get('_internal') or {}
     current['_internal']['mac'] = sys.platform == 'darwin'
-    target = c.config.get('_extends', None)
-    #if not target and exists(c, 'invoke.yaml'):
-    target = 'invoke.yaml'
+    target = 'invoke.yaml' if exists(c, 'invoke.yaml') else None
     temp_config = {}
     while target:
         if os.path.isabs(target):


### PR DESCRIPTION
I DON'T KNOW IF IT BREAKS ANYTHING, PLEASE REVIEW
Fix the issue with updating account_data.yaml in AWS and not getting the right configuration with invoke. The issue came from the fact that setup_ctx doesn't update the configuration if a file changed between the start of the invoke process and the actual actions. I needed to make "invoke.yaml" the target to ensure correct inheritance after the first call to setup_ctx.