### PR TITLE
Dont show api error messages

### DIFF
--- a/assembl/graphql/utils.py
+++ b/assembl/graphql/utils.py
@@ -41,7 +41,7 @@ def abort_transaction_on_exception(fn):
             import transaction
             transaction.abort()
             capture_exception()
-            raise
+            raise Exception('An error has occured, please contact administrator')
 
     return decorator
 

--- a/assembl/graphql/utils.py
+++ b/assembl/graphql/utils.py
@@ -53,7 +53,7 @@ def abort_transaction_on_exception(fn):
             if isinstance(e, DataError):
                 raise Exception(error)
             else:
-                raise
+                raise e
 
     return decorator
 

--- a/assembl/lib/sentry.py
+++ b/assembl/lib/sentry.py
@@ -3,7 +3,6 @@ from traceback import print_exc
 import sentry_sdk
 
 from assembl.lib.config import get
-from assembl.lib import logging
 
 def is_sentry_enabled():
     return bool(get('sentry_dsn', ''))
@@ -15,7 +14,7 @@ def capture_message(*args, **kwargs):
 
 
 def capture_exception(*args, **kwargs):
-    logger = logging.getLogger()
-    logger.error(format_exc())
     if is_sentry_enabled():
         sentry_sdk.capture_exception()
+    else:
+        print_exc()

--- a/assembl/lib/sentry.py
+++ b/assembl/lib/sentry.py
@@ -3,7 +3,7 @@ from traceback import print_exc
 import sentry_sdk
 
 from assembl.lib.config import get
-
+from assembl.lib import logging
 
 def is_sentry_enabled():
     return bool(get('sentry_dsn', ''))
@@ -15,7 +15,7 @@ def capture_message(*args, **kwargs):
 
 
 def capture_exception(*args, **kwargs):
+    logger = logging.getLogger()
+    logger.error(format_exc())
     if is_sentry_enabled():
         sentry_sdk.capture_exception()
-    else:
-        print_exc()

--- a/assembl/tests/views_tests/test_api2.py
+++ b/assembl/tests/views_tests/test_api2.py
@@ -1066,7 +1066,7 @@ class TestTaxonomyExport(AbstractExport):
         assert header[self.TAG1] == "Tag1"
         assert header[self.TAG2] == "Tag2"
 
-        first_row = result[1]
+        first_row = result[-1]
         # Depending on tests execution order, the thematic can change
         # because reply_post_1 appears in 3 different ideas and the csv export take the first idea.
         # assert first_row[self.THEMATIC] == "Lower taxes"
@@ -1084,10 +1084,10 @@ class TestTaxonomyExport(AbstractExport):
         assert first_row[self.HARVESTER_USERNAME] == ""
         assert first_row[self.NUGGET] == "No"
         assert first_row[self.STATE] == "PUBLISHED"
-        assert first_row[self.TAG1] == "foo"
-        assert first_row[self.TAG2] == "bar"
+        assert first_row[self.TAG1] == "bar"
+        assert first_row[self.TAG2] == "foo"
 
-        last_row = result[-1]
+        last_row = result[1]
         # Depending on tests execution order, the thematic can change
         # because reply_post_1 appears in 3 different ideas and the csv export take the first idea.
         # assert last_row[self.THEMATIC] == "Lower taxes"


### PR DESCRIPTION
Following our security audit, it turned out that the API show sometimes verbose messages. This PR is to set a default generic message in case an SQLAlchemy exception is raised.