### PR TITLE
Update flow config; fix file extension

### DIFF
--- a/assembl/static2/.flowconfig
+++ b/assembl/static2/.flowconfig
@@ -1,18 +1,7 @@
 [ignore]
-<PROJECT_ROOT>/node_modules/draft-js/lib/ContentBlock.js.flow
-<PROJECT_ROOT>/node_modules/draft-js/lib/ContentBlockNode.js.flow
-<PROJECT_ROOT>/node_modules/draft-js/lib/DraftEditor.react.js.flow
-<PROJECT_ROOT>/node_modules/draft-js/lib/DraftEditorDragHandler.js.flow
-<PROJECT_ROOT>/node_modules/draft-js/lib/DraftEditorLeaf.react.js.flow
-<PROJECT_ROOT>/node_modules/draft-js-plugins-editor/lib/Editor/index.js.flow
-<PROJECT_ROOT>/node_modules/config-chain
-<PROJECT_ROOT>/node_modules/npm/node_modules/config-chain
-<PROJECT_ROOT>/node_modules/stylelint
-<PROJECT_ROOT>/node_modules/babel-plugin-react-docgen
-<PROJECT_ROOT>/node_modules/radium
-<PROJECT_ROOT>/node_modules/graphql
-<PROJECT_ROOT>/node_modules/react-select
-<PROJECT_ROOT>/node_modules/react-apollo/react-apollo.umd.js.flow
+
+[untyped]
+.*/node_modules/*
 
 [include]
 

--- a/assembl/static2/js/app/components/common/documentExtensionIcon.jsx
+++ b/assembl/static2/js/app/components/common/documentExtensionIcon.jsx
@@ -26,7 +26,7 @@ export const getExtension = (filename: string): string => {
     return 'unknown';
   }
 
-  return parts[parts.length - 1];
+  return parts[parts.length - 1].toLowerCase();
 };
 
 export const getIconPathByExtension = (extension: string): string => {


### PR DESCRIPTION
Flow errors:
I had some flow errors on commits, but it seemed to be on files that should't be checked by flow. 

According to [this article](https://medium.com/shopback-engineering/5-things-you-might-be-interested-in-your-flow-config-1ad35b023e93), we should probably not use [ignore] but [untyped] instead (I suspect it's because of this misunderstanding that the flowconfig file looked like this).

File extension:
[This support ticket](https://bluenove.atlassian.net/browse/SUP-542) made me realise that if the file extension is in uppercase (PDF, JPG, ...) we don't recognize it and use a default image. This should fix it
