### PR TITLE
lib/sqla: use .ini configuration

### DIFF
--- a/assembl/configs/base_env.rc
+++ b/assembl/configs/base_env.rc
@@ -2,11 +2,13 @@ ini_files = production.ini RANDOM:random.ini.tmpl:saml_random.ini.tmpl RC_DATA
 # The file that will hold the generated random keys.
 random_file = random.ini
 *db_host = localhost
+*db_port = 5432
 *db_user = assembl
 # TODO: If generated remotely, fetch in fabfile
 *db_password = assembl
 *db_database = assembl
 db_schema = public
+sqlalchemy.url = postgresql+psycopg2://%(db_user)s:%(db_password)s@%(db_host)s:%(db_port)s/%(db_database)s?sslmode=disable
 _postgres_db_user = postgres
 _postgres_db_password =
 smtp_host = localhost

--- a/assembl/configs/base_env.rc
+++ b/assembl/configs/base_env.rc
@@ -8,7 +8,6 @@ random_file = random.ini
 *db_password = assembl
 *db_database = assembl
 db_schema = public
-sqlalchemy.url = postgresql+psycopg2://%(db_user)s:%(db_password)s@%(db_host)s:%(db_port)s/%(db_database)s?sslmode=disable
 _postgres_db_user = postgres
 _postgres_db_password =
 smtp_host = localhost

--- a/assembl/configs/base_env.yaml
+++ b/assembl/configs/base_env.yaml
@@ -194,6 +194,4 @@ password_required_classes: '{"[a-z]": {"en": "lower-case letter", "fr": "une let
 # mouseflow activation variable and website id
 activate_mouseflow: false
 mouseflow_website_id: ""
-sqlalchemy.url: "postgresql+psycopg2://%(db_user)s:%(db_password)s@%(db_host)s:%(db_port)s/%(db_database)s?sslmode=disable"
-
 

--- a/assembl/configs/base_env.yaml
+++ b/assembl/configs/base_env.yaml
@@ -1,5 +1,6 @@
 DEFAULT:
   db_host: localhost
+  db_port: '5432'
   db_user: assembl
   # TODO: If generated remotely, fetch in fabfile
   db_password: assembl
@@ -193,3 +194,6 @@ password_required_classes: '{"[a-z]": {"en": "lower-case letter", "fr": "une let
 # mouseflow activation variable and website id
 activate_mouseflow: false
 mouseflow_website_id: ""
+sqlalchemy.url: "postgresql+psycopg2://%(db_user)s:%(db_password)s@%(db_host)s:%(db_port)s/%(db_database)s?sslmode=disable"
+
+

--- a/assembl/configs/production.ini
+++ b/assembl/configs/production.ini
@@ -37,7 +37,7 @@ pyramid.default_locale_name = en_CA
 # Should requirejs defeat browser caching?  Useful in development
 requirejs.cache_bust = false
 
-sqlalchemy.url = postgresql+psycopg2://%(db_user)s:%(db_password)s@%(db_host)s/%(db_database)s?sslmode=disable
+sqlalchemy.url = postgresql+psycopg2://%(db_user)s:%(db_password)s@%(db_host)s:%(db_port)s/%(db_database)s?sslmode=disable
 # Unnessary to set this true in development, as logger_sqlalchemy DEBUG
 # below will also output sql statements
 sqlalchemy.echo = False
@@ -420,7 +420,7 @@ transaction = transaction
 [alembic]
 # Path to migration scripts
 script_location = %(code_root)s/assembl/alembic
-sqlalchemy.url = postgresql+psycopg2://%(db_user)s:%(db_password)s@%(db_host)s/%(db_database)s?sslmode=disable
+sqlalchemy.url = postgresql+psycopg2://%(db_user)s:%(db_password)s@%(db_host)s:%(db_port)s/%(db_database)s?sslmode=disable
 transaction_per_migration = true
 
 # Template used to generate migration files


### PR DESCRIPTION
The non-RDS use case made use of some separate variables to build a
psycopg2 connection string.

The make_url function from sqlalchemy is here to parse entire
connection strings, provided they are valid, into URL objects that can
then be fed to SQLAlchemy.

I propose that we use properly formatted SQLAlchemy URLs and stop using
directly the separate variables.

RFC1738 URLs in the SQLAlchemy context need the port to be specified and
will not be considered valid otherwise. This is a limitation we have to
work with and I suggest we do so.

Example invalid connection string as used before:
`postgresql+psycopg2://%(db_user)s:%(db_password)s@%(db_host)s/%(db_database)s?sslmode=disable`

Example valid connection string as I propose we use:
`postgresql+psycopg2://%(db_user)s:%(db_password)s@%(db_host)s:%(db_port)s/%(db_database)s?sslmode=disable`

This requires the following definition in the DEFAULT section:

`db_port = 5432`