### PR TITLE
delete the hash after the redirection

### DIFF
--- a/assembl/static2/js/app/components/common/tree/treeItem.jsx
+++ b/assembl/static2/js/app/components/common/tree/treeItem.jsx
@@ -107,6 +107,7 @@ class Child extends React.PureComponent<Props, State> {
     setTimeout(() => {
       this.setState({ expanded: true });
       if (expandParent) expandParent();
+      if (!expandParent) window.location.hash = '';
     }, 300);
   };
 

--- a/assembl/static2/tests/unit/components/voteSession/__snapshots__/Proposal.spec.jsx.snap
+++ b/assembl/static2/tests/unit/components/voteSession/__snapshots__/Proposal.spec.jsx.snap
@@ -800,6 +800,7 @@ exports[`Proposal component should match Proposal snapshot 1`] = `
                 Object {
                   "height": "12px",
                   "left": "0%",
+                  "right": "auto",
                   "visibility": "visible",
                   "width": "NaN%",
                 }
@@ -825,6 +826,8 @@ exports[`Proposal component should match Proposal snapshot 1`] = `
                   "height": "0",
                   "left": "NaN%",
                   "marginTop": "-20px",
+                  "right": "auto",
+                  "transform": "translateX(-50%)",
                   "width": "0",
                 }
               }

--- a/assembl/static2/tests/unit/components/voteSession/__snapshots__/Proposals.spec.jsx.snap
+++ b/assembl/static2/tests/unit/components/voteSession/__snapshots__/Proposals.spec.jsx.snap
@@ -1592,6 +1592,7 @@ exports[`Proposals component should match Proposals snapshot 1`] = `
                   Object {
                     "height": "12px",
                     "left": "0%",
+                    "right": "auto",
                     "visibility": "visible",
                     "width": "NaN%",
                   }
@@ -1617,6 +1618,8 @@ exports[`Proposals component should match Proposals snapshot 1`] = `
                     "height": "0",
                     "left": "NaN%",
                     "marginTop": "-20px",
+                    "right": "auto",
+                    "transform": "translateX(-50%)",
                     "width": "0",
                   }
                 }


### PR DESCRIPTION
When an attachment has an uppercase file extension (JPG, PDF, ...) we don't recognize its type.
