### PR TITLE
Modifying the functions reset_password and send_change_password_email…

### DIFF
--- a/assembl/views/api2/auth.py
+++ b/assembl/views/api2/auth.py
@@ -368,9 +368,7 @@ def reset_password(request):
                     localizer.translate(_("This email does not exist")),
                     code=HTTPNotFound.code)
             else:
-                raise JSONError(
-                    localizer.translate(_(generic_error_message)),
-                    code=HTTPNotFound.code)
+                send_change_password_email(request, user, email, discussion=discussion)
                 logger.error("This email does not exist.")
         if account:
             email = account.email
@@ -378,21 +376,22 @@ def reset_password(request):
         error = localizer.translate(_("Please give an identifier"))
         raise JSONError(error)
     if not email:
-        email = user.get_preferred_email()
+        if user:
+            email = user.get_preferred_email()
+        else:
+            email = None
         if not email:
             if not discussion.preferences['generic_errors']:
                 error = localizer.translate(_("This user has no email"))
             else:
-                error = localizer.translate(_(generic_error_message))
                 logger.error("This user has no email.")
-            raise JSONError(error, code=HTTPPreconditionFailed.code)
+                send_change_password_email(request, user, email, discussion=discussion)
     if not isinstance(user, User):
         if not discussion.preferences['generic_errors']:
             error = localizer.translate(_("This is not a user"))
         else:
-            error = localizer.translate(_(generic_error_message))
             logger.error("This is not a user.")
-        raise JSONError(error, code=HTTPPreconditionFailed.code)
+            send_change_password_email(request, user, email, discussion=discussion)
     send_change_password_email(request, user, email, discussion=discussion)
     return HTTPOk()
 

--- a/assembl/views/auth/views.py
+++ b/assembl/views/auth/views.py
@@ -1120,20 +1120,6 @@ on your {assembl} account.</p>
         mailer.send(message)
 
 
-def maybe_send_email(request, profile, email=None,
-        subject=None, text_body=None, html_body=None,
-        discussion=None, sender_name=None, welcome=False,
-        immediate=False):
-        if profile:
-            send_change_password_email(request, profile, email,
-            subject, text_body=text_body, html_body=html_body, discussion=discussion,
-            sender_name=sender_name, welcome=welcome, immediate=immediate)
-            log.info('An email has been sent to the profile %s' %  email)
-        else:
-            log.error("This profile does not exist")
-        return HTTPOk()
-
-
 def send_change_password_email(
         request, profile, email=None, subject=None,
         text_body=None, html_body=None, discussion=None,

--- a/assembl/views/auth/views.py
+++ b/assembl/views/auth/views.py
@@ -1126,53 +1126,54 @@ def send_change_password_email(
     mailer = get_mailer(request)
     localizer = request.localizer
     route_maker = create_get_route(request, discussion)
-    data = dict(
-        assembl="Assembl", name=profile.name,
-        confirm_url=get_global_base_url() + route_maker(
-            'welcome' if welcome else 'do_password_change',
-            token=password_change_token(profile)))
-    sender_email = config.get('assembl.admin_email')
-    if discussion:
-        data.update(dict(
-            discussion_topic=discussion.topic,
-            discussion_url=discussion.get_url()))
-        sender_name = sender_name or discussion.topic
-    if sender_name:
-        sender_name = normalize_email_name(sender_name)
-        sender = '"%s" <%s>' % (sender_name, sender_email)
-        sender_name = Header(sender_name, 'utf-8').encode()
-        if len(sender) > 255:
+    if profile:
+        data = dict(
+            assembl="Assembl", name=profile.name,
+            confirm_url=get_global_base_url() + route_maker(
+                'welcome' if welcome else 'do_password_change',
+                token=password_change_token(profile)))
+        sender_email = config.get('assembl.admin_email')
+        if discussion:
+            data.update(dict(
+                discussion_topic=discussion.topic,
+                discussion_url=discussion.get_url()))
+            sender_name = sender_name or discussion.topic
+        if sender_name:
+            sender_name = normalize_email_name(sender_name)
+            sender = '"%s" <%s>' % (sender_name, sender_email)
+            sender_name = Header(sender_name, 'utf-8').encode()
+            if len(sender) > 255:
+                sender = sender_email
+        else:
             sender = sender_email
-    else:
-        sender = sender_email
-    subject = (subject or localizer.translate(
-        _("Request for password change"))).format(**data)
-    #subject = Header(subject, 'utf-8').encode()  # Fails in some cases???
-    if text_body is None or html_body is not None:
-        # if text_body and no html_body, html_body remains None.
-        html_body = html_body or localizer.translate(_(u"""<p>Hello, {name}!</p>
-<p>We have received a request to change the password on your {assembl} account.
-Please <a href="{confirm_url}">click here to confirm your password change</a>.</p>
-<p>If you did not ask to reset your password please disregard this email.</p>
-<p>Best regards,<br />The {assembl} Team</p>
-"""))
-    text_body = text_body or localizer.translate(_(u"""Hello, {name}!
-We have received a request to change the password on your {assembl} account.
-To confirm your password change please click on the link below.
-<{confirm_url}>
+        subject = (subject or localizer.translate(
+            _("Request for password change"))).format(**data)
+        #subject = Header(subject, 'utf-8').encode()  # Fails in some cases???
+        if text_body is None or html_body is not None:
+            # if text_body and no html_body, html_body remains None.
+            html_body = html_body or localizer.translate(_(u"""<p>Hello, {name}!</p>
+    <p>We have received a request to change the password on your {assembl} account.
+    Please <a href="{confirm_url}">click here to confirm your password change</a>.</p>
+    <p>If you did not ask to reset your password please disregard this email.</p>
+    <p>Best regards,<br />The {assembl} Team</p>
+    """))
+        text_body = text_body or localizer.translate(_(u"""Hello, {name}!
+    We have received a request to change the password on your {assembl} account.
+    To confirm your password change please click on the link below.
+    <{confirm_url}>
 
-If you did not ask to reset your password please disregard this email.
+    If you did not ask to reset your password please disregard this email.
 
-Best regards,
-The {assembl} Team
-"""))
-    message = Message(
-        subject=subject,
-        sender=sender,
-        recipients=["%s <%s>" % (
-            profile.name, email or profile.get_preferred_email())],
-        body=text_body.format(**data), html=html_body.format(**data))
-    if immediate:
-        mailer.send_immediately(message)
-    else:
-        mailer.send(message)
+    Best regards,
+    The {assembl} Team
+    """))
+        message = Message(
+            subject=subject,
+            sender=sender,
+            recipients=["%s <%s>" % (
+                profile.name, email or profile.get_preferred_email())],
+            body=text_body.format(**data), html=html_body.format(**data))
+        if immediate:
+            mailer.send_immediately(message)
+        else:
+            mailer.send(message)


### PR DESCRIPTION
Following the security audit, it has been reported that if a user tries to reset his password when he does not have an account. The requested behaviour is to have a message stating that an email was sent to reset the password (no matter if the user has an account or not). See VLN08 