### PR TITLE
sqla: more compatibility

### DIFF
--- a/assembl/configs/base_env.rc
+++ b/assembl/configs/base_env.rc
@@ -1,6 +1,7 @@
 ini_files = production.ini RANDOM:random.ini.tmpl:saml_random.ini.tmpl RC_DATA
 # The file that will hold the generated random keys.
 random_file = random.ini
+sqlalchemy.url = postgresql+psycopg2://%(db_user)s:%(db_password)s@%(db_host)s:%(db_port)s/%(db_database)s?sslmode=allow
 *db_host = localhost
 *db_port = 5432
 *db_user = assembl

--- a/assembl/configs/base_env.yaml
+++ b/assembl/configs/base_env.yaml
@@ -41,6 +41,7 @@ _internal:
     npm: '6.4.1'
 
 ini_files: production.ini RANDOM:random.ini.tmpl:saml_random.ini.tmpl RC_DATA
+"sqlalchemy.url": "postgresql+psycopg2://%(db_user)s:%(db_password)s@%(db_host)s:%(db_port)s/%(db_database)s?sslmode=allow"
 # The file that will hold the generated random keys.
 random_file: random.ini
 db_schema: public

--- a/assembl/configs/production.ini
+++ b/assembl/configs/production.ini
@@ -37,7 +37,8 @@ pyramid.default_locale_name = en_CA
 # Should requirejs defeat browser caching?  Useful in development
 requirejs.cache_bust = false
 
-sqlalchemy.url = postgresql+psycopg2://%(db_user)s:%(db_password)s@%(db_host)s:%(db_port)s/%(db_database)s?sslmode=disable
+sqlalchemy.url = postgresql+psycopg2://%(db_user)s:%(db_password)s@%(db_host)s:%(db_port)s/%(db_database)s?sslmode=allow
+# sqlalchemy.url_ro = postgresql+psycopg2://%(dbro_user)s:%(dbro_password)s@%(dbro_host)s:%(dbro_port)s/%(dbro_database)s?sslmode=allow
 # Unnessary to set this true in development, as logger_sqlalchemy DEBUG
 # below will also output sql statements
 sqlalchemy.echo = False
@@ -420,7 +421,7 @@ transaction = transaction
 [alembic]
 # Path to migration scripts
 script_location = %(code_root)s/assembl/alembic
-sqlalchemy.url = postgresql+psycopg2://%(db_user)s:%(db_password)s@%(db_host)s:%(db_port)s/%(db_database)s?sslmode=disable
+sqlalchemy.url = postgresql+psycopg2://%(db_user)s:%(db_password)s@%(db_host)s:%(db_port)s/%(db_database)s?sslmode=allow
 transaction_per_migration = true
 
 # Template used to generate migration files

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -257,7 +257,7 @@ Also, many lines will differ that are built with interpolation; for example, ``p
 
 .. code:: ini
 
-    sqlalchemy.url = postgresql+psycopg2://%(db_user)s:%(db_password)s@%(db_host)s/%(db_database)s?sslmode=disable
+    sqlalchemy.url = postgresql+psycopg2://%(db_user)s:%(db_password)s@%(db_host)s:%(db_port)s/%(db_database)s?sslmode=allow
 
-Ideally, you would set the values of ``*db_user``, ``*db_password``, ``*db_host``, ``*db_database`` in your ``myinstance.rc`` file until the ``sqlalchemy.url`` key disappears from migration, without overriding the ``sqlalchemy.url`` key itself. A similar process applies to ``sentry_...`` variables.
+Ideally, you would set the values of ``*db_user``, ``*db_password``, ``*db_host``, ``*db_port``, ``*db_database`` in your ``myinstance.rc`` file until the ``sqlalchemy.url`` key disappears from migration, without overriding the ``sqlalchemy.url`` key itself. A similar process applies to ``sentry_...`` variables.
 


### PR DESCRIPTION
this adds support for a sqlalchemy.url_ro (for read replicas).
this also makes sqla more tolerant to non-updated configs which have
not set a proper sqlalchemy.url.