### PR TITLE
One line fix to stop using cache for visitor stats

### DIFF
--- a/assembl/models/discussion.py
+++ b/assembl/models/discussion.py
@@ -1151,7 +1151,7 @@ class Discussion(DiscussionBoundBase, NamedClassMixin):
 
         return generate_key
 
-    @visit_analytics_region.cache_on_arguments(function_key_generator=generate_redis_key)
+    # @visit_analytics_region.cache_on_arguments(function_key_generator=generate_redis_key) // Remove the cache for now
     def get_visits_time_series_analytics(self, start_date=None, end_date=None, only_fields=None):
         """
         Fetches visits analytics from bound piwik site.


### PR DESCRIPTION
So the current implementation (that stopped working since the migration to AWS) was to pull the stats from piwik (matamo) and then cache in redis so the server isn't hit too much.

I will create a backlog ticket for the 'why does this not work on Amazon' but the time being we can remove the decorator which enforces the redis and make a request every time.

This can be activated only on certain debates when the config for the API key is set - so by default this will NOT be on for everyone unless we change their local.ini as well.